### PR TITLE
fix: Handle undefined WMI query results in Sys.pm

### DIFF
--- a/lib/NMISNG/Sys.pm
+++ b/lib/NMISNG/Sys.pm
@@ -1360,7 +1360,7 @@ sub getValues
 		{
 			my $query = $todos{$itemname}->{query};
 
-			if ( !$seen{$query} )
+			if ( !defined($seen{$query}) )
 			{
 				# fixme: do we need dynamically created lists of fields, ie. from the known-to-be wanted stuff?
 				# or is a blanket retrieve-all-then-filter good enough? where are the costs, in wmic startup or the
@@ -1380,16 +1380,26 @@ sub getValues
 				{
 					( $error, $fields, $meta ) = $self->{wmi}->get( wql => $query );
 				}
+
 				if ($error)
 				{
 					$self->nmisng->log->error("($self->{name}) on get values by wmi: $error");
 					$status{wmi_error} = $error;
+					next;
 				}
 				else
 				{
 					# if indexed, gettable will have returned ALL known indices + values.
 					$seen{$query} = $fields;
 				}
+			}
+
+			#last check to make sure we have data
+			if(!defined($seen{$query}))
+			{
+				$self->nmisng->log->error("($self->{name}) on get values by wmi: no data returned for query $query");
+				$status{wmi_error} = "no data returned for query $query";
+				next;
 			}
 
 			# get the field name from the model entry

--- a/lib/NMISNG/Sys.pm
+++ b/lib/NMISNG/Sys.pm
@@ -1360,7 +1360,7 @@ sub getValues
 		{
 			my $query = $todos{$itemname}->{query};
 
-			if ( !defined($seen{$query}) )
+			if ( !$seen{$query} )
 			{
 				# fixme: do we need dynamically created lists of fields, ie. from the known-to-be wanted stuff?
 				# or is a blanket retrieve-all-then-filter good enough? where are the costs, in wmic startup or the
@@ -1395,7 +1395,7 @@ sub getValues
 			}
 
 			#last check to make sure we have data
-			if(!defined($seen{$query}))
+			if(!$seen{$query})
 			{
 				$self->nmisng->log->error("($self->{name}) on get values by wmi: no data returned for query $query");
 				$status{wmi_error} = "no data returned for query $query";


### PR DESCRIPTION
Add null check for $seen{$query} to prevent
"Can't use an undefined value as a HASH reference" error when WMI
queries fail. This prevents job processing exceptions with failed queries."