### PR TITLE
Add mongodb specific function counters and timing to opstatus

### DIFF
--- a/bin/nmisd
+++ b/bin/nmisd
@@ -1506,6 +1506,7 @@ sub worker_loop
 																								worker_process => $$ },
 						);
 				$nmisng->log->error("Failed to save opstatus: $error") if ($error);
+				NMISNG::DB::reset_db_stats();
 			}
 
 			# we don't want to end up with stuck jobs if anything dies, so bsts
@@ -2225,6 +2226,7 @@ sub worker_loop
 																										node_name => \@node_names },
 								);
 						$nmisng->log->error("Failed to save opstatus: $error") if ($error);
+						NMISNG::DB::reset_db_stats();
 
 						my $S;
 						for my $plugin ($nmisng->plugins)
@@ -2330,7 +2332,8 @@ sub worker_loop
 																									output => $ourjob->{output}},
 							);
 					$nmisng->log->error("Failed to save opstatus: $error") if ($error);
-					# start capturing log output to save into opstatus, make sure object can do it 
+					NMISNG::DB::reset_db_stats();
+					# start capturing log output to save into opstatus, make sure object can do it
 					my $capture;
 					$capture = $nmisng->log->capture_and_log() if( $can_log_capture & $opstatus_save_logs );
 					$nmisng->log->info("Starting $methodname for node $nodeuuid (".$thenode->name.")");
@@ -2379,6 +2382,7 @@ sub worker_loop
 			{
 				# work is done, report result in opstatus
 				$state->{stats}->{time} = Time::HiRes::time - $state->{stats}->{time}; # time was start marker, want it to be delta
+				$state->{stats}->{mongodb_stats} = NMISNG::DB::get_db_stats();
 				my ($error, undef) = $nmisng->save_opstatus(id => $state->{statusid},
 																										activity => $state->{activity} // $ourjob->{type},
 																										type => "completed",

--- a/bin/nmisd
+++ b/bin/nmisd
@@ -1491,6 +1491,7 @@ sub worker_loop
 
 
 			my $state = { stats => { time => Time::HiRes::time }};		# for opstatus and exception handling
+			NMISNG::DB::reset_db_stats();
 			$0 = "nmisd." . $ourjob->{type}; # Change worker name
 			
 			# the simpler jobs don't have extra args that need to go into opstatus context
@@ -1506,7 +1507,6 @@ sub worker_loop
 																								worker_process => $$ },
 						);
 				$nmisng->log->error("Failed to save opstatus: $error") if ($error);
-				NMISNG::DB::reset_db_stats();
 			}
 
 			# we don't want to end up with stuck jobs if anything dies, so bsts
@@ -2226,7 +2226,6 @@ sub worker_loop
 																										node_name => \@node_names },
 								);
 						$nmisng->log->error("Failed to save opstatus: $error") if ($error);
-						NMISNG::DB::reset_db_stats();
 
 						my $S;
 						for my $plugin ($nmisng->plugins)
@@ -2332,7 +2331,6 @@ sub worker_loop
 																									output => $ourjob->{output}},
 							);
 					$nmisng->log->error("Failed to save opstatus: $error") if ($error);
-					NMISNG::DB::reset_db_stats();
 					# start capturing log output to save into opstatus, make sure object can do it
 					my $capture;
 					$capture = $nmisng->log->capture_and_log() if( $can_log_capture & $opstatus_save_logs );

--- a/lib/Guard.pm
+++ b/lib/Guard.pm
@@ -1,0 +1,41 @@
+#  Copyright (C) Opmantek Limited (www.opmantek.com)
+#  
+#  ALL CODE MODIFICATIONS MUST BE SENT TO CODE@OPMANTEK.COM
+#  
+#  This file is part of Network Management Information System (“NMIS”).
+#  
+#  NMIS is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  
+#  NMIS is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  
+#  You should have received a copy of the GNU General Public License
+#  along with NMIS (most likely in a file named LICENSE).  
+#  If not, see <http://www.gnu.org/licenses/>
+#  
+#  For further information on NMIS or for a license other than GPL please see
+#  www.opmantek.com or email contact@opmantek.com 
+#  
+#  User group details:
+#  http://support.opmantek.com/users/
+#  
+# *****************************************************************************
+
+# Generic guard class to run code when it goes out of scope.
+package Guard;
+use strict;
+use warnings;
+
+sub new {
+    my ($class, $code) = @_;
+    return bless { code => $code }, $class;
+}
+
+sub DESTROY { $_[0]->{code}->() }
+
+1;

--- a/lib/NMISNG/DB.pm
+++ b/lib/NMISNG/DB.pm
@@ -41,6 +41,7 @@ use Try::Tiny;
 use boolean;         # do NOT use -truth! deprecated, segfaults in perl 5.20 and impossible with 5.22+
 use MongoDB 1.2.3;	 # we require a reasonably new Mongodb driver
 use Safe::Isa;       # provides $_isa, recommended by MongoDB driver for error handling
+use Time::HiRes ();
 use Time::Moment;    # opCharts needs times (for TTL) and using this is much faster
 use Carp;
 use Mojo::Util;									# for monkey_patch and  b64_encode/decode
@@ -98,6 +99,7 @@ my $error_string;
 #   - list of ( array of records, count, error ), count is = 0 if not asked for
 sub aggregate
 {
+	my $_timer = _start_time_and_count('aggregate');
 	my (%arg)               = @_;
 	my $collection          = $arg{collection};
 	my $pre_count_pipeline  = $arg{pre_count_pipeline} // [];
@@ -202,6 +204,7 @@ sub aggregate
 # returns: hashref with success/error/count/ids
 sub batch_insert
 {
+	my $_timer = _start_time_and_count('batch_insert');
 	my %arg = @_;
 
 	my $collection = $arg{collection};
@@ -245,6 +248,7 @@ sub batch_insert
 # returns: the bulk op object
 sub begin_bulk
 {
+	my $_timer = _start_time_and_count('begin_bulk');
 	my (%arg) = @_;
 	my $collection = $arg{"collection"};
 	my $ordered = $arg{'ordered'} // 0;
@@ -261,6 +265,7 @@ sub begin_bulk
 # if verbose 1, hashref with keys success, error, count.
 sub count
 {
+	my $_timer = _start_time_and_count('count');
 	my %arg        = @_;
 	my $collection = $arg{collection};
 	my $query      = $arg{query};
@@ -295,6 +300,7 @@ sub count
 # returns: result record plus error, success fields
 sub coll_stats
 {
+	my $_timer = _start_time_and_count('coll_stats');
 	my %arg        = @_;
 	my $db         = $arg{db};
 	my $collection = $arg{collection};
@@ -431,6 +437,7 @@ sub constrain_record
 # returns: result hash (with success, error, notes, changed, size keys)
 sub create_capped_collection
 {
+	my $_timer = _start_time_and_count('create_capped_collection');
 	my (%arg) = @_;
 	my ( $conn, $db, $collection, $wantsize ) = @arg{"connection", "db", "collection", "size"};
 
@@ -654,6 +661,7 @@ sub create_capped_collection
 # returns undef if there's a fault, listref of values otherwise
 sub distinct
 {
+	my $_timer = _start_time_and_count('distinct');
 	my %arg = @_;
 	my ( $db, $collname, $key, $query ) = @arg{qw(db collection key query)};
 
@@ -687,6 +695,7 @@ sub distinct
 # returns object with success/error and some results
 sub end_bulk
 {
+	my $_timer = _start_time_and_count('end_bulk');
 	my (%arg)   = @_;
 	my $bulk    = $arg{"bulk"};
 	my $success = undef;
@@ -728,6 +737,7 @@ sub end_bulk
 # returns: undef or error message
 sub ensure_index
 {
+	my $_timer = _start_time_and_count('ensure_index');
 	my (%args) = @_;
 
 	my ( $db, $coll, $indexlist ) = @args{"db", "collection", "indices"};
@@ -840,6 +850,7 @@ sub ensure_index
 # sets the error_string if problems are encountered.
 sub find
 {
+	my $_timer = _start_time_and_count('find');
 	my %arg        = @_;
 	my $collection = $arg{collection};
 	my $query      = $arg{query};
@@ -904,6 +915,7 @@ sub find
 # returns: collection handle or undef on failure (consult getErrorString in that case)
 sub get_collection
 {
+	my $_timer = _start_time_and_count('get_collection');
 	my (%args) = @_;
 	my ( $db, $collname ) = @args{"db", "name"};
 
@@ -1289,6 +1301,7 @@ sub get_query_part
 # returns: hashref, { succes: bool, id: inserted_id, error: message if error }
 sub insert
 {
+	my $_timer = _start_time_and_count('insert');
 	my %arg        = @_;
 	my $collection = $arg{collection};
 	my $record     = $arg{record};
@@ -1380,6 +1393,7 @@ sub make_oid
 # returns: connection handle or undef, plus sets error_string
 sub reget_db_connection
 {
+	my $_timer = _start_time_and_count('reget_db_connection');
 	my %args      = @_;
 	my $maybelive = $args{connection};
 
@@ -1428,6 +1442,7 @@ sub reget_db_connection
 # from docs: safe If the update fails and safe is set, this function will croak. ( version < 1.0 )
 sub remove
 {
+	my $_timer = _start_time_and_count('remove');
 	my %arg        = @_;
 	my $collection = $arg{collection};
 	my $query      = $arg{query} // {};
@@ -1476,6 +1491,7 @@ sub remove
 # code clones from errmsg, err or error (in that order) - no guarantees with the old driver, may not be hash!
 sub run_command
 {
+	my $_timer = _start_time_and_count('run_command');
 	my (%args) = @_;
 	return {ok => 0, errmsg => "Insufficient arguments"} if ( !$args{db} or !$args{command} );
 	my $result;
@@ -1518,6 +1534,7 @@ sub run_command
 # args: safe, optional allows setting write concern, see http://search.cpan.org/~mongodb/MongoDB-v0.705.0.0/lib/MongoDB/MongoClient.pm#w
 sub update
 {
+	my $_timer = _start_time_and_count('update');
 	my %arg         = @_;
 	my $collection  = $arg{collection};
 	my $query       = $arg{query};
@@ -1582,6 +1599,38 @@ sub update
 		error           => $error,
 		error_type      => $error_type
 	};
+}
+
+# per-function call counters and cumulative time for db operation tracking
+my %_db_stats;
+our %_db_time;
+
+# resets all db operation counters and timers
+sub reset_db_stats { %_db_stats = (); %_db_time = (); }
+
+# returns counts and cumulative times for all tracked functions
+sub get_db_stats {
+	return {
+		counts => { %_db_stats },
+		times  => { %_db_time },
+	};
+}
+
+# increments the call counter and returns a guard object whose DESTROY
+# accumulates elapsed time into %_db_time when the calling scope exits
+sub _start_time_and_count {
+	my ($fname) = @_;
+	$_db_stats{$fname}++;
+	my $start = Time::HiRes::time();
+	return bless [$fname, $start], 'NMISNG::DB::_Timer';
+}
+
+{
+	package NMISNG::DB::_Timer;
+	sub DESTROY {
+		my $self = shift;
+		$NMISNG::DB::_db_time{$self->[0]} += Time::HiRes::time() - $self->[1];
+	}
 }
 
 1;

--- a/lib/NMISNG/DB.pm
+++ b/lib/NMISNG/DB.pm
@@ -48,6 +48,7 @@ use Mojo::Util;									# for monkey_patch and  b64_encode/decode
 
 use version 0.77;    # needed to check driver version
 
+use Guard;
 use NMISNG::Util;								# for getbool and numify
 
 # this is a little bit unfriendly, but required because mongo uses boolean::true or ::false,
@@ -1622,15 +1623,9 @@ sub _start_time_and_count {
 	my ($fname) = @_;
 	$_db_stats{$fname}++;
 	my $start = Time::HiRes::time();
-	return bless [$fname, $start], 'NMISNG::DB::_Timer';
-}
-
-{
-	package NMISNG::DB::_Timer;
-	sub DESTROY {
-		my $self = shift;
-		$NMISNG::DB::_db_time{$self->[0]} += Time::HiRes::time() - $self->[1];
-	}
+	return Guard->new(sub {
+		$NMISNG::DB::_db_time{$fname} += Time::HiRes::time() - $start;
+	});
 }
 
 1;

--- a/test/t_db_stats.pl
+++ b/test/t_db_stats.pl
@@ -1,0 +1,77 @@
+#!/usr/bin/perl
+#
+# Test for NMISNG::DB statistics tracking (counts and times)
+# Validates that _start_time_and_count increments counters and accumulates time,
+# and that reset_db_stats clears everything.
+#
+# Usage: perl test/t_db_stats.pl
+#
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+
+use Test::More;
+use Time::HiRes ();
+
+use NMISNG::DB;
+
+# --- Test 1: stats start empty after reset ---
+NMISNG::DB::reset_db_stats();
+my $stats = NMISNG::DB::get_db_stats();
+is_deeply($stats->{counts}, {}, "counts empty after reset");
+is_deeply($stats->{times}, {}, "times empty after reset");
+
+# --- Test 2: _start_time_and_count increments count and records time ---
+{
+	# simulate what a DB function does: call _start_time_and_count,
+	# do some work, then let the guard go out of scope
+	my $_timer = NMISNG::DB::_start_time_and_count('test_func');
+	Time::HiRes::usleep(50_000);  # sleep 50ms
+}
+# guard is now destroyed, time should be recorded
+
+$stats = NMISNG::DB::get_db_stats();
+is($stats->{counts}->{test_func}, 1, "count is 1 after one call");
+ok(defined $stats->{times}->{test_func}, "time entry exists");
+ok($stats->{times}->{test_func} > 0, "time is greater than zero");
+ok($stats->{times}->{test_func} >= 0.04, "time is at least 40ms (slept 50ms)");
+
+# --- Test 3: multiple calls accumulate ---
+{
+	my $_timer = NMISNG::DB::_start_time_and_count('test_func');
+	Time::HiRes::usleep(20_000);  # sleep 20ms
+}
+$stats = NMISNG::DB::get_db_stats();
+is($stats->{counts}->{test_func}, 2, "count is 2 after two calls");
+ok($stats->{times}->{test_func} >= 0.06, "time accumulated across both calls");
+
+# --- Test 4: different function names are tracked independently ---
+{
+	my $_timer = NMISNG::DB::_start_time_and_count('other_func');
+	Time::HiRes::usleep(10_000);
+}
+$stats = NMISNG::DB::get_db_stats();
+is($stats->{counts}->{other_func}, 1, "other_func counted separately");
+ok($stats->{times}->{other_func} > 0, "other_func time tracked separately");
+is($stats->{counts}->{test_func}, 2, "test_func count unchanged");
+
+# --- Test 5: reset clears everything ---
+NMISNG::DB::reset_db_stats();
+$stats = NMISNG::DB::get_db_stats();
+is_deeply($stats->{counts}, {}, "counts empty after second reset");
+is_deeply($stats->{times}, {}, "times empty after second reset");
+
+# --- Test 6: early scope exit still records time ---
+{
+	my $_timer = NMISNG::DB::_start_time_and_count('early_exit');
+	Time::HiRes::usleep(10_000);
+	# simulate early return - guard destroyed here
+	goto AFTER_SCOPE if 1;
+}
+AFTER_SCOPE:
+$stats = NMISNG::DB::get_db_stats();
+is($stats->{counts}->{early_exit}, 1, "count recorded on early scope exit");
+ok($stats->{times}->{early_exit} > 0, "time recorded on early scope exit");
+
+done_testing();


### PR DESCRIPTION
Implemented only through nmisd jobs, a more generic way to do this would be nice, this should be fast and provide reasonable information.