### PR TITLE
OMK-10303 - Update patch_config.pl to make it run 3 times faster

### DIFF
--- a/admin/patch_config.pl
+++ b/admin/patch_config.pl
@@ -42,7 +42,8 @@ use Getopt::Std;
 use File::Copy;
 
 use NMISNG::Util;
-use Compat::NMIS; 								# for nmisng::util::dbg, fixme9
+## commenting this to make patch-config run 3 times faster.
+#use Compat::NMIS; 								# for nmisng::util::dbg, fixme9
 
 if (@ARGV == 1 && $ARGV[0] eq "--version")
 {


### PR DESCRIPTION
The use Compact::NMIS, was adding un-necessary bulk in patch-config.pl. By removing this , the script is running 3 times faster.