### PR TITLE
Move grouped_node_summary to use catchall

### DIFF
--- a/lib/Compat/NMIS.pm
+++ b/lib/Compat/NMIS.pm
@@ -783,14 +783,14 @@ sub getGroupSummary {
 	$nmisng->log->debug2(sub {&NMISNG::Log::trace()."Starting"});
 
 	# grouped_node_summary joins collections, node_config is the prefix for the nodes config
-	my $group_by = ['node_config.configuration.group']; # which is deeply structured!
+	my $group_by = ['configuration.group']; # which is deeply structured!
 	$group_by = undef if( !$group );
 
 	my ($entries,$count,$error);
 	if ($local_nodes) {
 		$nmisng->log->debug("getGroupSummary - Getting local nodes");
 		($entries,$count,$error) = $nmisng->grouped_node_summary(
-			filters => { 'node_config.configuration.group' => $group, cluster_id => $nmisng->config->{cluster_id}},
+			filters => { 'configuration.group' => $group, cluster_id => $nmisng->config->{cluster_id}},
 			group_by => $group_by,
 			include_nodes => $include_nodes
 		);
@@ -798,7 +798,7 @@ sub getGroupSummary {
 	else {
 		$nmisng->log->debug("getGroupSummary - Getting all nodes");
 		($entries,$count,$error) = $nmisng->grouped_node_summary(
-			filters => { 'node_config.configuration.group' => $group },
+			filters => { 'configuration.group' => $group },
 			group_by => $group_by,
 			include_nodes => $include_nodes
 		);

--- a/lib/NMISNG/NetworkStatus.pm
+++ b/lib/NMISNG/NetworkStatus.pm
@@ -403,14 +403,14 @@ sub getGroupSummary {
 	#$self->log->debug2(sub {&NMISNG::Log::trace()."Starting"});
 
 	# grouped_node_summary joins collections, node_config is the prefix for the nodes config
-	my $group_by = ['node_config.configuration.group']; # which is deeply structured!
+	my $group_by = ['configuration.group']; # which is deeply structured!
 	$group_by = undef if( !$group );
 
 	my ($entries,$count,$error);
 	if ($local_nodes) {
 		#$self->log->debug("getGroupSummary - Getting local nodes");
 		($entries,$count,$error) = $self->nmisng->grouped_node_summary(
-			filters => { 'node_config.configuration.group' => $group, cluster_id => $$self->nmisng->config->{cluster_id}},
+			filters => { 'configuration.group' => $group, cluster_id => $self->nmisng->config->{cluster_id}},
 			group_by => $group_by,
 			include_nodes => $include_nodes
 		);
@@ -419,7 +419,7 @@ sub getGroupSummary {
 	else {
 		#$self->log->debug("getGroupSummary - Getting all nodes");
 		($entries,$count,$error) = $self->nmisng->grouped_node_summary(
-			filters => { 'node_config.configuration.group' => $group },
+			filters => { 'configuration.group' => $group },
 			group_by => $group_by,
 			include_nodes => $include_nodes
 		);


### PR DESCRIPTION
Was starting with nodes and bringing in catchall using graphlookup and did not really need nodes.

We may need more code to make sure catchall is always there and up-to-date

This change removes the query from my slow query list