### PR TITLE
scheduler using $ne to find jobs is not efficient

### DIFF
--- a/bin/nmisd
+++ b/bin/nmisd
@@ -773,8 +773,7 @@ while (!$exit_marker)
 		my $jobtype = $automagic;
 
 		# don't schedule another if an instance is already in progress
-		my $running = $nmisng->get_queue_model(type => $jobtype,
-																					 in_progress => { '$ne' => 0 });
+		my $running = $nmisng->get_queue_model(type => $jobtype, in_progress => { '$gt' => 0 });
 		$nmisng->log->error("failed to query job queue: ".$running->error)
 				if ($running->error);
 		# also don't schedule anything if overdue instances exist,
@@ -929,7 +928,7 @@ while (!$exit_marker)
 	{
 		$nmisng->log->error("Failed to count overdue jobs: $error");
 	}
-	my $active = $nmisng->get_queue_model(limit => 0, count => 1, in_progress => { '$ne' => 0 });
+	my $active = $nmisng->get_queue_model(limit => 0, count => 1, in_progress => { '$gt' => 0 });
 	if (my $error = $active->error)
 	{
 		$nmisng->log->error("Failed to count in-progress jobs: $error");
@@ -1358,7 +1357,7 @@ sub worker_loop
 			# a job was claimable, but is it safe to perform this op right now?
 			# look for in_progress interfering jobs (needs args check for node-specific stuff!)
 			my %checkargs = ( time => { '$lt' => Time::HiRes::time }, # should have started
-								in_progress => { '$ne' => 0 },			# has started
+								in_progress => { '$gt' => 0 },			# has started
 #								id => { '$ne' => $canihaveit->{_id} },	# is not this job (this doesn't work!)
 								type => $canihaveit->{type});			# but of the same type
 			# Add the UUID if it is set.


### PR DESCRIPTION
$ne can't use an index well. value is >0 if it's started so use
 that check instead (it gets set to the time it starts).

Only issue here is making sure the value is 0 when it's added and not null, we need to test to make sure this code covers that properly and also try and prevent it from being added (schema validation could do this).