### PR TITLE
EOS stopping internal builds from compiling

### DIFF
--- a/bin/nmis-cli
+++ b/bin/nmis-cli
@@ -321,17 +321,38 @@ elsif ($Q->{act} =~ /^enable[-_]eos$/)
 	}
 	else
 	{
-		if (NMISNG::Util::isEOSAvailable() && NMISNG::Util::testEncryption())
+		my ($test, @errors) = NMISNG::Util::isEOSAvailable();
+		if ( $test && NMISNG::Util::testEncryption())
 		{
 			my $rc = NMISNG::Util::enableEOS();
 			exit($rc);
 		}
 		else
 		{
-			print("Encryption is not supported or not working, EOS cannot be enabled.\n");
-			exit(0);
+			print("Encryption is not supported or not working, EOS cannot be enabled, following errors were encountered:\n");
+			foreach my $error (@errors)
+			{
+				print("\t$error\n");
+			}
+			exit($test);
 		}
 	}
+}
+# Enable Encryption of Secrets
+# returns 1 if successful, and 0 if failed!
+elsif ($Q->{act} =~ /^test[-_]eos$/)
+{
+	my ($test, @errors) = NMISNG::Util::isEOSAvailable();
+	print("Encryption is ".($test? "enabled" : "disabled").".\n");
+	if (!$test)
+	{
+		print("The following errors were encountered:\n");
+		foreach my $error (@errors)
+		{
+			print("\t$error\n");
+		}
+	}
+	exit($test);
 }
 ##################################################################
 # Run the above two actions BEFORE getting a database connection #

--- a/bin/nmisd
+++ b/bin/nmisd
@@ -155,66 +155,6 @@ if ( !-d $tmpdir )
 	NMISNG::Util::createDir($tmpdir);
 }
 
-my $encryption_enabled = NMISNG::Util::getbool($config->{'global_enable_password_encryption'});
-if ($encryption_enabled)
-{
-	if (NMISNG::Util::isEOSAvailable())
-	{
-		if (!NMISNG::Util::testEncryption())
-		{
-			print("Encryption of Secrets is enabled, and encryption is broken or not supported!\n");
-			if (-t *STDIN)
-			{
-				my $answer = NMISNG::Util::askYesNo("Do you want to disable EOS and continue?", "no");
-				unless($answer)
-				{
-					print "Encryption of Secrets is enabled and does not work, unable to continue!\n";
-					exit(255);
-				}
-				else
-				{
-					print "Disabling Encryption of Secrets...\n";
-					unless (NMISNG::Util::disableEOS())
-					{
-						print "Disabling Encryption of Secrets failed, unable to continue!\n";
-						exit(255);
-					}
-				}
-			}
-			else
-			{
-				print "Encryption of Secrets is enabled and does not work, unable to continue!\n";
-				exit(255);
-			}
-		}
-	}
-	else
-	{
-		if (-t *STDIN)
-		{
-			my $answer = NMISNG::Util::askYesNo("Do you want to disable EOS and continue?", "no");
-			unless($answer)
-			{
-				print "Encryption of Secrets is enabled and does not work, unable to continue!\n";
-				exit(255);
-			}
-			else
-			{
-				print "Disabling Encryption of Secrets...\n";
-				unless (NMISNG::Util::disableEOS())
-				{
-					print "Disabling Encryption of Secrets failed, unable to continue!\n";
-					exit(255);
-				}
-			}
-		}
-		else
-		{
-			print "Encryption of Secrets is enabled and does not work, unable to continue!\n";
-			exit(255);
-		}
-	}
-}
 
 my $wantfpingworker = NMISNG::Util::getbool($config->{nmisd_fping_worker});
 my $fpingpath4;


### PR DESCRIPTION
CPAN::version was stopping our internal build server from compiling our apps.
Replaced this with 'version' for parsing versions.
Took enabled eos from the nmisd, this should not ask for user input and enable eos requires root priv which we dont want nmisd to always have.

Started to refactor isEOSAvailable, we might need to have a omk cli option to get the current versions of our apps, tbd. 