### PR TITLE
Stale lastupdates and uneeded expire_at updates

### DIFF
--- a/conf-default/plugins/AdtranInterface.pm
+++ b/conf-default/plugins/AdtranInterface.pm
@@ -507,7 +507,7 @@ sub update_plugin
 		}
 
 		# The above has added data to the inventory, that we now save.
-		my ( $op, $subError ) = $inventory->save( node => $node );
+		my ( $op, $subError ) = $inventory->save( node => $node, update => 1 );
 		$NG->log->debug2(sub { "saved ".join(',', @$path)." op: $op"});
 		if ($subError)
 		{

--- a/conf-default/plugins/AlcatelASAM.pm
+++ b/conf-default/plugins/AlcatelASAM.pm
@@ -505,7 +505,7 @@ sub update_plugin
 			}
 			# The above has added data to the inventory, that we now save.
 			$inventory->data( $atmVclData );
-			my ( $op, $subError ) = $inventory->save( node => $node );
+			my ( $op, $subError ) = $inventory->save( node => $node, update => 1 );
 			$NG->log->debug2(sub { "Saved ".join(',', @$path)."; op: $op"});
 			if ($subError)
 			{

--- a/conf-default/plugins/AsamInterface.pm
+++ b/conf-default/plugins/AsamInterface.pm
@@ -609,7 +609,7 @@ sub update_plugin
 		}
 
 		# The above has added data to the inventory, that we now save.
-		my ( $op, $subError ) = $inventory->save( node => $node );
+		my ( $op, $subError ) = $inventory->save( node => $node, update => 1 );
 		$NG->log->debug2(sub { "saved ".join(',', @$path)." op: $op"});
 		if ($subError)
 		{

--- a/conf-default/plugins/Aviat.pm
+++ b/conf-default/plugins/Aviat.pm
@@ -129,7 +129,7 @@ sub update_plugin
                     $inventory->enabled(1);
                     # disable for now
                     $inventory->data_info( subconcept => 'interface', enabled => 0 );
-                    my ($op,$error) = $inventory->save( node => $node );
+                    my ($op,$error) = $inventory->save( node => $node, update => 1 );
                     $NG->log->debug2(sub { "saved ".join(',', @$path)." op: $op"});
                     $NG->log->info( "saved ".join(',', @$path)." op: $op");
                 } else {

--- a/conf-default/plugins/Cisco_Features.pm
+++ b/conf-default/plugins/Cisco_Features.pm
@@ -93,7 +93,7 @@ sub update_plugin
 				$cpuinventory->data($cpudata); # set changed info
 				# set the inventory description to a nice string.
 				$cpuinventory->description( "$emibdata{$entityIndex}->{entPhysicalName}" );
-				(undef,$error) = $cpuinventory->save; # and save to the db
+				(undef,$error) = $cpuinventory->save; # and save to the db, update => 1 not required, inventory already existed
 				$NG->log->error("Failed to save inventory for $cpuid: $error")
 						if ($error);
 			}

--- a/conf-default/plugins/EricssonPPX.pm
+++ b/conf-default/plugins/EricssonPPX.pm
@@ -228,7 +228,7 @@ sub collect_plugin
 			}		
 
 			# The above has added data to the inventory, that we now save.
-			my ( $op, $saveError ) = $inventory->save( node => $node );
+			my ( $op, $saveError ) = $inventory->save( node => $node ); # update => 1 not required
 			$NG->log->debug2(sub { "saved op: $op"});
 			if ($saveError)
 			{

--- a/conf-default/plugins/F5BigIP.pm
+++ b/conf-default/plugins/F5BigIP.pm
@@ -204,7 +204,7 @@ sub collect_plugin
                 
                 # Save the data
                 $host_inventory->data($data); # set changed info
-                (undef,$error) = $host_inventory->save; # and save to the db
+                (undef,$error) = $host_inventory->save; # and save to the db, update not required
                 $NG->log->error("Failed to save inventory for ".$data->{hrStorageTypeName}. " : $error")
                         if ($error);
 			}

--- a/conf-default/plugins/F5BigIPAPI.pm
+++ b/conf-default/plugins/F5BigIPAPI.pm
@@ -410,7 +410,7 @@ sub update_plugin
 													data => $dbname) if ($dbname);
 
 		# the above will put data into inventory, so save
-		my ( $op, $subError ) = $subInventory->save( node => $node );
+		my ( $op, $subError ) = $subInventory->save( node => $node, update => 1 );
 		if ($subError)
 		{
 			$NG->log->error("Failed to save Concept '$virtSvrConcept' inventory for Virtual Server '$name': $subError");
@@ -497,7 +497,7 @@ sub update_plugin
 																	subconcept => $poolConcept,
 																	data => $dbname) if ($dbname);
 					# the above will put data into inventory, so save
-					my ( $op, $subError ) = $subMemberInventory->save( node => $node );
+					my ( $op, $subError ) = $subMemberInventory->save( node => $node, update => 1 );
 					if ($subError)
 					{
 						$NG->log->error("Failed to save '$poolConcept' inventory for Virtual Server Pool '$poolName'; Member '$memberName'; Error: $subError");

--- a/conf-default/plugins/Host_Resources.pm
+++ b/conf-default/plugins/Host_Resources.pm
@@ -364,7 +364,7 @@ sub update_plugin
             
             if ($changed) {
                 $host_inventory->data($data); # set changed info
-                (undef,$error) = $host_inventory->save(node => $node); # and save to the db
+                (undef,$error) = $host_inventory->save(node => $node); # and save to the db, update not required
                 $NG->log->error("Failed to save inventory for ".$data->{index}. " : $error")
                         if ($error);
             }
@@ -407,7 +407,7 @@ sub update_plugin
 				$changesweremade = 1;
 
                 $host_inventory->data($data); # set changed info
-                (undef,$error) = $host_inventory->save(node => $node); # and save to the db
+                (undef,$error) = $host_inventory->save(node => $node); # and save to the db, update not required
                 $NG->log->error("Failed to save inventory for ".$data->{index}. " : $error")
                         if ($error);
   
@@ -421,7 +421,7 @@ sub update_plugin
                 my $data_hs = $host_inventory_d->data();
                 $data_hs->{hrPartitionLabel} = $data->{hrPartitionLabel};
                 $host_inventory_d->data($data_hs); # set changed info
-                (undef,$error) = $host_inventory_d->save(node => $node); # and save to the db
+                (undef,$error) = $host_inventory_d->save(node => $node); # and save to the db, update not required
                 $NG->log->error("Failed to save inventory for ".$data_hs->{$hrFSStorageIndex}. " : $error")
                         if ($error);
 			}

--- a/conf-default/plugins/InterfaceTable.pm
+++ b/conf-default/plugins/InterfaceTable.pm
@@ -157,7 +157,7 @@ sub update_plugin
         $catchall_data->{ifNumber} = $ids;
         $catchall_data->{active} = $active;
         $inv->data($catchall_data);
-        my ($op,$error) = $inv->save( node => $node );
+        my ($op,$error) = $inv->save( node => $node, update => 1 );
         $NG->log->info( "saved catchall op: $op");
         
 	}

--- a/conf-default/plugins/MA5600.pm
+++ b/conf-default/plugins/MA5600.pm
@@ -150,7 +150,7 @@ sub update_plugin
 					# set the inventory things description, as this was made up from other data
 					$gpon_traffic->description( $data->{ONTBASE} );
 
-                    (undef,$error) = $gpon_traffic->save; # and save to the db
+                    (undef,$error) = $gpon_traffic->save; # and save to the db, update not required
                     $NG->log->error("Failed to save inventory for ".$gpon_traffic->id. " : $error")
                             if ($error);
                 } 
@@ -189,7 +189,7 @@ sub update_plugin
 					{
 						$data->{hwGponDeviceOntPassword} = $d;
 						$section->data($data); # set changed info
-						(undef,$error) = $section->save; # and save to the db
+						(undef,$error) = $section->save; # and save to the db, update not required
 						$NG->log->error("Failed to save inventory for ".$section->id. " : $error")
 								if ($error);
 					}

--- a/conf-default/plugins/QualityOfServiceStattable.pm
+++ b/conf-default/plugins/QualityOfServiceStattable.pm
@@ -152,7 +152,7 @@ sub update_plugin
 			if ($changed)
 			{
 				$inventory->data($inventory_data); # set changed info
-				(undef,$error) = $inventory->save; # and save to the db
+				(undef,$error) = $inventory->save; # and save to the db # update not required
 				if ($error)
 				{
 					$NG->log->error("$plugin:$sub: Failed to save inventory for $concept $inventory_data_key ".$inventory_data->{$inventory_data_key}. " : $error");

--- a/conf-default/plugins/RadwinWireless.pm
+++ b/conf-default/plugins/RadwinWireless.pm
@@ -73,7 +73,7 @@ sub update_plugin
 			$hbsdata->{node_uuid} = $managednode->uuid;
 
 			$hbsinventory->data($hbsdata); # set changed info
-			(undef,$error) = $hbsinventory->save; # and save it to db
+			(undef,$error) = $hbsinventory->save; # and save it to db # update not required
 			$NG->log->error("Failed to save inventory for $hbsid: $error")
 					if ($error);
 		}

--- a/conf-default/plugins/TeldatBRSStattable.pm
+++ b/conf-default/plugins/TeldatBRSStattable.pm
@@ -132,7 +132,7 @@ sub update_plugin
 			if ($changed)
 			{
 				$inventory->data($inventory_data); # set changed info
-				(undef,$error) = $inventory->save; # and save to the db
+				(undef,$error) = $inventory->save; # and save to the db # update not required
 				if ($error)
 				{
 					$NG->log->error("$plugin:$sub: Failed to save inventory for $concept $inventory_data_key ".$inventory_data->{$inventory_data_key}. " : $error");

--- a/conf-default/plugins/TeldatQoSStattable.pm
+++ b/conf-default/plugins/TeldatQoSStattable.pm
@@ -132,7 +132,7 @@ sub update_plugin
 			if ($changed)
 			{
 				$inventory->data($inventory_data); # set changed info
-				(undef,$error) = $inventory->save; # and save to the db
+				(undef,$error) = $inventory->save; # and save to the db # update not required
 				if ($error)
 				{
 					$NG->log->error("$plugin:$sub: Failed to save inventory for $concept $inventory_data_key ".$inventory_data->{$inventory_data_key}. " : $error");

--- a/conf-default/plugins/Ubiquiti.pm
+++ b/conf-default/plugins/Ubiquiti.pm
@@ -83,7 +83,7 @@ sub update_plugin
 			$changesweremade = 1;
 
 			$aminventory->data($airmaxdata); # set changed info
-			(undef,$error) = $aminventory->save;
+			(undef,$error) = $aminventory->save; # update not required
 			$NG->log->error("Failed to save inventory for $amid: $error")
 					if ($error);
 		}

--- a/conf-default/plugins/VirtMachines.pm
+++ b/conf-default/plugins/VirtMachines.pm
@@ -78,7 +78,7 @@ sub update_plugin
 			$vmdata->{vmwVmDisplayName_id} = "node_view_$vmName";
 
 			$vminventory->data($vmdata); # set changed info
-			(undef,$error) = $vminventory->save;
+			(undef,$error) = $vminventory->save; # update not required
 			$NG->log->error("Failed to save inventory for $vmid: $error")
 					if ($error);
 		}

--- a/conf-default/plugins/ZyxelInterface.pm
+++ b/conf-default/plugins/ZyxelInterface.pm
@@ -525,7 +525,7 @@ sub update_plugin
 		}
 
 		# The above has added data to the inventory, that we now save.
-		my ( $op, $subError ) = $inventory->save( node => $node );
+		my ( $op, $subError ) = $inventory->save( node => $node, update => 1 );
 		$NG->log->debug2(sub { "saved ".join(',', @$path)." op: $op"});
 		if ($subError)
 		{

--- a/conf-default/plugins/addressTable.pm
+++ b/conf-default/plugins/addressTable.pm
@@ -103,7 +103,7 @@ sub update_plugin
 		if ($mustsave)
 		{
 			$atinventory->data($atdata); # set changed info
-			(undef,$error) = $atinventory->save; # and save to the db
+			(undef,$error) = $atinventory->save; # and save to the db, update not required
 			$NG->log->error("Failed to save inventory for $atid: $error")
 					if ($error);
 		}

--- a/conf-default/plugins/cdpTable.pm
+++ b/conf-default/plugins/cdpTable.pm
@@ -157,7 +157,7 @@ sub update_plugin
 		if ($mustsave)
 		{
 			$cdpinventory->data($cdpdata); # set changed info
-			(undef,$error) = $cdpinventory->save; # and save to the db
+			(undef,$error) = $cdpinventory->save; # and save to the db, update not required, already existed
 			$NG->log->error("Failed to save inventory for $cdpid: $error")
 					if ($error);
 		}

--- a/conf-default/plugins/ciscoMacTable.pm
+++ b/conf-default/plugins/ciscoMacTable.pm
@@ -224,7 +224,7 @@ sub update_plugin
 					$inventory->historic(0);
 					$inventory->enabled(1);
 
-					(my $operation, $error) = $inventory->save;
+					(my $operation, $error) = $inventory->save( update => 1 ); # update required because we made id
 					$NG->log->error("Failed to save inventory for macTable $macAddress: $error") if($error);
 				}
 			}

--- a/conf-default/plugins/dot1qMacTable.pm
+++ b/conf-default/plugins/dot1qMacTable.pm
@@ -179,7 +179,7 @@ sub update_plugin
 		if ($mustsave)
 		{
 			$mactinventory->data($macdata); # set changed info
-			(undef,$error) = $mactinventory->save; # and save to the db
+			(undef,$error) = $mactinventory->save; # and save to the db, update => 1 not required, already exists
 			$NG->log->error("Failed to save inventory for $mactid: $error")
 					if ($error);
 		}

--- a/conf-default/plugins/hwMusaBoard.pm
+++ b/conf-default/plugins/hwMusaBoard.pm
@@ -67,7 +67,7 @@ sub update_plugin
 			$changesweremade = 1;
 
 			$hmbinventory->data($hmbdata); # set changed info
-			(undef,$error) = $hmbinventory->save; # and save to the db
+			(undef,$error) = $hmbinventory->save; # and save to the db, update not required
 			$NG->log->error("Failed to save inventory for $hmbid: $error")
 					if ($error);
 		}

--- a/conf-default/plugins/jnxCoStable.pm
+++ b/conf-default/plugins/jnxCoStable.pm
@@ -147,7 +147,7 @@ sub update_plugin
 						subconcept => "Juniper_CoS",
 						enabled => 0
 					);
-					my ( $op, $subError ) = $inventory->save( node => $node );
+					my ( $op, $subError ) = $inventory->save( node => $node ); # update not required
 					if ($subError)
 					{
 						$NG->log->error("Failed to unmanage inventory for Class of Service Index '$index': $subError");
@@ -183,7 +183,7 @@ sub update_plugin
 			$NG->log->debug2(sub {"jnxCoStable: cosDescription = '$juniperCoSData->{cosDescription}'"});
 			$NG->log->debug("jnxCoStable: update_plugin: Found COS Entry with interface '$juniperCoSData->{IntName}' and '$juniperCoSData->{jnxCosFcName}'.");
 			# The above has added data to the inventory, that we now save.
-			my ( $op, $subError ) = $inventory->save( node => $node );
+			my ( $op, $subError ) = $inventory->save( node => $node ); # update not required
 			if ($subError)
 			{
 				$NG->log->error("Failed to save inventory for Class of Service Index '$index': $subError");

--- a/conf-default/plugins/lldpTable.pm
+++ b/conf-default/plugins/lldpTable.pm
@@ -204,7 +204,7 @@ sub update_plugin
 		if ($mustsave)
 		{
 			$lldpinventory->data($data); # set changed info
-			(undef,$error) = $lldpinventory->save; # and save to the db
+			(undef,$error) = $lldpinventory->save; # and save to the db, update not required
 			$NG->log->error("Failed to save inventory for $lldpid: $error")
 					if ($error);
 		}

--- a/conf-default/plugins/mplsVpn.pm
+++ b/conf-default/plugins/mplsVpn.pm
@@ -105,7 +105,7 @@ sub update_plugin
 				$NG->log->debug5(sub {"Node '$node' 'mplsVpnVrf' entry $i After " . Dumper($entry)});
 				# Save the results in the database.
 				$mplsVpnVrf->data($entry);
-				my ( $op, $saveError ) = $mplsVpnVrf->save( node => $node );
+				my ( $op, $saveError ) = $mplsVpnVrf->save( node => $node ); # update not required
 				if ($saveError)
 				{
 					$NG->log->error("Failed to save Concept 'mplsVpnVrf' inventory for ID '$mplsVpnVrfId' in Node '$node'; Error: $saveError");
@@ -157,7 +157,7 @@ sub update_plugin
 				$NG->log->debug5(sub {"Node '$node' Concept 'mplsL3VpnVrf' entry $i After " . Dumper($entry)});
 				# Save the results back to the database.
 				$mplsL3VpnVrf->data($entry);
-				my ( $op, $saveError ) = $mplsL3VpnVrf->save( node => $node );
+				my ( $op, $saveError ) = $mplsL3VpnVrf->save( node => $node ); # update not required
 				if ($saveError)
 				{
 					$NG->log->error("Failed to save Concept 'mplsL3VpnVrf' inventory for ID '$mplsL3VpnVrfId' in Node '$node'; Error: $saveError");
@@ -215,7 +215,7 @@ sub update_plugin
 				}
 				# Save the results back to the database.
 				$mplsL3VpnIfConf->data($entry);
-				my ( $op, $saveError ) = $mplsL3VpnIfConf->save( node => $node );
+				my ( $op, $saveError ) = $mplsL3VpnIfConf->save( node => $node ); # update not required
 				if ($saveError)
 				{
 					$NG->log->error("Failed to save Concept 'mplsL3VpnIfConf' inventory for ID '$mplsL3VpnIfConfId' in Node '$node'; Error: $saveError");
@@ -273,7 +273,7 @@ sub update_plugin
 				$NG->log->debug5(sub {"Node '$node' Concept 'mplsVpnInterface' entry $i After " . Dumper($entry)});
 				# Save the results back to the database.
 				$mplsVpnInterface->data($entry);
-				my ( $op, $saveError ) = $mplsVpnInterface->save( node => $node );
+				my ( $op, $saveError ) = $mplsVpnInterface->save( node => $node ); # update not required
 				if ($saveError)
 				{
 					$NG->log->error("Failed to save Concept 'mplsVpnInterface' inventory for ID '$mplsVpnInterfaceId' in Node '$node'; Error: $saveError");
@@ -350,7 +350,7 @@ sub update_plugin
 				$NG->log->debug5(sub {"Node '$node' Concept 'mplsL3VpnVrfRT' entry $i After " . Dumper($entry)});
 				# Save the results back to the database.
 				$mplsL3VpnVrfRT->data($entry);
-				my ( $op, $saveError ) = $mplsL3VpnVrfRT->save( node => $node );
+				my ( $op, $saveError ) = $mplsL3VpnVrfRT->save( node => $node ); # update not required
 				if ($saveError)
 				{
 					$NG->log->error("Failed to save Concept 'mplsL3VpnVrfRT' inventory for ID '$mplsL3VpnVrfRTId' in Node '$node'; Error: $saveError");
@@ -413,7 +413,7 @@ sub update_plugin
 				$NG->log->debug5(sub {"Node '$node' Concept 'mplsVpnVrfRouteTarget' entry $i After " . Dumper($entry)});
 				# Save the results back to the database.
 				$mplsVpnVrfRouteTarget->data($entry);
-				my ( $op, $saveError ) = $mplsVpnVrfRouteTarget->save( node => $node );
+				my ( $op, $saveError ) = $mplsVpnVrfRouteTarget->save( node => $node ); # update not required
 				if ($saveError)
 				{
 					$NG->log->error("Failed to save Concept 'mplsVpnVrfRouteTarget' inventory for ID '$mplsVpnVrfRouteTargetId' in Node '$node'; Error: $saveError");
@@ -464,7 +464,7 @@ sub update_plugin
 				$NG->log->debug5(sub {"Node '$node' Concept 'mplsLdpEntity' entry $i After " . Dumper($entry)});
 				# Save the results back to the database.
 				$mplsLdpEntity->data($entry);
-				my ( $op, $saveError ) = $mplsLdpEntity->save( node => $node );
+				my ( $op, $saveError ) = $mplsLdpEntity->save( node => $node ); # update not required
 				if ($saveError)
 				{
 					$NG->log->error("Failed to save Concept 'mplsLdpEntity' inventory for ID '$mplsLdpEntityId' in Node '$node'; Error: $saveError");
@@ -515,7 +515,7 @@ sub update_plugin
 				$NG->log->debug5(sub {"Node '$node' Concept 'mplsVpnLdpCisco' entry $i After " . Dumper($entry)});
 				# Save the results back to the database.
 				$mplsVpnLdpCisco->data($entry);
-				my ( $op, $saveError ) = $mplsVpnLdpCisco->save( node => $node );
+				my ( $op, $saveError ) = $mplsVpnLdpCisco->save( node => $node ); # update not required
 				if ($saveError)
 				{
 					$NG->log->error("Failed to save Concept 'mplsVpnLdpCisco' inventory for ID '$mplsVpnLdpCiscoId' in Node '$node'; Error: $saveError");

--- a/conf-default/plugins/vtpVlan.pm
+++ b/conf-default/plugins/vtpVlan.pm
@@ -109,7 +109,7 @@ sub update_plugin
 		if ($mustsave)
 		{
 			$vtpinventory->data($vtpdata); # set changed info
-			(undef,$error) = $vtpinventory->save; # and save to the db
+			(undef,$error) = $vtpinventory->save; # and save to the db # update not required
 			$NG->log->error("Failed to save inventory for $vtpid: $error")
 					if ($error);
 		}

--- a/lib/NMISNG/Inventory.pm
+++ b/lib/NMISNG/Inventory.pm
@@ -1464,7 +1464,7 @@ sub save
 		$setthese{"expire_at"} = $record->{expire_at} if (exists $record->{expire_at});
 
 		#Handle cases where NMIS is updating the inventory but nothing in record has changed, we need to make sure lastupdate is updated as opHA uses this to track when data should be pushed
-		$setthese{lastupdate} = $lastupdate if($update);
+		$self->_dirty(1,"lastupdate") if ($update);
 
 		$op = 3; # nothing to update
 		for my $saveme ($self->_whatisdirty)

--- a/lib/NMISNG/Inventory.pm
+++ b/lib/NMISNG/Inventory.pm
@@ -1283,6 +1283,9 @@ sub path
 #
 # args: lastupdate, (optional, defaults to now), node (obj)
 # note: lastupdate and expire_at currently not added to object but stored in db only
+# 		update - 0/1 set 1 if the save is coming from an update function that is where
+#				that piece of inventory is created, if the function just updates existing
+#				inventory that is created elsewhere keep 0
 #
 # the object's _id and _path are refreshed
 # returns ($op,$error), op is 1 for insert, 2 for update/save,

--- a/lib/NMISNG/Node.pm
+++ b/lib/NMISNG/Node.pm
@@ -4231,7 +4231,7 @@ sub collect_intf_data
 		$inventory->historic(0);
 		$inventory->enabled(1);
 
-		my ($op, $error) = $inventory->save( node => $self, update => 1 );
+		my ($op, $error) = $inventory->save( node => $self );
 		$self->nmisng->log->error("failed to save inventory for $nodename, interface $inventory_data->{ifDescr}: $error")
 				if ($op <= 0);
 
@@ -5078,7 +5078,7 @@ sub collect_systemhealth_data
 				# technically the path shouldn't change during collect so for now don't recalculate path
 				# put the new values into the inventory and save
 				$inventory->data($data);
-				$inventory->save( node => $self , update => 1);
+				$inventory->save( node => $self );
 			}
 			# this allows us to prevent adding data when it wasn't collected (but not an error)
 			elsif( $howdiditgo->{skipped} ) {}
@@ -5758,7 +5758,7 @@ sub collect_cbqos_data
 			}
 			# saving is required bacause create_update_rrd can change inventory, setting data not done because
 			# it's not changed
-			$inventory->save( node => $self , update => 1);
+			$inventory->save( node => $self );
 		}
 	}
 	return $happy? 1 : 0;
@@ -7149,7 +7149,7 @@ sub collect_server_data
 			$inventory->enabled(1);
 			# disable for now
 			$inventory->data_info( subconcept => 'device_global', enabled => 0 );
-			($op,$error) = $inventory->save( node => $self , update => 1);
+			($op,$error) = $inventory->save( node => $self );
 			$self->nmisng->log->debug2(sub { "saved ".join(',', @$path)." op: $op"});
 		}
 
@@ -7226,7 +7226,7 @@ sub collect_server_data
 																										time => $catchall_data->{last_poll}, delay_insert => 1 );
 						$self->nmisng->log->error("($name) failed to add timed data for ". $inventory->concept .": $error") if ($error);
 
-						($op,$error) = $inventory->save( node => $self , update => 1);
+						($op,$error) = $inventory->save( node => $self );
 						$self->nmisng->log->debug2(sub { "saved ".join(',', @$path)." op: $op"});
 					}
 					$self->nmisng->log->error("Failed to save inventory, error_message:$error") if($error);
@@ -7240,7 +7240,7 @@ sub collect_server_data
 					if($inventory)
 					{
 						$inventory->enabled(0);
-						$inventory->save( node => $self , update => 1);
+						$inventory->save( node => $self );
 					}
 				}
 			}
@@ -7499,7 +7499,7 @@ sub collect_server_data
 				$inventory->description( $storage_target->{hrStorageDescr} )
 					if( defined($storage_target->{hrStorageDescr}) && $storage_target->{hrStorageDescr});
 
-				($op,$error) = $inventory->save( node => $self , update => 1);
+				($op,$error) = $inventory->save( node => $self );
 				$self->nmisng->log->debug2(sub { "saved ".join(',', @{$inventory->path})." op: $op"});
 				$self->nmisng->log->error("Failed to save storage inventory, op:$op, error_message:$error") if($error);
 			}
@@ -7509,7 +7509,7 @@ sub collect_server_data
 				if( $inventory )
 				{
 					$inventory->historic(1);
-					$inventory->save( node => $self , update => 1);
+					$inventory->save( node => $self );
 				}
 				# nothing needs to be done here, storage target is the data from last time so it's already in db
 				# maybe mark it historic?
@@ -7767,7 +7767,7 @@ sub collect_services
 
 			die "cannot instantiate inventory object: $error\n" if ($error or !ref($invobj));
 			$invobj->historic(1);
-			$error = $invobj->save( node => $self, update => 1 );
+			$error = $invobj->save( node => $self );
 			$self->nmisng->log->error("failed to save historic inventory object for service $maybedead: $error") if ($error);
 		}
 	}
@@ -8494,7 +8494,7 @@ sub collect_services
 
 		# TODO: enable this? needs to know some things to show potentially
 		$inventory->data_info( subconcept => 'service', enabled => 0 );
-		( my $op, $error ) = $inventory->save( node => $self , update => 1);
+		( my $op, $error ) = $inventory->save( node => $self );
 		$self->nmisng->log->error("service status saving inventory failed: $error") if ($error);
 
 		# and add a new point-in-time record for this service
@@ -8661,7 +8661,7 @@ sub collect
 			$old_data->{'last_poll_attempt'} = $polltime;
 		
 			$inventory->data($old_data);
-			my ($save, $error2) = $inventory->save( node => $self , update => 1);
+			my ($save, $error2) = $inventory->save( node => $self );
 			
 			$self->nmisng->log->warn("Update last poll for $name failed, $error2") if ($error2);
 		} 
@@ -8722,7 +8722,7 @@ sub collect
 		$self->nmisng->log->warn("'last update' time not known for $name, switching to update operation instead");
 		my $res = $self->update(lock => $lock); # tell update to reuse/upgrade the one lock already held
 		# collect will have to wait until a next run...
-		$catchall_inventory->save( node => $self, update => 1 );
+		$catchall_inventory->save( node => $self  );
 		return $res;
 	}
 

--- a/lib/NMISNG/Node.pm
+++ b/lib/NMISNG/Node.pm
@@ -1666,7 +1666,7 @@ sub sync_catchall
 		$catchall_data->{webserver} = $self->configuration->{webserver};
 		$catchall_data->{wmidomain} = $self->configuration->{wmidomain};
 		$catchall_data->{wmiversion} = $self->configuration->{wmiversion};
-		my ( $op, $error ) = $catchall_inventory->save( node => $self );
+		my ( $op, $error ) = $catchall_inventory->save( node => $self , update => 1);
 		if ($error)
 		{
 			$self->nmisng->log->error("Failed to update catchall inventory for node '$self->{_name}' during save: $error") if ($error);
@@ -2030,7 +2030,7 @@ sub handle_down
 		$quicklynow->{nodestatus} = $coarse < 0? "degraded" : $coarse? "reachable" : "unreachable";
 
 		$catchall->data($quicklynow);
-		$catchall->save( node => $self );
+		$catchall->save( node => $self, update => 1 );
 
 		$self->nmisng->log->debug($self->name.": changed ${typeofdown}down state to ".$quicklynow->{"${typeofdown}down"});
 	}
@@ -3468,7 +3468,7 @@ sub update_intf_info
 				$inventory->data_info( subconcept => 'interface', enabled => 1 );
 				$inventory->data_info( subconcept => 'pkts_hc', enabled => 0 );
 				$inventory->data_info( subconcept => 'pkts', enabled => 0 );
-				my ( $op, $error ) = $inventory->save( node => $self );
+				my ( $op, $error ) = $inventory->save( node => $self , update => 1);
 				$self->nmisng->log->debug2(sub { "saved ".join(',', @{$inventory->path})." op: $op"});
 				$self->nmisng->log->error( "Failed to save inventory:"
 																	 . join( ",", @{$inventory->path} ) . " error:$error" )
@@ -4231,7 +4231,7 @@ sub collect_intf_data
 		$inventory->historic(0);
 		$inventory->enabled(1);
 
-		my ($op, $error) = $inventory->save( node => $self );
+		my ($op, $error) = $inventory->save( node => $self, update => 1 );
 		$self->nmisng->log->error("failed to save inventory for $nodename, interface $inventory_data->{ifDescr}: $error")
 				if ($op <= 0);
 
@@ -4752,7 +4752,7 @@ sub collect_systemhealth_info
 					}
 	
 					# the above will put data into inventory, so save
-					my ( $op, $error ) = $inventory->save( node => $self );
+					my ( $op, $error ) = $inventory->save( node => $self , update => 1 );
 					$self->nmisng->log->debug2(sub { "saved ".join(',', @$path)." op: $op"});
 					$self->nmisng->log->error(
 						"Failed to save inventory:" . join( ",", @{$inventory->path} ) . " error:$error" )
@@ -4922,7 +4922,7 @@ sub collect_systemhealth_info
 					}
 					
 					# the above will put data into inventory, so save
-					my ( $op, $error ) = $inventory->save( node => $self );
+					my ( $op, $error ) = $inventory->save( node => $self , update => 1);
 					$self->nmisng->log->debug2(sub { "saved ".join(',', @$path)." op: $op"});
 					$self->nmisng->log->error(
 						"Failed to save inventory:" . join( ",", @{$inventory->path} ) . " error:$error" )
@@ -5078,7 +5078,7 @@ sub collect_systemhealth_data
 				# technically the path shouldn't change during collect so for now don't recalculate path
 				# put the new values into the inventory and save
 				$inventory->data($data);
-				$inventory->save( node => $self );
+				$inventory->save( node => $self , update => 1);
 			}
 			# this allows us to prevent adding data when it wasn't collected (but not an error)
 			elsif( $howdiditgo->{skipped} ) {}
@@ -5620,7 +5620,7 @@ sub collect_cbqos_info
 						$inventory->data_info( subconcept => $classname, enabled => 0 );
 					}
 
-					my ( $op, $error ) = $inventory->save( node => $self );
+					my ( $op, $error ) = $inventory->save( node => $self , update => 1);
 					$self->nmisng->log->debug2(sub { "saved ".join(',', @$path)." op: $op"});
 					$self->nmisng->log->error( "Failed to save inventory:" . join( ",", @{$inventory->path} ) . " error:$error" )
 							if ($error);
@@ -5758,7 +5758,7 @@ sub collect_cbqos_data
 			}
 			# saving is required bacause create_update_rrd can change inventory, setting data not done because
 			# it's not changed
-			$inventory->save( node => $self );
+			$inventory->save( node => $self , update => 1);
 		}
 	}
 	return $happy? 1 : 0;
@@ -6673,7 +6673,7 @@ sub update
 			$old_data->{'last_update_attempt'} = Time::HiRes::time;
 		
 			$inventory->data($old_data);
-			my ($save, $error2) = $inventory->save( node => $self );
+			my ($save, $error2) = $inventory->save( node => $self , update => 1);
 			
 			$self->nmisng->log->warn("Update last poll for $name failed, $error2") if ($error2);
 		} else {
@@ -7149,7 +7149,7 @@ sub collect_server_data
 			$inventory->enabled(1);
 			# disable for now
 			$inventory->data_info( subconcept => 'device_global', enabled => 0 );
-			($op,$error) = $inventory->save( node => $self );
+			($op,$error) = $inventory->save( node => $self , update => 1);
 			$self->nmisng->log->debug2(sub { "saved ".join(',', @$path)." op: $op"});
 		}
 
@@ -7226,7 +7226,7 @@ sub collect_server_data
 																										time => $catchall_data->{last_poll}, delay_insert => 1 );
 						$self->nmisng->log->error("($name) failed to add timed data for ". $inventory->concept .": $error") if ($error);
 
-						($op,$error) = $inventory->save( node => $self );
+						($op,$error) = $inventory->save( node => $self , update => 1);
 						$self->nmisng->log->debug2(sub { "saved ".join(',', @$path)." op: $op"});
 					}
 					$self->nmisng->log->error("Failed to save inventory, error_message:$error") if($error);
@@ -7240,7 +7240,7 @@ sub collect_server_data
 					if($inventory)
 					{
 						$inventory->enabled(0);
-						$inventory->save( node => $self );
+						$inventory->save( node => $self , update => 1);
 					}
 				}
 			}
@@ -7499,7 +7499,7 @@ sub collect_server_data
 				$inventory->description( $storage_target->{hrStorageDescr} )
 					if( defined($storage_target->{hrStorageDescr}) && $storage_target->{hrStorageDescr});
 
-				($op,$error) = $inventory->save( node => $self );
+				($op,$error) = $inventory->save( node => $self , update => 1);
 				$self->nmisng->log->debug2(sub { "saved ".join(',', @{$inventory->path})." op: $op"});
 				$self->nmisng->log->error("Failed to save storage inventory, op:$op, error_message:$error") if($error);
 			}
@@ -7509,7 +7509,7 @@ sub collect_server_data
 				if( $inventory )
 				{
 					$inventory->historic(1);
-					$inventory->save( node => $self );
+					$inventory->save( node => $self , update => 1);
 				}
 				# nothing needs to be done here, storage target is the data from last time so it's already in db
 				# maybe mark it historic?
@@ -7704,7 +7704,7 @@ sub collect_services
 			die "failed to create or load inventory for snmp_services: $error\n" if (!$processinventory);
 			# i think disabled here makes sense
 			$processinventory->data_info( subconcept => 'snmp_services', enabled => 0 );
-			(my $op, $error) = $processinventory->save( node => $self );
+			(my $op, $error) = $processinventory->save( node => $self , update => 1);
 			die "failed to save inventory for snmp_services: $error\n" if ($error);
 			$error = $processinventory->add_timed_data(data => \%services, derived_data => {}, node => $self,
 																								 subconcept => 'snmp_services');
@@ -7767,7 +7767,7 @@ sub collect_services
 
 			die "cannot instantiate inventory object: $error\n" if ($error or !ref($invobj));
 			$invobj->historic(1);
-			$error = $invobj->save( node => $self );
+			$error = $invobj->save( node => $self, update => 1 );
 			$self->nmisng->log->error("failed to save historic inventory object for service $maybedead: $error") if ($error);
 		}
 	}
@@ -8494,7 +8494,7 @@ sub collect_services
 
 		# TODO: enable this? needs to know some things to show potentially
 		$inventory->data_info( subconcept => 'service', enabled => 0 );
-		( my $op, $error ) = $inventory->save( node => $self );
+		( my $op, $error ) = $inventory->save( node => $self , update => 1);
 		$self->nmisng->log->error("service status saving inventory failed: $error") if ($error);
 
 		# and add a new point-in-time record for this service
@@ -8661,7 +8661,7 @@ sub collect
 			$old_data->{'last_poll_attempt'} = $polltime;
 		
 			$inventory->data($old_data);
-			my ($save, $error2) = $inventory->save( node => $self );
+			my ($save, $error2) = $inventory->save( node => $self , update => 1);
 			
 			$self->nmisng->log->warn("Update last poll for $name failed, $error2") if ($error2);
 		} 
@@ -8722,7 +8722,7 @@ sub collect
 		$self->nmisng->log->warn("'last update' time not known for $name, switching to update operation instead");
 		my $res = $self->update(lock => $lock); # tell update to reuse/upgrade the one lock already held
 		# collect will have to wait until a next run...
-		$catchall_inventory->save( node => $self );
+		$catchall_inventory->save( node => $self, update => 1 );
 		return $res;
 	}
 


### PR DESCRIPTION
This will keep lastupdate from going stale. When we update inventory and we only have one key to update expire_at check if the current value is greater than 2 days, if so then stop updating this record.