### PR TITLE
Mongo Changes, inventory index update, index hint for scheduler and app name passed to mongo when connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ Vagrantfile
 *.swp
 *.swo
 install.log
+.vscode


### PR DESCRIPTION
New index hint on path query for path.0 and path.2 for fixing the scheduler when asking for the current cluster_id and catchall index

DB.pm find can now have a index hint passed in and if defined call hint on the cursor.

App name passed to mongo when connecting and the mongo logs should log nmis-9.4.4 as the app who made the request.