### PR TITLE
Track timed collections and only create indexes when required

### DIFF
--- a/bin/nmisd
+++ b/bin/nmisd
@@ -462,6 +462,9 @@ $scheduler_state->{last_process_check} = 0; # DO run up worker children on start
 
 # this opens a database connection - which we must not share with any children!
 my $nmisng = Compat::NMIS::new_nmisng(config => $config, log => $logger);
+my $tc_list = $nmisng->timed_collections_list();
+$nmisng->existing_timed_collections($tc_list);
+
 &NMISNG::rrdfunc::require_RRDs;
 
 my $zoo = ($scheduler_state->{zoo} //= {}); # process state structure for manage_processes
@@ -1101,6 +1104,10 @@ sub manage_processes
 			# make sure this gets a NEW nmisng object, with NEW database handles!
 			$nmisng = Compat::NMIS::new_nmisng(nocache => 1,
 																				 debug => $debug);
+			# tell it which timed collections we know about
+			my $tc_list = $nmisng->timed_collections_list();
+			$nmisng->existing_timed_collections($tc_list);
+
 			if (!defined $cmdline->{debug})
 			{
 				# fping worker logs to its own logfile
@@ -1178,6 +1185,9 @@ sub manage_processes
 				srand();
 				# make sure this gets a NEW nmisng object, with NEW database handles!
 				$nmisng = Compat::NMIS::new_nmisng(nocache => 1, debug => $debug);
+				my $tc_list = $nmisng->timed_collections_list();
+				$nmisng->existing_timed_collections($tc_list);
+
 				$nmisng->log->logprefix("worker\[$$\] ");
 				$nmisng->log->info("started");
 				$0 = "nmisd.worker.<idle>";

--- a/lib/NMISNG.pm
+++ b/lib/NMISNG.pm
@@ -68,6 +68,9 @@ use Compat::Timing;
 #  log - NMISNG::Log object to log to, required.
 #  db - mongodb database object, optional.
 #  drop_unwanted_indices - optional, default is 0.
+#  existing_timed_collections - optional, list of existing timed collections, needed because they
+#		are created dynamically and will need indexes when they are knew, hash of name => 1 if 
+# 		it's there and all good
 #
 #  allow for instantiating a test collection in our $db for running tests
 #  in a hashkey named 'tests' passed as arg to NMISNG->new()
@@ -84,6 +87,7 @@ sub new
 	my $self = bless(
 		{   _config  => $args{config},
 			_db      => $args{db},
+			_existing_timed_collections => $args{existing_timed_collections} // {},
 			_log     => $args{log},
 			_plugins => undef,           # sub plugins populates that on the go
 		},
@@ -4544,6 +4548,38 @@ sub status_collection
 
 }
 
+# find all collections for timed_ data, they are created based
+# on model info so cannot be pre-calculated easily.
+# returns a hash of collection_name => 1 for collections
+# that exist
+sub timed_collections_list
+{
+	my ( $self, %args ) = @_;
+	my $query = NMISNG::DB::get_query( and_part => { name => "regex:timed_"} );
+	my $cursor = NMISNG::DB::list_collections( db => $self->get_db(), filter => $query );
+	
+	my $timed_collection_names = {};
+	if( $cursor ) {
+		while ( my $entry = $cursor->next )
+		{
+			# potentially could check indexes as well?
+			$timed_collection_names->{ $entry->{name} } = 1;
+		}
+	}
+	return $timed_collection_names;
+}
+
+# set/get which timed collections are known about
+sub existing_timed_collections
+{
+	my ($self, $newvalue) = @_;
+	if (defined $newvalue)
+	{
+		$self->{_existing_timed_collections} = $newvalue;
+	}
+	return $self->{_existing_timed_collections} // {};
+}
+
 # helper to instantiate/get/update one of the dynamic collections
 # for timed data, one per concept
 # indices are set up on set or instantiate
@@ -4568,12 +4604,17 @@ sub timed_concept_collection
 	my $stashname = "_db_$collname";
 
 	my $mustcheckindex;
+	# if we don't know about the collection we must try and create indexes for it
+	# otherwise we don't
+	my $my_existing_timed_collections = $self->existing_timed_collections();
+	if( $my_existing_timed_collections->{$collname} != 1 ) {
+		$mustcheckindex = 1;
+	}
 
 	# use and cache the given handle?
 	if ( ref($newhandle) eq "MongoDB::Collection" )
 	{
-		$self->{$stashname} = $newhandle;
-		$mustcheckindex = 1;
+		$self->{$stashname} = $newhandle;		
 	}
 
 	# or create a new one on the go?
@@ -4588,8 +4629,6 @@ sub timed_concept_collection
 			$self->log->fatal( "Could not get collection $collname: " . NMISNG::DB::get_error_string );
 			return undef;
 		}
-
-		$mustcheckindex = 1;
 	}
 
 	if ($mustcheckindex)
@@ -4605,7 +4644,13 @@ sub timed_concept_collection
 				[{expire_at => 1}, {expireAfterSeconds => 0}],            # ttl index for auto-expiration
 			]
 		);
-		$self->log->error("index setup failed for $collname: $err") if ($err);
+		if ($err) {
+			$self->log->error("index setup failed for $collname: $err");
+		} else {
+			$my_existing_timed_collections->{$collname} = 1;
+			$self->existing_timed_collections($my_existing_timed_collections);
+		}
+
 	}
 
 	return $self->{$stashname};

--- a/lib/NMISNG.pm
+++ b/lib/NMISNG.pm
@@ -4634,6 +4634,7 @@ sub timed_concept_collection
 	if ($mustcheckindex)
 	{
 		# sole index is by time and inventory_id, compound
+		$self->log->info("NMISNG::timed_concept_collection creating indexes for collection: $collname");
 		my $err = NMISNG::DB::ensure_index(
 			collection    => $self->{$stashname},
 			drop_unwanted => $drop_unwanted,

--- a/lib/NMISNG/DB.pm
+++ b/lib/NMISNG/DB.pm
@@ -921,6 +921,31 @@ sub get_collection
 	return $coll;
 }
 
+
+
+# a thin wrapper around list_collections
+# mainly for future-proofing at this point - but might get additional functionality, eg. index making
+# args: db, name (both required)
+# returns: collection handle or undef on failure (consult getErrorString in that case)
+sub list_collections
+{
+	my (%args) = @_;
+	my ( $db, $filter, $options ) = @args{"db", "filter", "options" };
+
+	if ( ref($db) ne "MongoDB::Database" )
+	{
+		$error_string = "Invalid args passed to list_collections!";
+		return;
+	}
+	my $cursor = eval { $db->list_collections($filter,$options); };
+	if ($@)
+	{
+		$error_string = $@;
+		return;
+	}
+	return $cursor;
+}
+
 sub get_db
 {
 	my %args = @_;


### PR DESCRIPTION
The goal is to significanly reduce the number of times create index is called for timed collections.

Track the timed_* collections that currently exist, only call create index when a collection is requested that the object doesn't know about.

This functionality is really only needed for nmisd which is why it has been added the way it was, this does not need to run every time a new nsming object is made