### PR TITLE
OMK-12085 Add apache httpd service to handle redirects

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -69,6 +69,7 @@ services:
       - /persistent/apache/conf-enabled:/usr/local/apache2/conf/conf-enabled
       - /persistent/apache/httpd.conf:/usr/local/apache2/conf/httpd.conf
       - /persistent/apache/sites-enabled:/usr/local/apache2/conf/sites-enabled
+      - apache2_logs:/usr/local/apache2/logs
     ports:
       - 8070:80
     networks:
@@ -85,3 +86,4 @@ volumes:
   omk_conf_data:
   mongo_data:
   redis_data:
+  apache2_logs:

--- a/compose.yaml
+++ b/compose.yaml
@@ -63,6 +63,16 @@ services:
     command: ["redis-server", "--requirepass", "${REDIS_PASSWORD}"]
     networks:
       - nmis_net
+  httpd:
+    image: httpd:2.4.62-bookworm
+    volumes:
+      - /persistent/apache/conf-enabled:/usr/local/apache2/conf/conf-enabled
+      - /persistent/apache/httpd.conf:/usr/local/apache2/conf/httpd.conf
+      - /persistent/apache/sites-enabled:/usr/local/apache2/conf/sites-enabled
+    ports:
+      - 8070:80
+    networks:
+      - nmis_net
 networks:
   nmis_net:
 volumes:

--- a/conf-default/docker/apache2/conf-enabled/04omk-proxy.conf
+++ b/conf-default/docker/apache2/conf-enabled/04omk-proxy.conf
@@ -1,0 +1,50 @@
+## For more information on the listed Apache features please consult:
+## http://httpd.apache.org/docs/
+
+# Don't forget to restart the daemon if you make changes to this configuration file1
+# apachectl restart
+
+<IfModule mod_proxy.c>
+ProxyRequests off
+
+<IfModule mod_headers.c>
+# if you are using the Opmantek applications behind an ssl-terminating apache vhost,
+# then you should adjust the vhost configuration to add this header but with 
+# protocol "https". 
+# The Opmantek applications are location- and protocol-independent in almost all cases.
+RequestHeader set X-Forwarded-Proto "http"
+</IfModule>
+
+<Location "/omk">
+    ProxyPass http://nmis:8042/omk retry=5
+    ProxyPassReverse http://nmis:8042/omk
+		ErrorDocument 503 '<html><head><meta http-equiv="refresh" content="60"></head><body><h1>Temporary Service Interruption</h1>The requested OMK page should be back soon. This page will automatically reload in 60 seconds.</body></html>'
+</Location>
+
+# the first location directive only covers /omk and /omk/something,
+# not /omk.json
+<Location "/omk.json">
+    ProxyPass http://nmis:8042/omk.json retry=5
+    ProxyPassReverse http://nmis:8042/omk.json
+</Location>
+
+
+<Location "/es">
+    ProxyPass http://nmis:8042/es retry=5
+    ProxyPassReverse http://nmis:8042/es
+		ErrorDocument 503 '<html><head><meta http-equiv="refresh" content="60"></head><body><h1>Temporary Service Interruption</h1>The requested OMK page should be back soon. This page will automatically reload in 60 seconds.</body></html>'
+</Location>
+
+<Location "/en">
+    ProxyPass http://nmis:8042/en retry=5
+    ProxyPassReverse http://nmis:8042/en
+		ErrorDocument 503 '<html><head><meta http-equiv="refresh" content="60"></head><body><h1>Temporary Service Interruption</h1>The requested OMK page should be back soon. This page will automatically reload in 60 seconds.</body></html>'
+</Location>
+
+<Location "/pt">
+    ProxyPass http://nmis:8042/pt retry=5
+    ProxyPassReverse http://nmis:8042/pt
+		ErrorDocument 503 '<html><head><meta http-equiv="refresh" content="60"></head><body><h1>Temporary Service Interruption</h1>The requested OMK page should be back soon. This page will automatically reload in 60 seconds.</body></html>'
+</Location>
+
+</IfModule>

--- a/conf-default/docker/apache2/conf-enabled/charset.conf
+++ b/conf-default/docker/apache2/conf-enabled/charset.conf
@@ -1,0 +1,8 @@
+# Read the documentation before enabling AddDefaultCharset.
+# In general, it is only a good idea if you know that all your files
+# have this encoding. It will override any encoding given in the files
+# in meta http-equiv or xml encoding tags.
+
+#AddDefaultCharset UTF-8
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/conf-default/docker/apache2/conf-enabled/javascript-common.conf
+++ b/conf-default/docker/apache2/conf-enabled/javascript-common.conf
@@ -1,0 +1,5 @@
+Alias /javascript /usr/share/javascript/
+
+<Directory "/usr/share/javascript/">
+	Options FollowSymLinks MultiViews
+</Directory>

--- a/conf-default/docker/apache2/conf-enabled/localized-error-pages.conf
+++ b/conf-default/docker/apache2/conf-enabled/localized-error-pages.conf
@@ -1,0 +1,81 @@
+# Customizable error responses come in three flavors:
+# 1) plain text
+# 2) local redirects
+# 3) external redirects
+#
+# Some examples:
+#ErrorDocument 500 "The server made a boo boo."
+#ErrorDocument 404 /missing.html
+#ErrorDocument 404 "/cgi-bin/missing_handler.pl"
+#ErrorDocument 402 http://www.example.com/subscription_info.html
+#
+
+#
+# Putting this all together, we can internationalize error responses.
+#
+# We use Alias to redirect any /error/HTTP_<error>.html.var response to
+# our collection of by-error message multi-language collections.  We use
+# includes to substitute the appropriate text.
+#
+# You can modify the messages' appearance without changing any of the
+# default HTTP_<error>.html.var files by adding the line:
+#
+#Alias /error/include/ "/your/include/path/"
+#
+# which allows you to create your own set of files by starting with the
+# /usr/share/apache2/error/include/ files and copying them to /your/include/path/,
+# even on a per-VirtualHost basis.  If you include the Alias in the global server
+# context, is has to come _before_ the 'Alias /error/ ...' line.
+#
+# The default include files will display your Apache version number and your
+# ServerAdmin email address regardless of the setting of ServerSignature.
+#
+# WARNING: The configuration below will NOT work out of the box if you have a
+#		  SetHandler directive in a <Location /> context somewhere. Adding
+#		  the following three lines AFTER the <Location /> context should
+#		  make it work in most cases:
+#		  <Location /error/>
+#			 SetHandler none
+#		  </Location>
+#
+# The internationalized error documents require mod_alias, mod_include
+# and mod_negotiation.  To activate them, uncomment the following 37 lines.
+
+#<IfModule mod_negotiation.c>
+#	<IfModule mod_include.c>
+#		<IfModule mod_alias.c>
+#
+#			Alias /error/ "/usr/share/apache2/error/"
+#
+#			<Directory "/usr/share/apache2/error">
+#				Options IncludesNoExec
+#				AddOutputFilter Includes html
+#				AddHandler type-map var
+#				Order allow,deny
+#				Allow from all
+#				LanguagePriority en cs de es fr it nl sv pt-br ro
+#				ForceLanguagePriority Prefer Fallback
+#			</Directory>
+#
+#			ErrorDocument 400 /error/HTTP_BAD_REQUEST.html.var
+#			ErrorDocument 401 /error/HTTP_UNAUTHORIZED.html.var
+#			ErrorDocument 403 /error/HTTP_FORBIDDEN.html.var
+#			ErrorDocument 404 /error/HTTP_NOT_FOUND.html.var
+#			ErrorDocument 405 /error/HTTP_METHOD_NOT_ALLOWED.html.var
+#			ErrorDocument 408 /error/HTTP_REQUEST_TIME_OUT.html.var
+#			ErrorDocument 410 /error/HTTP_GONE.html.var
+#			ErrorDocument 411 /error/HTTP_LENGTH_REQUIRED.html.var
+#			ErrorDocument 412 /error/HTTP_PRECONDITION_FAILED.html.var
+#			ErrorDocument 413 /error/HTTP_REQUEST_ENTITY_TOO_LARGE.html.var
+#			ErrorDocument 414 /error/HTTP_REQUEST_URI_TOO_LARGE.html.var
+#			ErrorDocument 415 /error/HTTP_UNSUPPORTED_MEDIA_TYPE.html.var
+#			ErrorDocument 500 /error/HTTP_INTERNAL_SERVER_ERROR.html.var
+#			ErrorDocument 501 /error/HTTP_NOT_IMPLEMENTED.html.var
+#			ErrorDocument 502 /error/HTTP_BAD_GATEWAY.html.var
+#			ErrorDocument 503 /error/HTTP_SERVICE_UNAVAILABLE.html.var
+#			ErrorDocument 506 /error/HTTP_VARIANT_ALSO_VARIES.html.var
+#		</IfModule>
+#	</IfModule>
+#</IfModule>
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/conf-default/docker/apache2/conf-enabled/nmis-proxy.conf
+++ b/conf-default/docker/apache2/conf-enabled/nmis-proxy.conf
@@ -1,0 +1,11 @@
+
+<IfModule mod_headers.c>
+# if you are using the Opmantek applications behind an ssl-terminating apache vhost,
+# then you should adjust the vhost configuration to add this header but with 
+# protocol "https". 
+# The Opmantek applications are location- and protocol-independent in almost all cases.
+RequestHeader set X-Forwarded-Proto "http"
+</IfModule>
+
+ProxyPass "/" http://nmis:8080/
+ProxyPassReverse "/" http://nmis:8080/

--- a/conf-default/docker/apache2/conf-enabled/other-vhosts-access-log.conf
+++ b/conf-default/docker/apache2/conf-enabled/other-vhosts-access-log.conf
@@ -1,0 +1,4 @@
+# Define an access log for VirtualHosts that don't define their own logfile
+CustomLog /usr/local/apache2/logs/other_vhosts_access.log vhost_combined
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/conf-default/docker/apache2/conf-enabled/security.conf
+++ b/conf-default/docker/apache2/conf-enabled/security.conf
@@ -1,0 +1,73 @@
+#
+# Disable access to the entire file system except for the directories that
+# are explicitly allowed later.
+#
+# This currently breaks the configurations that come with some web application
+# Debian packages.
+#
+#<Directory />
+#   AllowOverride None
+#   Require all denied
+#</Directory>
+
+
+# Changing the following options will not really affect the security of the
+# server, but might make attacks slightly more difficult in some cases.
+
+#
+# ServerTokens
+# This directive configures what you return as the Server HTTP response
+# Header. The default is 'Full' which sends information about the OS-Type
+# and compiled in modules.
+# Set to one of:  Full | OS | Minimal | Minor | Major | Prod
+# where Full conveys the most information, and Prod the least.
+#ServerTokens Minimal
+ServerTokens OS
+#ServerTokens Full
+
+#
+# Optionally add a line containing the server version and virtual host
+# name to server-generated pages (internal error documents, FTP directory
+# listings, mod_status and mod_info output etc., but not CGI generated
+# documents or custom error documents).
+# Set to "EMail" to also include a mailto: link to the ServerAdmin.
+# Set to one of:  On | Off | EMail
+#ServerSignature Off
+ServerSignature On
+
+#
+# Allow TRACE method
+#
+# Set to "extended" to also reflect the request body (only for testing and
+# diagnostic purposes).
+#
+# Set to one of:  On | Off | extended
+TraceEnable Off
+#TraceEnable On
+
+#
+# Forbid access to version control directories
+#
+# If you use version control systems in your document root, you should
+# probably deny access to their directories. For example, for subversion:
+#
+#<DirectoryMatch "/\.svn">
+#   Require all denied
+#</DirectoryMatch>
+
+#
+# Setting this header will prevent MSIE from interpreting files as something
+# else than declared by the content type in the HTTP headers.
+# Requires mod_headers to be enabled.
+#
+#Header set X-Content-Type-Options: "nosniff"
+
+#
+# Setting this header will prevent other sites from embedding pages from this
+# site as frames. This defends against clickjacking attacks.
+# Requires mod_headers to be enabled.
+#
+#Header set X-Frame-Options: "sameorigin"
+
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/conf-default/docker/apache2/conf-enabled/serve-cgi-bin.conf
+++ b/conf-default/docker/apache2/conf-enabled/serve-cgi-bin.conf
@@ -1,0 +1,20 @@
+<IfModule mod_alias.c>
+	<IfModule mod_cgi.c>
+		Define ENABLE_USR_LIB_CGI_BIN
+	</IfModule>
+
+	<IfModule mod_cgid.c>
+		Define ENABLE_USR_LIB_CGI_BIN
+	</IfModule>
+
+	<IfDefine ENABLE_USR_LIB_CGI_BIN>
+		ScriptAlias /cgi-bin/ /usr/lib/cgi-bin/
+		<Directory "/usr/lib/cgi-bin">
+			AllowOverride None
+			Options +ExecCGI -MultiViews +SymLinksIfOwnerMatch
+			Require all granted
+		</Directory>
+	</IfDefine>
+</IfModule>
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/conf-default/docker/apache2/sites-enabled/000-default.conf
+++ b/conf-default/docker/apache2/sites-enabled/000-default.conf
@@ -1,0 +1,32 @@
+<VirtualHost *:80>
+        define APACHE_LOG_DIR /usr/local/apache2/logs
+	# The ServerName directive sets the request scheme, hostname and port that
+	# the server uses to identify itself. This is used when creating
+	# redirection URLs. In the context of virtual hosts, the ServerName
+	# specifies what hostname must appear in the request's Host: header to
+	# match this virtual host. For the default virtual host (this file) this
+	# value is not decisive as it is used as a last resort host regardless.
+	# However, you must set it for any further virtual host explicitly.
+	#ServerName www.example.com
+
+	ServerAdmin webmaster@localhost
+	DocumentRoot /usr/local/apache2/htdocs
+
+	# Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
+	# error, crit, alert, emerg.
+	# It is also possible to configure the loglevel for particular
+	# modules, e.g.
+	#LogLevel info ssl:warn
+
+	ErrorLog /usr/local/apache2/logs/error.log
+	CustomLog /usr/local/apache2/logs/access.log combined
+
+	# For most configuration files from conf-available/, which are
+	# enabled or disabled at a global level, it is possible to
+	# include a line for only one particular virtual host. For example the
+	# following line enables the CGI configuration for this host only
+	# after it has been globally disabled with "a2disconf".
+	#Include conf-available/serve-cgi-bin.conf
+</VirtualHost>
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/conf-default/docker/apache2/sites-enabled/nmis.conf
+++ b/conf-default/docker/apache2/sites-enabled/nmis.conf
@@ -1,0 +1,32 @@
+# Apache 2.4 configuration snippet for NMIS
+
+# this should either be made part of your preferred VirtualHost,
+# or saved in /etc/apache2/sites-enabled as <somefile>.conf
+
+# Further documentation about Apache: http://httpd.apache.org/docs/2.4/
+
+# Aliases for static files:
+Alias /nmis9 "/usr/local/nmis9/htdocs"
+# but make the landing page the main dashboard
+RedirectMatch permanent "^/nmis9/$" "/cgi-nmis9/nmiscgi.pl"
+
+<Directory "/usr/local/nmis9/htdocs">
+  Options FollowSymLinks MultiViews
+	AllowOverride None
+  Require all granted
+</Directory>
+
+Alias /menu9/ "/usr/local/nmis9/menu/"
+<Directory "/usr/local/nmis9/menu">
+  Options FollowSymLinks MultiViews
+  AllowOverride None
+  Require all granted
+</Directory>
+
+# Alias and Activation for the CGI scripts
+ScriptAlias /cgi-nmis9/ "/usr/local/nmis9/cgi-bin/"
+<Directory "/usr/local/nmis9/cgi-bin">
+  Options +ExecCGI
+  Require all granted
+</Directory>
+

--- a/conf-default/docker/apache2/sites-enabled/nmisux.conf
+++ b/conf-default/docker/apache2/sites-enabled/nmisux.conf
@@ -1,0 +1,15 @@
+<VirtualHost *:80>
+    ServerName localhost
+
+    ProxyRequests Off
+    ProxyPreserveHost On
+
+    ProxyPass / http://nmis:8080
+    ProxyPassReverse / http://nmis:8080
+
+    ProxyPass /omk http://nmis:8042/omk
+    ProxyPass /en/omk http://nmis:8042/en/omk
+    ProxyPassReverse / http://nmis:8042/en/omk
+
+    ErrorDocument 503 '<html><head><meta http-equiv="refresh" content="60"></head><body><h1>Temporary Service Interruption</h1>The requested OMK page should be back shortly.</body></html>'
+</VirtualHost>

--- a/conf-default/docker/httpd.conf
+++ b/conf-default/docker/httpd.conf
@@ -1,0 +1,636 @@
+#
+# This is the main Apache HTTP server configuration file.  It contains the
+# configuration directives that give the server its instructions.
+# See <URL:http://httpd.apache.org/docs/2.4/> for detailed information.
+# In particular, see 
+# <URL:http://httpd.apache.org/docs/2.4/mod/directives.html>
+# for a discussion of each configuration directive.
+#
+# Do NOT simply read the instructions in here without understanding
+# what they do.  They're here only as hints or reminders.  If you are unsure
+# consult the online docs. You have been warned.  
+#
+# Configuration and logfile names: If the filenames you specify for many
+# of the server's control files begin with "/" (or "drive:/" for Win32), the
+# server will use that explicit path.  If the filenames do *not* begin
+# with "/", the value of ServerRoot is prepended -- so "logs/access_log"
+# with ServerRoot set to "/usr/local/apache2" will be interpreted by the
+# server as "/usr/local/apache2/logs/access_log", whereas "/logs/access_log" 
+# will be interpreted as '/logs/access_log'.
+
+#
+# ServerRoot: The top of the directory tree under which the server's
+# configuration, error, and log files are kept.
+#
+# Do not add a slash at the end of the directory path.  If you point
+# ServerRoot at a non-local disk, be sure to specify a local disk on the
+# Mutex directive, if file-based mutexes are used.  If you wish to share the
+# same ServerRoot for multiple httpd daemons, you will need to change at
+# least PidFile.
+#
+ServerRoot "/usr/local/apache2"
+
+#
+# Mutex: Allows you to set the mutex mechanism and mutex file directory
+# for individual mutexes, or change the global defaults
+#
+# Uncomment and change the directory if mutexes are file-based and the default
+# mutex file directory is not on a local disk or is not appropriate for some
+# other reason.
+#
+# Mutex default:logs
+
+#
+# Listen: Allows you to bind Apache to specific IP addresses and/or
+# ports, instead of the default. See also the <VirtualHost>
+# directive.
+#
+# Change this to Listen on specific IP addresses as shown below to 
+# prevent Apache from glomming onto all bound IP addresses.
+#
+#Listen 12.34.56.78:80
+Listen 80
+
+#
+# Dynamic Shared Object (DSO) Support
+#
+# To be able to use the functionality of a module which was built as a DSO you
+# have to place corresponding `LoadModule' lines at this location so the
+# directives contained in it are actually available _before_ they are used.
+# Statically compiled modules (those listed by `httpd -l') do not need
+# to be loaded here.
+#
+# Example:
+# LoadModule foo_module modules/mod_foo.so
+#
+LoadModule mpm_event_module modules/mod_mpm_event.so
+#LoadModule mpm_prefork_module modules/mod_mpm_prefork.so
+#LoadModule mpm_worker_module modules/mod_mpm_worker.so
+LoadModule authn_file_module modules/mod_authn_file.so
+#LoadModule authn_dbm_module modules/mod_authn_dbm.so
+#LoadModule authn_anon_module modules/mod_authn_anon.so
+#LoadModule authn_dbd_module modules/mod_authn_dbd.so
+#LoadModule authn_socache_module modules/mod_authn_socache.so
+LoadModule authn_core_module modules/mod_authn_core.so
+LoadModule authz_host_module modules/mod_authz_host.so
+LoadModule authz_groupfile_module modules/mod_authz_groupfile.so
+LoadModule authz_user_module modules/mod_authz_user.so
+#LoadModule authz_dbm_module modules/mod_authz_dbm.so
+#LoadModule authz_owner_module modules/mod_authz_owner.so
+#LoadModule authz_dbd_module modules/mod_authz_dbd.so
+LoadModule authz_core_module modules/mod_authz_core.so
+#LoadModule authnz_ldap_module modules/mod_authnz_ldap.so
+#LoadModule authnz_fcgi_module modules/mod_authnz_fcgi.so
+LoadModule access_compat_module modules/mod_access_compat.so
+LoadModule auth_basic_module modules/mod_auth_basic.so
+#LoadModule auth_form_module modules/mod_auth_form.so
+#LoadModule auth_digest_module modules/mod_auth_digest.so
+#LoadModule allowmethods_module modules/mod_allowmethods.so
+#LoadModule isapi_module modules/mod_isapi.so
+#LoadModule file_cache_module modules/mod_file_cache.so
+#LoadModule cache_module modules/mod_cache.so
+#LoadModule cache_disk_module modules/mod_cache_disk.so
+#LoadModule cache_socache_module modules/mod_cache_socache.so
+#LoadModule socache_shmcb_module modules/mod_socache_shmcb.so
+#LoadModule socache_dbm_module modules/mod_socache_dbm.so
+#LoadModule socache_memcache_module modules/mod_socache_memcache.so
+#LoadModule socache_redis_module modules/mod_socache_redis.so
+#LoadModule watchdog_module modules/mod_watchdog.so
+#LoadModule macro_module modules/mod_macro.so
+#LoadModule dbd_module modules/mod_dbd.so
+#LoadModule bucketeer_module modules/mod_bucketeer.so
+#LoadModule dumpio_module modules/mod_dumpio.so
+#LoadModule echo_module modules/mod_echo.so
+#LoadModule example_hooks_module modules/mod_example_hooks.so
+#LoadModule case_filter_module modules/mod_case_filter.so
+#LoadModule case_filter_in_module modules/mod_case_filter_in.so
+#LoadModule example_ipc_module modules/mod_example_ipc.so
+#LoadModule buffer_module modules/mod_buffer.so
+#LoadModule data_module modules/mod_data.so
+#LoadModule ratelimit_module modules/mod_ratelimit.so
+LoadModule reqtimeout_module modules/mod_reqtimeout.so
+#LoadModule ext_filter_module modules/mod_ext_filter.so
+#LoadModule request_module modules/mod_request.so
+#LoadModule include_module modules/mod_include.so
+LoadModule filter_module modules/mod_filter.so
+#LoadModule reflector_module modules/mod_reflector.so
+#LoadModule substitute_module modules/mod_substitute.so
+#LoadModule sed_module modules/mod_sed.so
+#LoadModule charset_lite_module modules/mod_charset_lite.so
+#LoadModule deflate_module modules/mod_deflate.so
+#LoadModule xml2enc_module modules/mod_xml2enc.so
+#LoadModule proxy_html_module modules/mod_proxy_html.so
+#LoadModule brotli_module modules/mod_brotli.so
+LoadModule mime_module modules/mod_mime.so
+#LoadModule ldap_module modules/mod_ldap.so
+LoadModule log_config_module modules/mod_log_config.so
+#LoadModule log_debug_module modules/mod_log_debug.so
+#LoadModule log_forensic_module modules/mod_log_forensic.so
+#LoadModule logio_module modules/mod_logio.so
+#LoadModule lua_module modules/mod_lua.so
+LoadModule env_module modules/mod_env.so
+#LoadModule mime_magic_module modules/mod_mime_magic.so
+#LoadModule cern_meta_module modules/mod_cern_meta.so
+#LoadModule expires_module modules/mod_expires.so
+LoadModule headers_module modules/mod_headers.so
+#LoadModule ident_module modules/mod_ident.so
+#LoadModule usertrack_module modules/mod_usertrack.so
+#LoadModule unique_id_module modules/mod_unique_id.so
+LoadModule setenvif_module modules/mod_setenvif.so
+LoadModule version_module modules/mod_version.so
+#LoadModule remoteip_module modules/mod_remoteip.so
+LoadModule proxy_module modules/mod_proxy.so
+#LoadModule proxy_connect_module modules/mod_proxy_connect.so
+#LoadModule proxy_ftp_module modules/mod_proxy_ftp.so
+LoadModule proxy_http_module modules/mod_proxy_http.so
+#LoadModule proxy_fcgi_module modules/mod_proxy_fcgi.so
+#LoadModule proxy_scgi_module modules/mod_proxy_scgi.so
+#LoadModule proxy_uwsgi_module modules/mod_proxy_uwsgi.so
+#LoadModule proxy_fdpass_module modules/mod_proxy_fdpass.so
+#LoadModule proxy_wstunnel_module modules/mod_proxy_wstunnel.so
+#LoadModule proxy_ajp_module modules/mod_proxy_ajp.so
+#LoadModule proxy_balancer_module modules/mod_proxy_balancer.so
+#LoadModule proxy_express_module modules/mod_proxy_express.so
+#LoadModule proxy_hcheck_module modules/mod_proxy_hcheck.so
+#LoadModule session_module modules/mod_session.so
+#LoadModule session_cookie_module modules/mod_session_cookie.so
+#LoadModule session_crypto_module modules/mod_session_crypto.so
+#LoadModule session_dbd_module modules/mod_session_dbd.so
+#LoadModule slotmem_shm_module modules/mod_slotmem_shm.so
+#LoadModule slotmem_plain_module modules/mod_slotmem_plain.so
+#LoadModule ssl_module modules/mod_ssl.so
+#LoadModule optional_hook_export_module modules/mod_optional_hook_export.so
+#LoadModule optional_hook_import_module modules/mod_optional_hook_import.so
+#LoadModule optional_fn_import_module modules/mod_optional_fn_import.so
+#LoadModule optional_fn_export_module modules/mod_optional_fn_export.so
+#LoadModule dialup_module modules/mod_dialup.so
+#LoadModule http2_module modules/mod_http2.so
+#LoadModule proxy_http2_module modules/mod_proxy_http2.so
+#LoadModule md_module modules/mod_md.so
+#LoadModule lbmethod_byrequests_module modules/mod_lbmethod_byrequests.so
+#LoadModule lbmethod_bytraffic_module modules/mod_lbmethod_bytraffic.so
+#LoadModule lbmethod_bybusyness_module modules/mod_lbmethod_bybusyness.so
+#LoadModule lbmethod_heartbeat_module modules/mod_lbmethod_heartbeat.so
+LoadModule unixd_module modules/mod_unixd.so
+#LoadModule heartbeat_module modules/mod_heartbeat.so
+#LoadModule heartmonitor_module modules/mod_heartmonitor.so
+#LoadModule dav_module modules/mod_dav.so
+LoadModule status_module modules/mod_status.so
+LoadModule autoindex_module modules/mod_autoindex.so
+#LoadModule asis_module modules/mod_asis.so
+#LoadModule info_module modules/mod_info.so
+#LoadModule suexec_module modules/mod_suexec.so
+<IfModule !mpm_prefork_module>
+        #LoadModule cgid_module modules/mod_cgid.so
+</IfModule>
+<IfModule mpm_prefork_module>
+        #LoadModule cgi_module modules/mod_cgi.so
+</IfModule>
+#LoadModule dav_fs_module modules/mod_dav_fs.so
+#LoadModule dav_lock_module modules/mod_dav_lock.so
+#LoadModule vhost_alias_module modules/mod_vhost_alias.so
+#LoadModule negotiation_module modules/mod_negotiation.so
+LoadModule dir_module modules/mod_dir.so
+#LoadModule imagemap_module modules/mod_imagemap.so
+#LoadModule actions_module modules/mod_actions.so
+#LoadModule speling_module modules/mod_speling.so
+#LoadModule userdir_module modules/mod_userdir.so
+LoadModule alias_module modules/mod_alias.so
+#LoadModule rewrite_module modules/mod_rewrite.so
+
+<IfModule unixd_module>
+#
+# If you wish httpd to run as a different user or group, you must run
+# httpd as root initially and it will switch.  
+#
+# User/Group: The name (or #number) of the user/group to run httpd as.
+# It is usually good practice to create a dedicated user and group for
+# running httpd, as with most system services.
+#
+User www-data
+Group www-data
+
+</IfModule>
+
+# 'Main' server configuration
+#
+# The directives in this section set up the values used by the 'main'
+# server, which responds to any requests that aren't handled by a
+# <VirtualHost> definition.  These values also provide defaults for
+# any <VirtualHost> containers you may define later in the file.
+#
+# All of these directives may appear inside <VirtualHost> containers,
+# in which case these default settings will be overridden for the
+# virtual host being defined.
+#
+
+#
+# ServerAdmin: Your address, where problems with the server should be
+# e-mailed.  This address appears on some server-generated pages, such
+# as error documents.  e.g. admin@your-domain.com
+#
+#ServerAdmin you@example.com
+
+#
+# ServerName gives the name and port that the server uses to identify itself.
+# This can often be determined automatically, but we recommend you specify
+# it explicitly to prevent problems during startup.
+#
+# If your host doesn't have a registered DNS name, enter its IP address here.
+#
+ServerName localhost:80
+
+#
+# Deny access to the entirety of your server's filesystem. You must
+# explicitly permit access to web content directories in other 
+# <Directory> blocks below.
+#
+<Directory />
+    AllowOverride none
+    Require all denied
+</Directory>
+
+#
+# Note that from this point forward you must specifically allow
+# particular features to be enabled - so if something's not working as
+# you might expect, make sure that you have specifically enabled it
+# below.
+#
+
+#
+# DocumentRoot: The directory out of which you will serve your
+# documents. By default, all requests are taken from this directory, but
+# symbolic links and aliases may be used to point to other locations.
+#
+DocumentRoot "/usr/local/apache2/htdocs"
+<Directory "/usr/local/apache2/htdocs">
+    #
+    # Possible values for the Options directive are "None", "All",
+    # or any combination of:
+    #   Indexes Includes FollowSymLinks SymLinksifOwnerMatch ExecCGI MultiViews
+    #
+    # Note that "MultiViews" must be named *explicitly* --- "Options All"
+    # doesn't give it to you.
+    #
+    # The Options directive is both complicated and important.  Please see
+    # http://httpd.apache.org/docs/2.4/mod/core.html#options
+    # for more information.
+    #
+    Options Indexes FollowSymLinks
+
+    #
+    # AllowOverride controls what directives may be placed in .htaccess files.
+    # It can be "All", "None", or any combination of the keywords:
+    #   AllowOverride FileInfo AuthConfig Limit
+    #
+    AllowOverride None
+
+    #
+    # Controls who can get stuff from this server.
+    #
+    Require all granted
+</Directory>
+
+#
+# DirectoryIndex: sets the file that Apache will serve if a directory
+# is requested.
+#
+<IfModule dir_module>
+    DirectoryIndex index.html
+</IfModule>
+
+#
+# The following lines prevent .htaccess and .htpasswd files from being 
+# viewed by Web clients. 
+#
+<Files ".ht*">
+    Require all denied
+</Files>
+
+#
+# ErrorLog: The location of the error log file.
+# If you do not specify an ErrorLog directive within a <VirtualHost>
+# container, error messages relating to that virtual host will be
+# logged here.  If you *do* define an error logfile for a <VirtualHost>
+# container, that host's errors will be logged there and not here.
+#
+ErrorLog /proc/self/fd/2
+
+#
+# LogLevel: Control the number of messages logged to the error_log.
+# Possible values include: debug, info, notice, warn, error, crit,
+# alert, emerg.
+#
+LogLevel warn
+
+<IfModule log_config_module>
+    #
+    # The following directives define some format nicknames for use with
+    # a CustomLog directive (see below).
+    #
+    LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+    LogFormat "%h %l %u %t \"%r\" %>s %b" common
+
+    <IfModule logio_module>
+      # You need to enable mod_logio.c to use %I and %O
+      LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" %I %O" combinedio
+    </IfModule>
+
+    #
+    # The location and format of the access logfile (Common Logfile Format).
+    # If you do not define any access logfiles within a <VirtualHost>
+    # container, they will be logged here.  Contrariwise, if you *do*
+    # define per-<VirtualHost> access logfiles, transactions will be
+    # logged therein and *not* in this file.
+    #
+    CustomLog /proc/self/fd/1 common
+
+    #
+    # If you prefer a logfile with access, agent, and referer information
+    # (Combined Logfile Format) you can use the following directive.
+    #
+    #CustomLog "logs/access_log" combined
+</IfModule>
+
+<IfModule alias_module>
+    #
+    # Redirect: Allows you to tell clients about documents that used to 
+    # exist in your server's namespace, but do not anymore. The client 
+    # will make a new request for the document at its new location.
+    # Example:
+    # Redirect permanent /foo http://www.example.com/bar
+
+    #
+    # Alias: Maps web paths into filesystem paths and is used to
+    # access content that does not live under the DocumentRoot.
+    # Example:
+    # Alias /webpath /full/filesystem/path
+    #
+    # If you include a trailing / on /webpath then the server will
+    # require it to be present in the URL.  You will also likely
+    # need to provide a <Directory> section to allow access to
+    # the filesystem path.
+
+    #
+    # ScriptAlias: This controls which directories contain server scripts. 
+    # ScriptAliases are essentially the same as Aliases, except that
+    # documents in the target directory are treated as applications and
+    # run by the server when requested rather than as documents sent to the
+    # client.  The same rules about trailing "/" apply to ScriptAlias
+    # directives as to Alias.
+    #
+    ScriptAlias /cgi-bin/ "/usr/local/apache2/cgi-bin/"
+
+</IfModule>
+
+<IfModule cgid_module>
+    #
+    # ScriptSock: On threaded servers, designate the path to the UNIX
+    # socket used to communicate with the CGI daemon of mod_cgid.
+    #
+    #Scriptsock cgisock
+</IfModule>
+
+#
+# "/usr/local/apache2/cgi-bin" should be changed to whatever your ScriptAliased
+# CGI directory exists, if you have that configured.
+#
+<Directory "/usr/local/apache2/cgi-bin">
+    AllowOverride None
+    Options None
+    Require all granted
+</Directory>
+
+<IfModule headers_module>
+    #
+    # Avoid passing HTTP_PROXY environment to CGI's on this or any proxied
+    # backend servers which have lingering "httpoxy" defects.
+    # 'Proxy' request header is undefined by the IETF, not listed by IANA
+    #
+    RequestHeader unset Proxy early
+</IfModule>
+
+<IfModule mime_module>
+    #
+    # TypesConfig points to the file containing the list of mappings from
+    # filename extension to MIME-type.
+    #
+    TypesConfig conf/mime.types
+
+    #
+    # AddType allows you to add to or override the MIME configuration
+    # file specified in TypesConfig for specific file types.
+    #
+    #AddType application/x-gzip .tgz
+    #
+    # AddEncoding allows you to have certain browsers uncompress
+    # information on the fly. Note: Not all browsers support this.
+    #
+    #AddEncoding x-compress .Z
+    #AddEncoding x-gzip .gz .tgz
+    #
+    # If the AddEncoding directives above are commented-out, then you
+    # probably should define those extensions to indicate media types:
+    #
+    AddType application/x-compress .Z
+    AddType application/x-gzip .gz .tgz
+
+    #
+    # AddHandler allows you to map certain file extensions to "handlers":
+    # actions unrelated to filetype. These can be either built into the server
+    # or added with the Action directive (see below)
+    #
+    # To use CGI scripts outside of ScriptAliased directories:
+    # (You will also need to add "ExecCGI" to the "Options" directive.)
+    #
+    #AddHandler cgi-script .cgi
+
+    # For type maps (negotiated resources):
+    #AddHandler type-map var
+
+    #
+    # Filters allow you to process content before it is sent to the client.
+    #
+    # To parse .shtml files for server-side includes (SSI):
+    # (You will also need to add "Includes" to the "Options" directive.)
+    #
+    #AddType text/html .shtml
+    #AddOutputFilter INCLUDES .shtml
+</IfModule>
+
+#
+# The mod_mime_magic module allows the server to use various hints from the
+# contents of the file itself to determine its type.  The MIMEMagicFile
+# directive tells the module where the hint definitions are located.
+#
+#MIMEMagicFile conf/magic
+
+#
+# Customizable error responses come in three flavors:
+# 1) plain text 2) local redirects 3) external redirects
+#
+# Some examples:
+#ErrorDocument 500 "The server made a boo boo."
+#ErrorDocument 404 /missing.html
+#ErrorDocument 404 "/cgi-bin/missing_handler.pl"
+#ErrorDocument 402 http://www.example.com/subscription_info.html
+#
+
+#
+# MaxRanges: Maximum number of Ranges in a request before
+# returning the entire resource, or one of the special
+# values 'default', 'none' or 'unlimited'.
+# Default setting is to accept 200 Ranges.
+#MaxRanges unlimited
+
+#
+# EnableMMAP and EnableSendfile: On systems that support it, 
+# memory-mapping or the sendfile syscall may be used to deliver
+# files.  This usually improves server performance, but must
+# be turned off when serving from networked-mounted 
+# filesystems or if support for these functions is otherwise
+# broken on your system.
+# Defaults: EnableMMAP On, EnableSendfile Off
+#
+#EnableMMAP off
+#EnableSendfile on
+
+# Supplemental configuration
+#
+# The configuration files in the conf/extra/ directory can be 
+# included to add extra features or to modify the default configuration of 
+# the server, or you may simply copy their contents here and change as 
+# necessary.
+
+# Server-pool management (MPM specific)
+#Include conf/extra/httpd-mpm.conf
+
+# Multi-language error messages
+#Include conf/extra/httpd-multilang-errordoc.conf
+
+# Fancy directory listings
+#Include conf/extra/httpd-autoindex.conf
+
+# Language settings
+#Include conf/extra/httpd-languages.conf
+
+# User home directories
+#Include conf/extra/httpd-userdir.conf
+
+# Real-time info on requests and configuration
+#Include conf/extra/httpd-info.conf
+
+# Virtual hosts
+#Include conf/extra/httpd-vhosts.conf
+
+# Local access to the Apache HTTP Server Manual
+#Include conf/extra/httpd-manual.conf
+
+# Distributed authoring and versioning (WebDAV)
+#Include conf/extra/httpd-dav.conf
+
+# Various default settings
+#Include conf/extra/httpd-default.conf
+
+# Configure mod_proxy_html to understand HTML4/XHTML1
+<IfModule proxy_html_module>
+Include conf/extra/proxy-html.conf
+</IfModule>
+
+# Secure (SSL/TLS) connections
+#Include conf/extra/httpd-ssl.conf
+#
+# Note: The following must must be present to support
+#       starting without SSL on platforms with no /dev/random equivalent
+#       but a statically compiled-in mod_ssl.
+#
+<IfModule ssl_module>
+SSLRandomSeed startup builtin
+SSLRandomSeed connect builtin
+</IfModule>
+
+<VirtualHost *:80>
+   <IfModule mod_proxy.c>
+   ProxyRequests off
+   
+   <IfModule mod_headers.c>
+   # if you are using the Opmantek applications behind an ssl-terminating apache vhost,
+   # then you should adjust the vhost configuration to add this header but with 
+   # protocol "https". 
+   # The Opmantek applications are location- and protocol-independent in almost all cases.
+   RequestHeader set X-Forwarded-Proto "http"
+   </IfModule>
+  
+   <Location "/cgi-nmis9/nmiscgi.pl">
+       ProxyPass http://nmis:8080/cgi-nmis9/nmiscgi.pl retry=5
+       ProxyPassReverse http://nmis:8080/cgi-nmis9/nmiscgi.pl
+                   ErrorDocument 503 '<html><head><meta http-equiv="refresh" content="60"></head><body><h1>Temporary Service Interruption</h1>The requested NMIS page should be back soon. This page will automatically reload in 60 seconds.</body></html>'
+   </Location>
+   
+   # the first location directive only covers /omk and /omk/something,
+   
+   <Location "/omk">
+       ProxyPass http://nmis:8042/omk retry=5
+       ProxyPassReverse http://nmis:8042/omk
+                   ErrorDocument 503 '<html><head><meta http-equiv="refresh" content="60"></head><body><h1>Temporary Service Interruption</h1>The requested OMK page should be back soon. This page will automatically reload in 60 seconds.</body></html>'
+   </Location>
+   
+   # the first location directive only covers /omk and /omk/something,
+   # not /omk.json
+   <Location "/omk.json">
+       ProxyPass http://nmis:8042/omk.json retry=5
+       ProxyPassReverse http://nmis:8042/omk.json
+   </Location>
+   
+   
+   <Location "/es">
+       ProxyPass http://nmis:8042/es retry=5
+       ProxyPassReverse http://nmis:8042/es
+                   ErrorDocument 503 '<html><head><meta http-equiv="refresh" content="60"></head><body><h1>Temporary Service Interruption</h1>The requested OMK page should be back soon. This page will automatically reload in 60 seconds.</body></html>'
+   </Location>
+   
+   <Location "/en">
+       ProxyPass http://nmis:8042/en retry=5
+       ProxyPassReverse http://nmis:8042/en
+                   ErrorDocument 503 '<html><head><meta http-equiv="refresh" content="60"></head><body><h1>Temporary Service Interruption</h1>The requested OMK page should be back soon. This page will automatically reload in 60 seconds.</body></html>'
+   </Location>
+   
+   <Location "/pt">
+       ProxyPass http://nmis:8042/pt retry=5
+       ProxyPassReverse http://nmis:8042/pt
+                   ErrorDocument 503 '<html><head><meta http-equiv="refresh" content="60"></head><body><h1>Temporary Service Interruption</h1>The requested OMK page should be back soon. This page will automatically reload in 60 seconds.</body></html>'
+   </Location>
+   
+   </IfModule>
+   
+   Alias /javascript /usr/share/javascript/
+   
+   <Directory "/usr/share/javascript/">
+           Options FollowSymLinks MultiViews
+   </Directory>
+   
+   <IfModule mod_alias.c>
+           <IfModule mod_cgi.c>
+                   Define ENABLE_USR_LIB_CGI_BIN
+           </IfModule>
+   
+           <IfModule mod_cgid.c>
+                   Define ENABLE_USR_LIB_CGI_BIN
+           </IfModule>
+   
+           <IfDefine ENABLE_USR_LIB_CGI_BIN>
+                   ScriptAlias /cgi-bin/ /usr/lib/cgi-bin/
+                   <Directory "/usr/lib/cgi-bin">
+                           AllowOverride None
+                           Options +ExecCGI -MultiViews +SymLinksIfOwnerMatch
+                           Require all granted
+                   </Directory>
+           </IfDefine>
+   </IfModule>
+
+#Include conf/envvars
+</VirtualHost>
+
+
+IncludeOptional conf/conf-enabled/*.conf
+IncludeOptional conf/sites-enabled/*.conf


### PR DESCRIPTION
Add apache httpd service to handle redirects between the NMIS and OMK applications.

The Apache official image uses `/usr/local/apache2/` as it's Apache directory and is laid out differently to Debian Apache. I have hard-coded that path in configs, but we can add it as a variable by using define `define APACHE_LOG_DIRECTORY /usr/local/apache2/logs` and call it like ${APACHE_LOG_DIRECTORY} if there is value in that. 

I have removed the envvars configuration shell script that we use in Debian Apache, because I don't see much point in configuration when this container should work out of the box.

We need to review the paths and configurations themselves but they are meant to be default configurations.

I have added:
* Hard coded Apache directory path `/usr/local/apache2/`
* Add include in httpd.conf to apply configurations from conf-enabled and sites-enabled directories
* Added httpd service to compose.yaml