### PR TITLE
OMK-12085 Change base image to debian:11 and fix nmis user permissions

### DIFF
--- a/docker-dev/compose-dev.yaml
+++ b/docker-dev/compose-dev.yaml
@@ -31,6 +31,7 @@ services:
       NMIS_DB_PASSWORD: ${MONGODB_PASSWORD}
       NMIS_DB_SERVER: mongo
       NMIS_SERVER_NAME: ${NMIS_SERVER_NAME}
+      CONTAINER: 1
     depends_on:
       - mongo
     volumes:

--- a/docker-dev/dockerfile-dev
+++ b/docker-dev/dockerfile-dev
@@ -1,5 +1,5 @@
 # This dockerfile is to create NMIS from source images
-FROM perl:5.32.1-threaded-bullseye
+FROM debian:bullseye
 
 LABEL maintainer="James Greewnwood. <james.greenwood@firstwave.com>" 
 LABEL maintainer="Louis Tissington. <louis.tissington@firstwave.com>"
@@ -43,7 +43,9 @@ RUN apt-get update  > /dev/null && \
     snmptrapd \
     iputils-ping \
     dnsutils \
+    gcc \
     mtr \
+    make \
     traceroute \
     libnet-snmp-perl \
     libcrypt-passwdmd5-perl \
@@ -106,7 +108,7 @@ RUN apt-get update  > /dev/null && \
 WORKDIR /tmp
 
 # Essential cpanm perl modules
-RUN /usr/bin/cpanm --notest --no-interactive \
+RUN cpanm --notest --no-interactive \
     --local-lib=/usr/local/lib/site_perl \
     IO::Socket::IP \
     Socket \
@@ -127,8 +129,7 @@ RUN /usr/bin/cpanm --notest --no-interactive \
     Crypt::UnixCrypt \
     Authen::TacacsPlus \
     Authen::Simple::RADIUS \
-    SOAP::Lite \
-    Net::SFTP::Foreign
+    SOAP::Lite
 
 # Soft link because some tools look for /usr/bin/ip not /sbin/ip
 RUN ln -s /sbin/ip /usr/bin/ip
@@ -151,6 +152,10 @@ COPY ../conf-default/Users.nmis \
 
 RUN mv ${NMIS_HOME}/conf/Config.nmis.docker \
        ${NMIS_HOME}/conf/Config.nmis
+
+RUN chown -R ${NMIS_USER}:${NMIS_GROUP} ${NMIS_HOME}
+
+USER ${NMIS_USER}
 
 # NMIS Web 8080
 # MTA Port 25


### PR DESCRIPTION
* Image changes the base image to debian:bullseye (11). This addresses an issue with our software and the perl base image which by default, has two perl binaries installed and it's$PATH variable uses the non-system perl first. Debian 11 base image more closely resembles our VM environment.

* Change to the NMIS user before starting  entrypoint. Most tasks should be handled by the NMIS user.