### PR TITLE
On node save attempt to create and update catchall, also only create …

### DIFF
--- a/lib/NMISNG/Node.pm
+++ b/lib/NMISNG/Node.pm
@@ -1635,13 +1635,13 @@ sub save
 					my $catchall_data = $catchall_inventory->data_live();
 					$self->update_host_addr( catchall_data => $catchall_data );
 					$self->sync_catchall( cache => $catchall_inventory );
-					$self->unlock(lock => $lock);
 				}
 				else 
 				{
 					# this isn't a huge deal
 					$self->nmisng->log->warn(sub {"Node::save failed to get catchall so cannot sync: $error"});	
 				}
+				$self->unlock(lock => $lock);
 			}
 		}
 	}


### PR DESCRIPTION
…it when server cluster_id matches node cluster_id

This should help prevent catchall being created on servers that it should not be, and help keep the catchall up-to-sync in more cases (still not perfect).