### PR TITLE
Update Model-net-snmp.nmis to revert to OMK-8576 fix

### DIFF
--- a/models-default/Model-net-snmp.nmis
+++ b/models-default/Model-net-snmp.nmis
@@ -162,7 +162,7 @@
             'oid' => 'hrSystemProcesses',
             'title' => 'System Processes',
             'alert' => {
-              'test' => '$r > 200',
+              'test' => '$r > 375',
               'event' => 'High Number of System Processes',
               'unit' => 'processes',
               'level' => 'Warning'


### PR DESCRIPTION
I just wanted to add a test node on a new VM, and I added athena, and it come up as DEGRADED in opCharts and I wondered why? 
There has been a reversion of OMK-8576, **Improve default setting for High Number of System Processes**
Doug edited Model-net-snmp.nmis and overwrote the new value of 375 with the old value of 200.

I have changed it back to 375.