### PR TITLE
OMK-11923 Fixes for dockerfile and adding sample docker-compose.yaml file

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,60 @@
+version: '3.4'
+services:
+  mongo:
+    image: mongo:6.0
+    restart: always
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: example
+    volumes:
+      - /persistent/mongod.conf:/etc/mongod.conf
+      - mongo_data:/data/mongodb
+    ports:
+      - "27017:27017"
+    networks:
+      - nmis_net
+  nmis:
+    image: public.ecr.aws/n2x4v8j4/firstwave/nmis9_omk:v1.7
+    restart: always
+    environment:
+      NMIS_DB_USERNAME: root
+      NMIS_DB_PASSWORD: example
+      NMIS_DB_SERVER: 192.168.xx.xxx
+      NMIS_SERVER_NAME: xxx.opmantek.net
+    depends_on:
+      - mongo
+    volumes:
+      - log_data:/usr/local/nmis9/logs
+      - var_data:/usr/local/nmis9/var
+      - conf_data:/usr/local/nmis9/conf
+      - database_data:/usr/local/nmis9/database
+      # You can mount your own config files into volumes in the container but 
+      # you must ensure that the db config details match whats in this compose file
+      # - ./default-config/Config.nmis:/usr/local/nmis9/conf/Config.nmis
+      # - ./default-config/opCommon.json:/usr/local/omk/conf/opCommon.json
+      - /persistent/Config.nmis:/usr/local/nmis9/conf/Config.nmis
+      - /persistent/opCommon.json:/usr/local/omk/conf/opCommon.json
+      - omk_log_data:/usr/local/omk/log
+      - omk_var_data:/usr/local/omk/var
+      - omk_conf_data:/usr/local/omk/conf
+      # - ./persistent:/persistent
+      # - ./app_conf/opLicense.json:/usr/local/omk/conf/opLicense.json
+    ports:
+      - "8080:8080"
+      - "8042:8042"
+      - "2055:2055/udp"
+      - "161:161/udp"
+      - "25:25"
+    networks:
+      - nmis_net
+networks:
+  nmis_net:
+volumes:
+  log_data:
+  var_data:
+  conf_data:
+  database_data:
+  omk_log_data:
+  omk_var_data:
+  omk_conf_data:
+  mongo_data:

--- a/dockerfile
+++ b/dockerfile
@@ -9,6 +9,8 @@ LABEL maintainer="Kishen Kumar. <kishen.kumar@firstwave.com>"
 ARG NMIS_HOME=/usr/local/nmis9
 ARG NMIS_USER=nmis
 ARG NMIS_GROUP=nmis
+ARG NMIS_USER_UID=10001
+ARG NMIS_USER_GID=10001
 
 ENV PERL5LIB="/usr/share/perl5:/usr/lib/x86_64-linux-gnu/perl5/5.32"
 
@@ -82,6 +84,10 @@ RUN apt-get -y install --no-install-recommends tini \
     libtie-ixhash-perl \
     libmojolicious-plugin-cgi-perl \
     libmongodb-perl \
+    libconfig-yaml-perl \
+    sysstat \
+    net-tools \
+    mongodb-mongosh \
     #OMK related packages from here down
     sshpass \
     unixodbc \
@@ -91,11 +97,19 @@ RUN apt-get -y install --no-install-recommends tini \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* 
 
+WORKDIR /tmp
+
+# Systemctl redirect when scripts try call systemctl inside the container
+RUN git clone https://github.com/gdraheim/docker-systemctl-replacement && \
+    cp docker-systemctl-replacement/files/docker/systemctl3.py /usr/bin/systemctl && \
+    rm -rf docker-systemctl-replacement
+
+RUN addgroup --gid ${NMIS_USER_GID} ${NMIS_GROUP} && \
+    useradd --uid ${NMIS_USER_UID} --gid ${NMIS_GROUP} --shell /bin/bash ${NMIS_USER}
+
 WORKDIR ${NMIS_HOME}
 
 COPY . ${NMIS_HOME}
-
-EXPOSE 8080
 
 RUN mkdir ${NMIS_HOME}/conf \
     ${NMIS_HOME}/database \
@@ -120,6 +134,16 @@ RUN mv /usr/local/nmis9/omk /usr/local/ && \
     mv /usr/local/omk/install/opconfigd.init.d.bak /etc/init.d/opconfigd && \
     mv /usr/local/omk/install/opeventsd.init.d.bak /etc/init.d/opeventsd
 
-EXPOSE 8042
+# NMIS Web 8080
+# OMK Web 8042
+# MTA Port 25
+# SNMP Ports 161/udp 162/udp
+# NetFlow Port 2055
+EXPOSE 8080 \
+       8042 \
+       25 \
+       161/udp \
+       162/udp \
+       2055/udp
 
 ENTRYPOINT ["tini", "--", "/usr/local/nmis9/docker-entrypoint.sh"]

--- a/dockerfile
+++ b/dockerfile
@@ -14,15 +14,17 @@ ARG NMIS_USER_GID=10001
 
 ENV PERL5LIB="/usr/share/perl5:/usr/lib/x86_64-linux-gnu/perl5/5.32"
 
-RUN wget -qO- https://www.mongodb.org/static/pgp/server-8.0.asc | tee /etc/apt/trusted.gpg.d/server-8.0.asc && \
-    echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/8.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-8.0.list
-
 RUN apt-get update  > /dev/null && \
     apt-get install --assume-yes \
+      gnupg \
       ca-certificates \
       curl > /dev/null
 
-RUN apt-get -y install --no-install-recommends tini \
+RUN curl -fsSL https://www.mongodb.org/static/pgp/server-6.0.asc | sudo gpg --dearmor -o /usr/share/keyrings/mongodb-server-6.0.gpg && \
+    echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-6.0.gpg ] http://repo.mongodb.org/apt/debian bullseye/mongodb-org/6.0 main" | sudo tee /etc/apt/sources.list.d/mongodb-org-6.0.list
+
+RUN apt-get update  > /dev/null && \
+    apt-get -y install --no-install-recommends tini \
     libcairo2 \
     libcairo2-dev \
     libglib2.0-dev \
@@ -136,7 +138,7 @@ RUN mv /usr/local/nmis9/omk /usr/local/ && \
     mv /usr/local/omk/install/opchartsd.init.d.bak /etc/init.d/opchartsd && \
     mv /usr/local/omk/install/opconfigd.init.d.bak /etc/init.d/opconfigd && \
     mv /usr/local/omk/install/opeventsd.init.d.bak /etc/init.d/opeventsd && \
-    rm /etc/apt/sources.list.d/mongodb-org-8.0.list
+    rm /etc/apt/sources.list.d/mongodb-org-6.0.list
 
 # NMIS Web 8080
 # OMK Web 8042

--- a/dockerfile
+++ b/dockerfile
@@ -14,6 +14,9 @@ ARG NMIS_USER_GID=10001
 
 ENV PERL5LIB="/usr/share/perl5:/usr/lib/x86_64-linux-gnu/perl5/5.32"
 
+RUN wget -qO- https://www.mongodb.org/static/pgp/server-8.0.asc | tee /etc/apt/trusted.gpg.d/server-8.0.asc && \
+    echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/8.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-8.0.list
+
 RUN apt-get update  > /dev/null && \
     apt-get install --assume-yes \
       ca-certificates \
@@ -132,7 +135,8 @@ RUN mv /usr/local/nmis9/omk /usr/local/ && \
     mv /usr/local/omk/install/omkd.init.d.bak /etc/init.d/omkd && \
     mv /usr/local/omk/install/opchartsd.init.d.bak /etc/init.d/opchartsd && \
     mv /usr/local/omk/install/opconfigd.init.d.bak /etc/init.d/opconfigd && \
-    mv /usr/local/omk/install/opeventsd.init.d.bak /etc/init.d/opeventsd
+    mv /usr/local/omk/install/opeventsd.init.d.bak /etc/init.d/opeventsd && \
+    rm /etc/apt/sources.list.d/mongodb-org-8.0.list
 
 # NMIS Web 8080
 # OMK Web 8042

--- a/dockerfile
+++ b/dockerfile
@@ -17,11 +17,12 @@ ENV PERL5LIB="/usr/share/perl5:/usr/lib/x86_64-linux-gnu/perl5/5.32"
 RUN apt-get update  > /dev/null && \
     apt-get install --assume-yes \
       gnupg \
+      git \
       ca-certificates \
       curl > /dev/null
 
-RUN curl -fsSL https://www.mongodb.org/static/pgp/server-6.0.asc | sudo gpg --dearmor -o /usr/share/keyrings/mongodb-server-6.0.gpg && \
-    echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-6.0.gpg ] http://repo.mongodb.org/apt/debian bullseye/mongodb-org/6.0 main" | sudo tee /etc/apt/sources.list.d/mongodb-org-6.0.list
+RUN curl -fsSL https://www.mongodb.org/static/pgp/server-6.0.asc | gpg --dearmor -o /usr/share/keyrings/mongodb-server-6.0.gpg && \
+    echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-6.0.gpg ] http://repo.mongodb.org/apt/debian bullseye/mongodb-org/6.0 main" | tee /etc/apt/sources.list.d/mongodb-org-6.0.list
 
 RUN apt-get update  > /dev/null && \
     apt-get -y install --no-install-recommends tini \


### PR DESCRIPTION
- Fixes to the dockerfile that address issues from functionality testing NMIS
- UID/GID added for NMIS user
- Python script which functions as a systemctl redirect added so scripts that call systemctl still work
- Installs missing packages e.g. mongosh needed for some scripts
- EXPOSE ports for SNMP, MAIL AGENTS, NETFLOW. These ports are bound through the docker-compose.yaml.
- Added sample docker-compose.yaml file