### PR TITLE
net-snmp node reset needs sysUpTime, WMI calculations back

### DIFF
--- a/lib/NMISNG/Node.pm
+++ b/lib/NMISNG/Node.pm
@@ -2123,10 +2123,10 @@ sub makesysuptime
 
 	# if this is wmi, we need to make a sysuptime first. these are seconds
 	# who should own sysUpTime, this needs to only happen if SNMP not available OMK-3223
-	#if ($catchall_data->{wintime} && $catchall_data->{winboottime})
-	#{
-	#	$catchall_data->{sysUpTime} = 100 * ($catchall_data->{wintime}-$catchall_data->{winboottime});
-	#}
+	if (defined($catchall_data->{wintime}) && $catchall_data->{wintime} && $catchall_data->{winboottime})
+	{
+		$catchall_data->{sysUpTime} = 100 * ($catchall_data->{wintime}-$catchall_data->{winboottime});
+	}
 
 	# pre-mangling it's a number, maybe fractional, in 1/100s ticks
 	# post-manging it is text, and we can't do a damn thing anymore

--- a/models-default/Model-net-snmp.nmis
+++ b/models-default/Model-net-snmp.nmis
@@ -113,16 +113,14 @@
           # SRC IMPORTANT - sysUptime is the number of clock ticks that snapped
           #              has been running for, not the uptime of the box.  hrSystemUpTime
           #              is the same as 'uptime' on the bash command line.
-          #'sysUpTime' => {
-          #  'oid' => 'hrSystemUptime',
-          #  'title' => 'Uptime',
-          #},
-          
+          'sysUpTime' => {
+            'oid' => 'hrSystemUptime',
+            'title' => 'Uptime',
+          },
 					'snmpUpTime' => {
             'oid' => 'sysUpTime',
             'title' => 'SNMP_Uptime',
           },
-
 					'hrSystemDateSec' => {
 						'oid' => 'hrSystemDate',
 						# have: the 0xhexstring equivalent of local 2016-9-9,5:53:28.0,+10:0


### PR DESCRIPTION
Node reset nodes now working for net-snmp and wmi models