### PR TITLE
OMK-12085 Fix for nmisng database auth not working

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -46,7 +46,7 @@ nmis_frontend() {
 }
 
 setup_db() {
-#make sure we set up
+  yes '' | /usr/local/nmis9/admin/setup_mongodb.pl
 	yes '' | /usr/local/omk/bin/setup_mongodb.exe
 }
 


### PR DESCRIPTION
Admin tools are failing because the root user is not granted correct access. Running the setup_mongodb.pl should fix this.