### PR TITLE
Layered configuration system for loading and saving 

### DIFF
--- a/bin/nmis-cli
+++ b/bin/nmis-cli
@@ -1151,6 +1151,47 @@ elsif ($Q->{act} eq "groupsync")
 {
 	die "groupsync is no longer supported or necessary.\n";
 }
+elsif ($Q->{act} =~ /^strip[_-]config[_-]defaults$/)
+{
+	my ($stripped, $removals) = NMISNG::Util::stripDefaults();
+
+	if (!@$removals)
+	{
+		print "No default values found in site config — nothing to strip.\n" if (!$quiet);
+		exit 0;
+	}
+
+	if (!$quiet)
+	{
+		print "The following " . scalar(@$removals) . " properties match defaults and will be removed:\n\n";
+		my %by_section;
+		for my $r (@$removals) { push @{$by_section{$r->{section}}}, $r; }
+		for my $section (sort keys %by_section)
+		{
+			print "  [$section]\n";
+			for my $r (@{$by_section{$section}})
+			{
+				my $display = ref($r->{value})
+					? Data::Dumper->new([$r->{value}])->Terse(1)->Indent(0)->Dump
+					: $r->{value} // 'undef';
+				$display = substr($display, 0, 60) . '...' if length($display) > 60;
+				print "    $r->{key} = $display\n";
+			}
+		}
+		print "\n";
+
+		if (!NMISNG::Util::askYesNo("Save stripped config? (y/n)", "n"))
+		{
+			print "Aborted — no changes made.\n";
+			exit 0;
+		}
+	}
+
+	my $error = NMISNG::Util::writeConfData(data => $stripped);
+	die "Failed to write config: $error\n" if $error;
+	print "Saved. Removed " . scalar(@$removals) . " default properties from $C->{configfile}\n" if (!$quiet);
+	exit 0;
+}
 # do sanitary checking on inventory
 elsif ($Q->{act} =~ /^check[_-]inventory$/)
 {

--- a/bin/nmis-cli
+++ b/bin/nmis-cli
@@ -1157,7 +1157,7 @@ elsif ($Q->{act} =~ /^strip[_-]config[_-]defaults$/)
 
 	if (!@$removals)
 	{
-		print "No default values found in site config — nothing to strip.\n" if (!$quiet);
+		print "No default values found in local config — nothing to strip.\n" if (!$quiet);
 		exit 0;
 	}
 

--- a/bin/nmis-cli
+++ b/bin/nmis-cli
@@ -1192,6 +1192,86 @@ elsif ($Q->{act} =~ /^strip[_-]config[_-]defaults$/)
 	print "Saved. Removed " . scalar(@$removals) . " default properties from $C->{configfile}\n" if (!$quiet);
 	exit 0;
 }
+elsif ($Q->{act} =~ /^restore[_-]config$/)
+{
+	my $configfile = $C->{configfile};
+	my $bakfile = "$configfile.bak";
+
+	if (!-r $bakfile)
+	{
+		die "No backup found at $bakfile\n";
+	}
+
+	if (!$quiet)
+	{
+		print "Restoring $bakfile to $configfile\n";
+		if (!NMISNG::Util::askYesNo("Proceed? (y/n)", "n"))
+		{
+			print "Aborted — no changes made.\n";
+			exit 0;
+		}
+	}
+
+	File::Copy::move($bakfile, $configfile)
+		or die "Failed to restore $bakfile to $configfile: $!\n";
+	print "Restored config from $bakfile\n" if (!$quiet);
+	exit 0;
+}
+elsif ($Q->{act} =~ /^show[_-]config$/)
+{
+	my $sources = NMISNG::Util::getConfigSources();
+	my $filter_section = $Q->{section};
+	my $filter_key = $Q->{key};
+
+	# Single key lookup
+	if (defined $filter_key)
+	{
+		my $val = $C->{$filter_key};
+		my $src = $sources->{$filter_key};
+		if (!defined $val && !$src)
+		{
+			print STDERR "Key '$filter_key' not found in config.\n";
+			exit 1;
+		}
+		my $display = ref($val) ? Data::Dumper->new([$val])->Terse(1)->Indent(0)->Dump : $val // 'undef';
+		my $source_info = $src ? "$src->{source}, layer $src->{layer}" : "unknown";
+		print "$filter_key = $display  ($source_info)\n";
+		exit 0;
+	}
+
+	# Group keys by section from source tracking
+	my %by_section;
+	for my $k (keys %$C)
+	{
+		next if $k eq 'configfile'; # internal key
+		my $src = $sources->{$k};
+		my $section = $src->{section} // 'other';
+		next if (defined $filter_section && $section ne $filter_section);
+		push @{$by_section{$section}}, $k;
+	}
+
+	if (!keys %by_section)
+	{
+		print "No config keys found" . (defined $filter_section ? " for section '$filter_section'" : "") . ".\n";
+		exit 0;
+	}
+
+	for my $section (sort keys %by_section)
+	{
+		print "[$section]\n";
+		for my $k (sort @{$by_section{$section}})
+		{
+			my $val = $C->{$k};
+			my $src = $sources->{$k};
+			my $display = ref($val) ? Data::Dumper->new([$val])->Terse(1)->Indent(0)->Dump : $val // 'undef';
+			$display = substr($display, 0, 60) . '...' if length($display) > 60;
+			my $source_info = $src ? "$src->{source}, layer $src->{layer}" : "unknown";
+			printf "  %-40s = %-30s (%s)\n", $k, $display, $source_info;
+		}
+		print "\n";
+	}
+	exit 0;
+}
 # do sanitary checking on inventory
 elsif ($Q->{act} =~ /^check[_-]inventory$/)
 {

--- a/cgi-bin/config.pl
+++ b/cgi-bin/config.pl
@@ -203,7 +203,11 @@ sub typeSect {
 	my @items_cfg = sort keys %{$CC->{$section}};
 	for my $i (@items_cfg) { push @items_all,$i unless grep { $_ eq $i } @items; }
 
-	push @out,Tr(td({class=>"header"},$section),td({class=>'info Plain',colspan=>'3'},"&nbsp;"),td({class=>'info Plain'},
+	push @out,Tr(td({class=>"header"},$section),
+			td({class=>"header"},"Property"),
+			td({class=>"header"},"Value"),
+			td({class=>"header"},"Source"),
+			td({class=>'info Plain'},
 			eval {
 				if ($AU->CheckAccess("Table_Config_rw","check")) {
 					return a({ href=>"$ref?act=config_nmis_add&section=$section&widget=$widget"},'add&nbsp;');
@@ -245,7 +249,7 @@ sub typeSect {
 		} elsif ($src->{layer} == 1) {
 			$source_display = "default";
 		} elsif ($src->{layer} == 2) {
-			$source_display = "site config";
+			$source_display = "local";
 		} elsif ($src->{layer} == 3) {
 			$source_display = "conf.d";
 			$editable = 0;
@@ -256,8 +260,24 @@ sub typeSect {
 			$source_display = "system";
 		}
 
+		# Show default value in value column when property has been overridden
+		my $valueDisplay = escape($showOut);
+		if ($src && $src->{layer} != 1)
+		{
+			my $defaults = NMISNG::Util::getConfigDefaults();
+			if (ref($defaults->{$section}) eq 'HASH' && exists $defaults->{$section}{$k})
+			{
+				my $def_val = $defaults->{$section}{$k};
+				my $def_display = ref($def_val)
+					? Data::Dumper->new([$def_val])->Terse(1)->Indent(0)->Dump
+					: $def_val // 'undef';
+				$def_display = substr($def_display, 0, 40) . '...' if length($def_display) > 40;
+				$valueDisplay .= "<br><i>default: " . escape($def_display) . "</i>";
+			}
+		}
+
 		push @out,Tr(td({class=>"header"},"&nbsp;"),
-				td({class=>"header"},escape($k)),td({class=>'info Plain'}, escape($showOut)),
+				td({class=>"header"},escape($k)),td({class=>'info Plain'}, $valueDisplay),
 				td({class=>'info Plain'}, $source_display),
 				eval {
 					if ($editable && $AU->CheckAccess("Table_Config_rw","check")) {
@@ -292,7 +312,7 @@ sub editConfig {
 
 	my $CT = Compat::NMIS::loadCfgTable(); # load configuration of table
 
-	# Load defaults + site config so edit form shows current effective value
+	# Load defaults + local config so edit form shows current effective value
 	my ($CC, undef) = NMISNG::Util::getConfDeep();
 
 	my $ref;

--- a/cgi-bin/config.pl
+++ b/cgi-bin/config.pl
@@ -459,25 +459,20 @@ sub doEditConfig
 	my $value = $Q->{value};
 	my $confirm = $Q->{confirm};
 
-	# Full effective config for validation
-	my ($effective, undef) = NMISNG::Util::getConfDeep();
-	# Site-local config for writing
-	my ($CC, undef) = NMISNG::Util::getConfDeep(only_local => 1);
+	my ($CC, undef) = NMISNG::Util::getConfDeep();
 	# that's the set of display and validation rules
 	my $configrules = Compat::NMIS::loadCfgTable(table => "Config", user => $AU->{user});
 
-	# Validate section against full effective config
-	if (!$effective->{$section}) {
+	# Validate section
+	if (!$CC->{$section}) {
 		return validation_abort($section,
 								"non valid '$section'.")
 	}
-	# Validate item against full effective config
-	if (!exists $effective->{$section}->{$item}) {
+	# Validate item
+	if (!exists $CC->{$section}->{$item}) {
 		return validation_abort($item,
 								"non valid '$item' in '$section'.")
 	}
-	# Ensure the section/key exists in site config for writing
-	$CC->{$section}{$item} //= $effective->{$section}{$item};
 	
 	
 	# handle the roletype, nettype and nodetype lists and translate the separate values
@@ -746,7 +741,7 @@ sub doDeleteConfig {
 	my $section = $Q->{section};
 	my $item = decode_entities($Q->{item});
 
-	my ($CC, undef) = NMISNG::Util::getConfDeep(only_local => 1);
+	my ($CC, undef) = NMISNG::Util::getConfDeep();
 	# that's the set of display and validation rules
 	my $configrules = Compat::NMIS::loadCfgTable(table => "Config", user => $AU->{user});
 
@@ -820,18 +815,15 @@ sub doAddConfig {
 
 	$AU->CheckAccess("Table_Config_rw");
 
-	my ($effective, undef) = NMISNG::Util::getConfDeep();
-	my ($CC, undef) = NMISNG::Util::getConfDeep(only_local => 1);
+	my ($CC, undef) = NMISNG::Util::getConfDeep();
 
 	my $section = $Q->{section};
 
-	# Validate section against full effective config
-	if (!$effective->{$section}) {
+	# Validate section
+	if (!$CC->{$section}) {
 		return validation_abort($section,
 								"non valid '$section'.")
 	}
-	# Ensure section exists in site config for writing
-	$CC->{$section} //= {};
 	
 	if ($Q->{id} ne '') {
 		$CC->{$section}{decode_entities($Q->{id})} = decode_entities($Q->{value});

--- a/cgi-bin/config.pl
+++ b/cgi-bin/config.pl
@@ -133,7 +133,7 @@ sub displayConfig{
 
 	my $CT = Compat::NMIS::loadCfgTable(); # load configuration of table
 
-	my ($CC,undef) = NMISNG::Util::readConfData();
+	my ($CC, undef) = NMISNG::Util::getConfDeep();
 
 	# start of form
     # the get() code doesn't work without a query param, nor does it work with all params present
@@ -143,11 +143,6 @@ sub displayConfig{
 			. hidden(-override => 1, -name => "widget", -value => $widget);
 
 	print start_table({width=>"400px"}) ; # first table level
-
-	if ($C->{configpeerfiles})
-	{
-		print Tr(td({class=>'Warning',align=>'center'}, "There are files from the master overriding the configuration"));
-	}
 	
 	if (defined $Q->{error_message} && $Q->{error_message} ne "" )
 	{
@@ -200,6 +195,7 @@ sub typeSect {
 
 	my $CT = Compat::NMIS::loadCfgTable(); # load configuration of table
 	my $ref = url(-absolute=>1);
+	my $sources = NMISNG::Util::getConfigSources();
 
 	# create items list, contains of presets and adds
 	my @items = map { keys %{$_} } @{$CT->{$section}};
@@ -207,9 +203,9 @@ sub typeSect {
 	my @items_cfg = sort keys %{$CC->{$section}};
 	for my $i (@items_cfg) { push @items_all,$i unless grep { $_ eq $i } @items; }
 
-	push @out,Tr(td({class=>"header"},$section),td({class=>'info Plain',colspan=>'2'},"&nbsp;"),td({class=>'info Plain'},
+	push @out,Tr(td({class=>"header"},$section),td({class=>'info Plain',colspan=>'3'},"&nbsp;"),td({class=>'info Plain'},
 			eval {
-				if ($AU->CheckAccess("Table_Config_rw","check") and !$C->{configpeerfiles}) {
+				if ($AU->CheckAccess("Table_Config_rw","check")) {
 					return a({ href=>"$ref?act=config_nmis_add&section=$section&widget=$widget"},'add&nbsp;');
 				} else { return ""; }
 			}
@@ -240,10 +236,31 @@ sub typeSect {
 		my $showOut = $value;
 		$showOut = '**************' if ($eachRef->{display} =~ /password/);
 
+		# Source display and editability
+		my $src = $sources->{$k};
+		my $source_display;
+		my $editable = 1;
+		if (!$src) {
+			$source_display = "";
+		} elsif ($src->{layer} == 1) {
+			$source_display = "default";
+		} elsif ($src->{layer} == 2) {
+			$source_display = "site config";
+		} elsif ($src->{layer} == 3) {
+			$source_display = "conf.d";
+			$editable = 0;
+		} elsif ($src->{layer} == 4) {
+			$source_display = "ENV";
+			$editable = 0;
+		} else {
+			$source_display = "system";
+		}
+
 		push @out,Tr(td({class=>"header"},"&nbsp;"),
 				td({class=>"header"},escape($k)),td({class=>'info Plain'}, escape($showOut)),
+				td({class=>'info Plain'}, $source_display),
 				eval {
-					if ($AU->CheckAccess("Table_Config_rw","check") and !$C->{configpeerfiles}) {
+					if ($editable && $AU->CheckAccess("Table_Config_rw","check")) {
 						return td({class=>'info Plain'},
 							a({ href=>"$ref?act=config_nmis_edit&section=$section&item=$k&widget=$widget"},'edit&nbsp;'),
 							eval {
@@ -252,7 +269,7 @@ sub typeSect {
 														'delete&nbsp;') unless (grep { $_ eq $k } @items);
 								return $line;
 							});
-					} else { return ""; }
+					} else { return td({class=>'info Plain'}, ""); }
 				}
 			);
 	}
@@ -275,7 +292,8 @@ sub editConfig {
 
 	my $CT = Compat::NMIS::loadCfgTable(); # load configuration of table
 
-	my ($CC,undef) = NMISNG::Util::readConfData(only_local => 1);
+	# Load defaults + site config so edit form shows current effective value
+	my ($CC, undef) = NMISNG::Util::getConfDeep();
 
 	my $ref;
 	for my $rf (@{$CT->{$section}}) {
@@ -441,21 +459,25 @@ sub doEditConfig
 	my $value = $Q->{value};
 	my $confirm = $Q->{confirm};
 
-	# that's the  non-flattened raw hash
-	my ($CC,undef) = NMISNG::Util::readConfData(only_local => 1);
+	# Full effective config for validation
+	my ($effective, undef) = NMISNG::Util::getConfDeep();
+	# Site-local config for writing
+	my ($CC, undef) = NMISNG::Util::getConfDeep(only_local => 1);
 	# that's the set of display and validation rules
 	my $configrules = Compat::NMIS::loadCfgTable(table => "Config", user => $AU->{user});
 
-	# Validate section
-	if (!$CC->{$section}) {
+	# Validate section against full effective config
+	if (!$effective->{$section}) {
 		return validation_abort($section,
 								"non valid '$section'.")
 	}
-	# Validate item
-	if (!$CC->{$section}->{$item}) {
+	# Validate item against full effective config
+	if (!exists $effective->{$section}->{$item}) {
 		return validation_abort($item,
 								"non valid '$item' in '$section'.")
 	}
+	# Ensure the section/key exists in site config for writing
+	$CC->{$section}{$item} //= $effective->{$section}{$item};
 	
 	
 	# handle the roletype, nettype and nodetype lists and translate the separate values
@@ -674,7 +696,7 @@ sub deleteConfig {
 
 	$AU->CheckAccess("Table_Config_rw");
 
-	my ($CC,undef) = NMISNG::Util::readConfData(only_local => 1);
+	my ($CC, undef) = NMISNG::Util::getConfDeep();
 
 	my $value = $CC->{$section}{$item};
 
@@ -724,8 +746,7 @@ sub doDeleteConfig {
 	my $section = $Q->{section};
 	my $item = decode_entities($Q->{item});
 
-	# that's the  non-flattened raw hash
-	my ($CC,undef) = NMISNG::Util::readConfData(only_local => 1);
+	my ($CC, undef) = NMISNG::Util::getConfDeep(only_local => 1);
 	# that's the set of display and validation rules
 	my $configrules = Compat::NMIS::loadCfgTable(table => "Config", user => $AU->{user});
 
@@ -746,7 +767,7 @@ sub doDeleteConfig {
 sub addConfig{
 	my %args = @_;
 
-	my ($CC,undef) = NMISNG::Util::readConfData(only_local => 1);
+	my ($CC, undef) = NMISNG::Util::getConfDeep();
 
 	my $section = $Q->{section};
 
@@ -799,15 +820,18 @@ sub doAddConfig {
 
 	$AU->CheckAccess("Table_Config_rw");
 
-	my ($CC,undef) = NMISNG::Util::readConfData(only_local => 1);
+	my ($effective, undef) = NMISNG::Util::getConfDeep();
+	my ($CC, undef) = NMISNG::Util::getConfDeep(only_local => 1);
 
 	my $section = $Q->{section};
-	
-	# Validate section
-	if (!$CC->{$section}) {
+
+	# Validate section against full effective config
+	if (!$effective->{$section}) {
 		return validation_abort($section,
 								"non valid '$section'.")
 	}
+	# Ensure section exists in site config for writing
+	$CC->{$section} //= {};
 	
 	if ($Q->{id} ne '') {
 		$CC->{$section}{decode_entities($Q->{id})} = decode_entities($Q->{value});

--- a/cgi-bin/config.pl
+++ b/cgi-bin/config.pl
@@ -196,6 +196,7 @@ sub typeSect {
 	my $CT = Compat::NMIS::loadCfgTable(); # load configuration of table
 	my $ref = url(-absolute=>1);
 	my $sources = NMISNG::Util::getConfigSources();
+	my $defaults = NMISNG::Util::getConfigDefaults();
 
 	# create items list, contains of presets and adds
 	my @items = map { keys %{$_} } @{$CT->{$section}};
@@ -263,8 +264,7 @@ sub typeSect {
 		# Show default value in value column when property has been overridden
 		my $valueDisplay = escape($showOut);
 		if ($src && $src->{layer} != 1)
-		{
-			my $defaults = NMISNG::Util::getConfigDefaults();
+		{			
 			if (ref($defaults->{$section}) eq 'HASH' && exists $defaults->{$section}{$k})
 			{
 				my $def_val = $defaults->{$section}{$k};

--- a/ci/scripts/perl_tests.sh
+++ b/ci/scripts/perl_tests.sh
@@ -7,6 +7,7 @@ nmis_tests="$nmis_home/test"
 working_tests=(
     uuid.t
     t_util.pm
+    t_nmis_config.pl
     t_status.pl
     t_nmisng_sys.pl
     t_nmisng_node_rename.pl

--- a/conf-default/docker/Config.nmis.docker
+++ b/conf-default/docker/Config.nmis.docker
@@ -49,7 +49,7 @@
     'db_name' => 'nmisng',
     'db_never_remove_indices' => [
       'nodes'
-    ],    
+    ],
     'db_port' => '27017',
     'db_query_timeout' => 5000,
   },

--- a/conf-default/docker/Config.nmis.docker
+++ b/conf-default/docker/Config.nmis.docker
@@ -49,12 +49,9 @@
     'db_name' => 'nmisng',
     'db_never_remove_indices' => [
       'nodes'
-    ],
-    'db_password' => '$ENV{NMIS_DB_PASSWORD}',
+    ],    
     'db_port' => '27017',
     'db_query_timeout' => 5000,
-    'db_server' => '$ENV{NMIS_DB_SERVER}',
-    'db_username' => '$ENV{NMIS_DB_USERNAME}'
   },
   'directories' => {
     '<menu_base>' => '<nmis_base>/menu',

--- a/docs/configuration-system.md
+++ b/docs/configuration-system.md
@@ -1,0 +1,165 @@
+# NMIS9 Configuration System
+
+The configuration system uses layered loading with source tracking. Config files use a two-level Perl hash format (`%hash = (section => {key => value, ...}, ...)`). At runtime, the two-level structure is flattened into a single hash with macro expansion for path references.
+
+## Layers
+
+Config is loaded in this order. Each layer can override values from previous layers.
+
+### Layer 0: Hardcoded
+
+Set directly in `loadConfTable` after all file/env layers merge. Cannot be overridden.
+
+- `conf` = `"Config"`
+- `auth_require` = `1`
+- `hide_groups` = `[]` (if not already set)
+- `debug` / `info` (parsed from command-line args)
+
+If `cluster_id` is missing after all layers, a UUID is generated and written to `conf/Config.nmis`.
+
+### Layer 1: Defaults (`conf-default/Config.nmis`)
+
+Shipped with NMIS. Contains every config key with its default value. Never modified by users -- overwritten on upgrade. Establishes the full set of known keys.
+
+### Layer 2: Local config (`conf/Config.nmis`)
+
+Site-specific overrides. Only needs to contain keys that differ from defaults. Full merge -- can add new keys and override existing ones. This is the file the GUI and CLI write to.
+
+`writeConfData` automatically filters out values that match defaults, so only actual overrides are persisted. If the file becomes empty (all values match defaults), it is backed up and removed.
+
+### Layer 3: Fragments (`conf/conf.d/*.nmis`)
+
+Managed by external tools (configuration management, orchestration, master servers). Loaded in sorted filename order for deterministic merging.
+
+**Override-only** -- can only change keys that already exist in layers 1-2, not add new ones. NMIS never writes to these files. Attempting to modify a conf.d-managed key through the GUI or `writeConfData` returns an error.
+
+### Layer 4: Environment variables (`NMIS_*`)
+
+Runtime overrides via `NMIS_`-prefixed environment variables. Can override existing keys or add new ones.
+
+**Key resolution:** `NMIS_DB_SERVER` tries `db_server` first, then `<db_server>`. So `NMIS_NMIS_BASE` maps to `<nmis_base>`, and `NMIS_CGI_URL_BASE` maps to `<cgi_url_base>`.
+
+Like conf.d, these are read-only from NMIS's perspective -- `writeConfData` rejects changes to ENV-managed keys. An override of a default (layer 1) value is silent; overriding a local or conf.d value logs a warning.
+
+## Exclusive Keys
+
+The properties `cluster_id`, `server_name`, and `nmis_host` may only be defined in **one** non-default source (across layers 2, 3, and 4). If already claimed by an earlier source, later definitions are warned and ignored. Layer 1 defaults do not count for this check.
+
+## Macro Expansion
+
+After all layers are merged, `replace_macros()` runs once. Values containing `<key_name>` are expanded by looking up `<key_name>` or `key_name` in the config. For example, `<nmis_conf>/users.dat` becomes `/usr/local/nmis9/conf/users.dat`.
+
+Macro expansion only affects the runtime flat cache. The raw layer data (used for writing back to files) preserves the original macro references.
+
+## Caching
+
+Config is loaded once per process and cached. Subsequent calls to `loadConfTable` return the cached result immediately.
+
+To force a reload (e.g. after writing config):
+
+```perl
+$NMISNG::Util::_config_cache_invalid = 1;
+my $C = NMISNG::Util::loadConfTable();
+```
+
+`writeConfData` sets this flag automatically after a successful write.
+
+## Change Notification
+
+When `writeConfData` writes config, it also writes a timestamp to `<nmis_var>/nmis_system/config_changed`. Other processes can poll `NMISNG::Util::configChanged()` to detect that config has changed on disk since they loaded it.
+
+## Public API
+
+All functions are in `NMISNG::Util` (`lib/NMISNG/Util.pm`).
+
+### `loadConfTable(%args)`
+
+Loads and returns the effective config as a flat hashref (keys flattened from two-level structure, macros expanded).
+
+- `dir` -- config directory (default: `$FindBin::RealBin/../conf`)
+- `debug` -- debug level override
+- Returns: hashref
+
+### `getConfigSources(%args)`
+
+Returns source tracking for config keys.
+
+- No args: returns `{ key => { source => $file, layer => $n, section => $name }, ... }`
+- `key => "db_server"`: returns just that key's source info hashref
+
+### `getConfigDefaults()`
+
+Returns the layer 1 defaults as a two-level hashref `{ section => { key => value } }`.
+
+### `getConfDeep(%args)`
+
+Returns the effective config as a two-level hashref with raw (pre-macro) values. Used by `writeConfData` and the config GUI.
+
+- No args: merges all layers (1-4), suitable for display and round-tripping through `writeConfData`
+- `only_local => 1`: returns only layer 2 (local config) keys
+
+Returns: `($deep_hashref, $configfile_path)`
+
+### `writeConfData(%args)`
+
+Writes config to `conf/Config.nmis` with automatic filtering:
+
+- Layer 3/4 managed keys: error if value changed, silently skipped if unchanged
+- Keys matching layer 1 defaults: silently skipped
+- Empty result: backs up and removes the config file
+
+Also invalidates the in-process cache and writes a change notification marker.
+
+- `data` -- two-level hashref to write
+- Returns: `undef` on success, error message string on failure
+
+### `stripDefaults()`
+
+Compares local config (layer 2) against defaults (layer 1). Returns the stripped data and a list of removals.
+
+Returns: `($stripped_hashref, \@removals)` where each removal is `{ section, key, value }`
+
+### `configChanged()`
+
+Returns true if the config change marker on disk is newer than when this process loaded config. Processes can poll this to decide whether to restart.
+
+## CLI Actions
+
+### `bin/nmis-cli act=show-config`
+
+Displays all config keys grouped by section, with source info.
+
+- `section=database` -- filter to one section
+- `key=db_server` -- show one key
+
+### `bin/nmis-cli act=strip-config-defaults`
+
+Removes default-matching values from `conf/Config.nmis`. Prompts for confirmation unless `quiet=true`.
+
+### `bin/nmis-cli act=restore-config`
+
+Restores `conf/Config.nmis` from the `.bak` backup created by `writeConfData`. Prompts unless `quiet=true`.
+
+## Config File Format
+
+All `.nmis` config files use the same two-level Perl hash format:
+
+```perl
+%hash = (
+  'section_name' => {
+    'key1' => 'value1',
+    'key2' => 'value2',
+  },
+  'another_section' => {
+    'key3' => 'value3',
+  },
+);
+```
+
+## Testing
+
+Tests are in `test/t_nmis_config.pl`. They use a temp directory for all config writes (protecting the live system) and in-process cache invalidation (no subprocesses). Run with:
+
+```bash
+perl test/t_nmis_config.pl
+```

--- a/docs/configuration-system.md
+++ b/docs/configuration-system.md
@@ -66,7 +66,7 @@ my $C = NMISNG::Util::loadConfTable();
 
 ## Change Notification
 
-When `writeConfData` writes config, it also writes a timestamp to `<nmis_var>/nmis_system/config_changed`. Other processes can poll `NMISNG::Util::configChanged()` to detect that config has changed on disk since they loaded it.
+When `writeConfData` writes config, it also writes a timestamp to `<nmis_var>/nmis_system/config_changed`. Other processes can poll `NMISNG::Util::configChanged( conf=> $C )` to detect that config has changed on disk since they loaded it.
 
 ## Public API
 
@@ -119,9 +119,9 @@ Compares local config (layer 2) against defaults (layer 1). Returns the stripped
 
 Returns: `($stripped_hashref, \@removals)` where each removal is `{ section, key, value }`
 
-### `configChanged()`
+### `configChanged(conf => $C)`
 
-Returns true if the config change marker on disk is newer than when this process loaded config. Processes can poll this to decide whether to restart.
+Returns true if the config change marker on disk is newer than when this process loaded config. Requires the loaded config hashref (`$C` from `loadConfTable`). Processes can poll this to decide whether to restart.
 
 ## CLI Actions
 

--- a/lib/NMISNG/Util.pm
+++ b/lib/NMISNG/Util.pm
@@ -787,7 +787,7 @@ sub loadConfTable
 	my $dir = $args{dir} || "$FindBin::RealBin/../conf";
 	mkpath($dir, { verbose  => 0, mode => 0755} ) if (!-d $dir);
 
-	my $fn = Cwd::abs_path("$dir/Config.nmis");
+	my $fn = Cwd::abs_path("$dir/Config.nmis") // "$dir/Config.nmis";
 	# if caller gave us a dir previously but not now, use the cached path
 	$fn = $cached_configfile_fn if ($cached_configfile_fn && !defined $args{dir});
 
@@ -849,8 +849,12 @@ sub loadConfTable
 	}
 
 	# --- Layer 3: conf/conf.d/*.nmis (fragments, override-only) ---
-	my $partialconf_dir = Cwd::abs_path("$dir/conf.d");
-	my $external_files = get_external_files(dir => $partialconf_dir);
+	my $partialconf_dir = "$dir/conf.d";
+	my $external_files = [];
+	if (-d $partialconf_dir) {
+		$partialconf_dir = Cwd::abs_path($partialconf_dir) || $partialconf_dir;
+		$external_files = get_external_files(dir => $partialconf_dir);
+	}
 	$_raw_layers{3} = {};
 	for my $extfile (@$external_files)
 	{
@@ -974,11 +978,28 @@ sub getConfigDefaults
 }
 
 # Load a .nmis config file and flatten its two-level hash to a single level.
+# Uses shared lock to avoid reading partially-written files.
 # Returns: ($flattened_hashref, $section_map_hashref, $raw_two_level_hashref)
 sub _load_and_flatten
 {
 	my ($filepath) = @_;
-	my %deepdata = do($filepath);
+
+	# Read under shared lock to protect against concurrent writes
+	open(my $fh, "<", $filepath) or do {
+		warn("cannot open configuration file $filepath: $!");
+		return (undef, undef, undef);
+	};
+	flock($fh, LOCK_SH) or do {
+		warn("cannot lock configuration file $filepath: $!");
+		close($fh);
+		return (undef, undef, undef);
+	};
+	local $/;
+	my $content = <$fh>;
+	close($fh);
+
+	# no strict 'vars' needed because .nmis files use %hash = (...) without declaring it
+	my %deepdata = do { no strict 'vars'; eval $content };
 	if ($@)
 	{
 		warn("configuration file $filepath unparseable: $@");

--- a/lib/NMISNG/Util.pm
+++ b/lib/NMISNG/Util.pm
@@ -1905,6 +1905,7 @@ sub readConfData
 }
 
 # trivial wrapper around writeHashtoFile
+# If data is empty (no keys or all sections empty), backs up and removes the config file.
 # args: data, required
 # returns: undef or error message
 sub writeConfData
@@ -1918,6 +1919,26 @@ sub writeConfData
 	# save old one
 	File::Copy::cp($configfile, "$configfile.bak") # this overwrites any existing backup file
 			if (-r "$configfile");
+
+	# If data has no meaningful keys, remove the config file instead of writing an empty one
+	my $has_keys = 0;
+	if (ref($CC) eq 'HASH')
+	{
+		for my $section (keys %$CC)
+		{
+			if (ref($CC->{$section}) eq 'HASH' && keys %{$CC->{$section}})
+			{
+				$has_keys = 1;
+				last;
+			}
+		}
+	}
+
+	if (!$has_keys)
+	{
+		unlink($configfile) if (-e $configfile);
+		return undef;
+	}
 
 	return NMISNG::Util::writeHashtoFile(file=>$configfile, data=>$CC);
 }

--- a/lib/NMISNG/Util.pm
+++ b/lib/NMISNG/Util.pm
@@ -1929,15 +1929,12 @@ sub writeConfData
 		{
 			my $src = $sources->{$key};
 
-			# ENV-sourced: skip silently
-			next if ($src && $src->{layer} == 4);
-
-			# conf.d-sourced: error if value changed, skip if unchanged
-			if ($src && $src->{layer} == 3)
+			# ENV-sourced or conf.d-sourced: error if value changed, skip if unchanged
+			if ($src && ($src->{layer} == 3 || $src->{layer} == 4))
 			{
 				if (!_config_values_equal($CC->{$section}{$key}, $C->{$key}))
 				{
-					return "Cannot modify property '$key' — it is managed by conf.d file $src->{source}";
+					return "Cannot modify property '$key' — it is managed by $src->{source}";
 				}
 				next;
 			}

--- a/lib/NMISNG/Util.pm
+++ b/lib/NMISNG/Util.pm
@@ -775,17 +775,17 @@ sub getServerRole {
 sub loadConfTable
 {
 	my %args = @_;
-	state ($config_cache, $cached_configfile);
+	state ($config_cache, $cached_configfile_fn);
 
 	my $dir = $args{dir} || "$FindBin::RealBin/../conf";
 	mkpath($dir, { verbose  => 0, mode => 0755} ) if (!-d $dir);
 
 	my $fn = Cwd::abs_path("$dir/Config.nmis");
 	# if caller gave us a dir previously but not now, use the cached path
-	$fn = $cached_configfile if ($cached_configfile && !defined $args{dir});
+	$fn = $cached_configfile_fn if ($cached_configfile_fn && !defined $args{dir});
 
 	# return cached config if already loaded for this path
-	if ($config_cache && $cached_configfile && $cached_configfile eq $fn)
+	if ($config_cache && $cached_configfile_fn && $cached_configfile_fn eq $fn)
 	{
 		return $config_cache;
 	}
@@ -862,7 +862,7 @@ sub loadConfTable
 
 	# Set configfile key (points to conf/Config.nmis or fallback)
 	$config_cache->{configfile} = (-r $fn) ? $fn : $default_fn;
-	$cached_configfile = $fn;
+	$cached_configfile_fn = $fn;
 
 	# Replace macros once across entire config
 	$config_cache = replace_macros( config_cache => $config_cache );
@@ -1890,6 +1890,80 @@ sub writeConfData
 			if (-r "$configfile");
 
 	return NMISNG::Util::writeHashtoFile(file=>$configfile, data=>$CC);
+}
+
+# Compare conf/Config.nmis against conf-default/Config.nmis and return
+# a stripped version containing only keys that differ from or don't exist in defaults.
+# args: conf (optional, loadConfTable result)
+# returns: ($stripped_data, $removals)
+#   $stripped_data: deep two-level hashref ready for writeConfData
+#   $removals: arrayref of { section => $s, key => $k, value => $v }
+sub stripDefaults
+{
+	my %args = @_;
+	my $C = $args{conf} // NMISNG::Util::loadConfTable();
+
+	my $default_file = $C->{'<nmis_conf_default>'} . "/Config.nmis";
+	my $site_file = $C->{configfile};
+
+	my $defaults = NMISNG::Util::readFiletoHash(file => $default_file);
+	my $site = NMISNG::Util::readFiletoHash(file => $site_file);
+
+	my %stripped;
+	my @removals;
+
+	for my $section (keys %$site)
+	{
+		next unless ref($site->{$section}) eq 'HASH';
+		for my $key (keys %{$site->{$section}})
+		{
+			if (ref($defaults->{$section}) eq 'HASH'
+				&& exists $defaults->{$section}{$key}
+				&& _config_values_equal($site->{$section}{$key}, $defaults->{$section}{$key}))
+			{
+				push @removals, { section => $section, key => $key, value => $site->{$section}{$key} };
+			}
+			else
+			{
+				$stripped{$section}{$key} = $site->{$section}{$key};
+			}
+		}
+	}
+
+	return (\%stripped, \@removals);
+}
+
+# Deep equality check for config values (scalars, arrayrefs, hashrefs, regexps, undef)
+sub _config_values_equal
+{
+	my ($a, $b) = @_;
+	return 1 if (!defined $a && !defined $b);
+	return 0 if (!defined $a || !defined $b);
+	my ($ra, $rb) = (ref $a, ref $b);
+	return 0 if $ra ne $rb;
+	if ($ra eq 'Regexp') { return "$a" eq "$b"; }
+	if ($ra eq 'ARRAY')
+	{
+		return 0 if @$a != @$b;
+		for my $i (0..$#$a)
+		{
+			return 0 if !_config_values_equal($a->[$i], $b->[$i]);
+		}
+		return 1;
+	}
+	if ($ra eq 'HASH')
+	{
+		my @ka = sort keys %$a;
+		my @kb = sort keys %$b;
+		return 0 if @ka != @kb;
+		for my $i (0..$#ka)
+		{
+			return 0 if $ka[$i] ne $kb[$i];
+			return 0 if !_config_values_equal($a->{$ka[$i]}, $b->{$kb[$i]});
+		}
+		return 1;
+	}
+	return $a eq $b;
 }
 
 # creates the dir in question, and all missing intermediate

--- a/lib/NMISNG/Util.pm
+++ b/lib/NMISNG/Util.pm
@@ -908,12 +908,12 @@ sub loadConfTable
 				or warn_die("cannot symlink $normalvar to configured $confdvar: $!");
 	}
 
-	# Cluster ID: if missing, generate UUID and write to conf/conf.d/system.nmis
+	# Cluster ID: if missing, generate UUID and write to conf/Config.nmis
 	if (!$config_cache->{cluster_id})
 	{
 		$config_cache->{cluster_id} = create_uuid_as_string(UUID_RANDOM);
-		$config_sources->{cluster_id} = { source => "generated", layer => 0, section => "id" };
-		_write_cluster_id_to_confd($dir, $config_cache->{cluster_id});
+		$config_sources->{cluster_id} = { source => $config_cache->{configfile}, layer => 2, section => "id" };
+		_write_cluster_id_to_config($config_cache->{configfile}, $config_cache->{cluster_id});
 	}
 
 	# Store sources in package variable for getConfigSources access
@@ -1019,19 +1019,23 @@ sub _apply_env_overrides
 	}
 }
 
-# Write cluster_id to conf/conf.d/system.nmis
-sub _write_cluster_id_to_confd
+# Write cluster_id to conf/Config.nmis (reads existing content, merges, writes back)
+sub _write_cluster_id_to_config
 {
-	my ($conf_dir, $cluster_id) = @_;
-	my $confd_dir = "$conf_dir/conf.d";
-	mkpath($confd_dir, { verbose => 0, mode => 0755 }) if (!-d $confd_dir);
+	my ($configfile, $cluster_id) = @_;
+	my %data;
+	if (-r $configfile)
+	{
+		%data = do($configfile);
+		%data = () if ($@ || !%data);
+	}
+	$data{id}{cluster_id} = $cluster_id;
 
-	my $system_file = "$confd_dir/system.nmis";
-	my %data = ( 'id' => { 'cluster_id' => $cluster_id } );
-	open(my $fh, ">", $system_file) or do {
-		warn("cannot write cluster_id to $system_file: $!");
+	open(my $fh, ">", $configfile) or do {
+		warn("cannot write cluster_id to $configfile: $!");
 		return;
 	};
+	flock($fh, LOCK_EX) or warn("cannot lock $configfile: $!");
 	print $fh Data::Dumper->Dump([\%data], [qw(*hash)]);
 	close $fh;
 }

--- a/lib/NMISNG/Util.pm
+++ b/lib/NMISNG/Util.pm
@@ -74,6 +74,8 @@ use NMISNG::Log;					# for parse_debug_level
 
 # Package-level storage for config source tracking (populated by loadConfTable)
 our $_config_sources_ref = {};
+# Set to 1 to force loadConfTable to reload on next call
+our $_config_cache_invalid = 0;
 
 sub TODO
 {
@@ -784,11 +786,14 @@ sub loadConfTable
 	# if caller gave us a dir previously but not now, use the cached path
 	$fn = $cached_configfile_fn if ($cached_configfile_fn && !defined $args{dir});
 
-	# return cached config if already loaded for this path
-	if ($config_cache && $cached_configfile_fn && $cached_configfile_fn eq $fn)
+	# return cached config if already loaded for this path (unless invalidated)
+	if ($config_cache && $cached_configfile_fn && $cached_configfile_fn eq $fn
+		&& !$NMISNG::Util::_config_cache_invalid)
 	{
 		return $config_cache;
 	}
+	warn("Config cache invalidated, reloading from disk\n") if $NMISNG::Util::_config_cache_invalid;
+	$NMISNG::Util::_config_cache_invalid = 0;
 
 	# --- Layer 1: conf-default/Config.nmis (defaults) ---
 	my $default_dir = $args{dir} ? "$args{dir}/../conf-default" : "$FindBin::RealBin/../conf-default";
@@ -1852,60 +1857,29 @@ sub getdebug_cli
 # difference to loadConfTable: loadconftable flattens and adds a few entries
 # args: only_local eq 1 loads only local config (Not by default)
 # returns: hashref-or-errormessage, file name
-sub readConfData
+# Reconstruct two-level config hash from loadConfTable + getConfigSources.
+# Replaces readConfData — no file I/O, uses cached layered config.
+# args: only_local => 1 (exclude conf.d layer 3 and ENV layer 4 keys)
+# returns: ($deep_hashref, $configfile_path)
+sub getConfDeep
 {
 	my %args = @_;
-	my $logger;
+	my $C = loadConfTable();
+	my $sources = getConfigSources();
+	my %deep;
 
-	my $C = loadConfTable;
-	my $fn = $C->{configfile};
-
-	my $rawdata = NMISNG::Util::readFiletoHash(file => $fn);
-
-	if (defined($args{log}))
+	for my $k (keys %$C)
 	{
-		$logger = $args{log};
-	}
-	else
-	{
-		my $nmisng = Compat::NMIS::new_nmisng();
-		$logger  = $nmisng->log;
+		my $src = $sources->{$k};
+		next unless $src && defined $src->{section};
+
+		# only_local: skip conf.d (layer 3) and ENV (layer 4) keys
+		next if ($args{only_local} && $src->{layer} >= 3);
+
+		$deep{$src->{section}}{$k} = $C->{$k};
 	}
 
-	if ($args{only_local} ne 1)
-	{
-		$logger->info("Reading config properties from conf.d files. ");
-		# Determine conf.d directory from the configfile path
-		my $conf_dir = File::Basename::dirname($fn);
-		my $confd_dir = "$conf_dir/conf.d";
-		my $confd_files = get_external_files(dir => $confd_dir);
-		eval {
-			foreach ( @$confd_files ) {
-
-				my $rawpartialdata = NMISNG::Util::readFiletoHash(file => $_);
-
-				# strip the outer of two levels, does not flatten any deeper structure
-				# merge
-				for my $k (keys %{$rawpartialdata})
-				{
-					for my $kk (keys %{$rawpartialdata->{$k}})
-					{
-						if (ref($rawpartialdata->{$k}->{$kk}) ne "HASH" )
-						{
-							$rawdata->{$k}->{$kk} = $rawpartialdata->{$k}->{$kk};
-						}
-						else
-						{
-							# FIXME: Support nested config values
-							$logger->warn($kk . " is a hash. Not being merged");
-						}
-					}
-				}
-			}
-		}; if ($@) { $logger->warn("Error reading config peer files. Show local config " . $@); }
-	}
-
-	return ($rawdata, $fn);
+	return (\%deep, $C->{configfile});
 }
 
 # Writes config data to conf/Config.nmis, filtering keys by their source:
@@ -1955,10 +1929,13 @@ sub writeConfData
 	if (!$has_keys)
 	{
 		unlink($configfile) if (-e $configfile);
+		$NMISNG::Util::_config_cache_invalid = 1;
 		return undef;
 	}
 
-	return NMISNG::Util::writeHashtoFile(file => $configfile, data => \%filtered);
+	my $error = NMISNG::Util::writeHashtoFile(file => $configfile, data => \%filtered);
+	$NMISNG::Util::_config_cache_invalid = 1 if (!$error);
+	return $error;
 }
 
 # Compare conf/Config.nmis against conf-default/Config.nmis and return
@@ -4062,7 +4039,7 @@ sub disableEOS {
 	{
 		$logger->info("Disabling Encryption of secrets.");
 		print("Disabling Encryption of secrets.\n");
-		my ($fullConfig,undef) = readConfData(log =>$logger, only_local => 1);
+		my ($fullConfig,undef) = getConfDeep(only_local => 1);
 		$fullConfig->{globals}{global_enable_password_encryption} = "false";
 		writeConfData(data=>$fullConfig);
 		# We changed encryption, so the test below is backwards.
@@ -4128,7 +4105,7 @@ sub enableEOS {
 		{
 			$logger->info("Enabling encryption of secrets.");
 			print("Enabling encryption of secrets.\n");
-			my ($fullConfig,undef) = readConfData(log =>$logger, only_local => 1);
+			my ($fullConfig,undef) = getConfDeep(only_local => 1);
 			$fullConfig->{globals}{global_enable_password_encryption} = "true";
 			writeConfData(data=>$fullConfig);
 			# We changed encryption, so the test below is backwards.
@@ -4194,7 +4171,7 @@ sub verifyNMISEncryption {
 
 	my $nmis_encryption_enabled = getbool($config->{'global_enable_password_encryption'});
 
-	my ($fullConfig,undef) = readConfData(log =>$logger, only_local => 1);
+	my ($fullConfig,undef) = getConfDeep(only_local => 1);
 	eval {require Crypt::CBC; require Crypt::Cipher::AES; require Math::Random::Secure; };
 	if($@)
 	{
@@ -4333,7 +4310,7 @@ sub verifyNMISEncryption {
 	}
 	else
 	{
-		my ($fullConfig,undef) = readConfData(log =>$logger, only_local => 1);
+		my ($fullConfig,undef) = getConfDeep(only_local => 1);
 		my $installDir = $config->{'<nmis_base>'} . "/conf-default";
 		if (open($fh, '<', $installDir . '/PasswordFields.nmis'))
 	   	{
@@ -4450,7 +4427,7 @@ sub decrypt {
 		{
 			$logger->error("ERROR: The configuration option 'global_enable_password_encryption' is set to 'true'!");
 			$logger->error("Disabling Encryption of secrets.");
-			my ($fullConfig,undef) = readConfData(log =>$logger, only_local => 1);
+			my ($fullConfig,undef) = getConfDeep(only_local => 1);
 			$fullConfig->{globals}{global_enable_password_encryption} = "false";
 			writeConfData(data=>$fullConfig);
 			return $password;
@@ -4479,7 +4456,7 @@ sub decrypt {
 			# dealing with the configuration file, so we we encrypt it in the file.
 			if (defined($section) && defined($keyword) && $section ne '' && $keyword ne '') {
 				# Get the non-flattened raw hash
-				my ($fullConfig,undef) = readConfData(log =>$logger, only_local => 1);
+				my ($fullConfig,undef) = getConfDeep(only_local => 1);
 				$logger->debug9(sub {"Config '" .  Dumper($fullConfig) . "'."});
 				my $encrypted_pw = encrypt($password);
 				if ($fullConfig->{$section}{$keyword} ne $encrypted_pw) {
@@ -4532,7 +4509,7 @@ sub decrypt {
 					# (If the 'section and 'keyword' arguments are passed, it means we are dealing with the configuration file)
 					if (defined($section) && defined($keyword) && $section ne '' && $keyword ne '') {
 						# Get the non-flattened raw hash
-						my ($fullConfig,undef) = readConfData(log =>$logger, only_local => 1);
+						my ($fullConfig,undef) = getConfDeep(only_local => 1);
 						$logger->debug9(sub {"Config '" .  Dumper($fullConfig) . "'."});
 						if ($fullConfig->{$section}{$keyword} ne $password) {
 							$logger->debug3(sub {"Decrypting the password for Section: '$section' Field: '$keyword'"});
@@ -4584,7 +4561,7 @@ sub encrypt {
 		{
 			$logger->error("ERROR: The configuration option 'global_enable_password_encryption' is set to 'true'!");
 			$logger->error("Disabling Encryption of secrets.");
-			my ($fullConfig,undef) = readConfData(log =>$logger, only_local => 1);
+			my ($fullConfig,undef) = getConfDeep(only_local => 1);
 			$fullConfig->{globals}{global_enable_password_encryption} = "false";
 			writeConfData(data=>$fullConfig);
 		}
@@ -4614,7 +4591,7 @@ sub encrypt {
 			# dealing with the configuration file, so we we decrypt it in the file.
 			if (defined($section) && defined($keyword) && $section ne '' && $keyword ne '') {
 				# Get the non-flattened raw hash
-				my ($fullConfig,undef) = readConfData(log =>$logger, only_local => 1);
+				my ($fullConfig,undef) = getConfDeep(only_local => 1);
 				$logger->debug9(sub {"Config '" .  Dumper($fullConfig) . "'."});
 				if ($fullConfig->{$section}{$keyword} ne $decrypted_pw) {
 					$logger->debug3(sub {"Decrypting the password for Section: '$section' Field: '$keyword'"});

--- a/lib/NMISNG/Util.pm
+++ b/lib/NMISNG/Util.pm
@@ -78,8 +78,9 @@ our $_config_sources_ref = {};
 our $_config_cache_invalid = 0;
 # Epoch when config was last loaded (not cache hit) — used by configChanged()
 our $_config_load_time = 0;
-# Snapshot of config values before macro expansion — used by getConfDeep/writeConfData
-our $_config_pre_macros = {};
+# Raw two-level hashes per layer, stored during loadConfTable
+# layer => { section => { key => value } }
+our %_raw_layers;
 
 sub TODO
 {
@@ -805,6 +806,7 @@ sub loadConfTable
 
 	$config_cache = {};
 	my $config_sources = {};
+	%NMISNG::Util::_raw_layers = ();
 
 	# Properties that may only be defined in one non-default config file
 	my @exclusive_keys = ('cluster_id', 'server_name', 'nmis_host');
@@ -812,27 +814,29 @@ sub loadConfTable
 
 	if (-r $default_fn)
 	{
-		my ($flat, $smap) = _load_and_flatten($default_fn);
+		my ($flat, $smap, $raw) = _load_and_flatten($default_fn);
 		warn_die("configuration file $default_fn unparseable or empty") if (!$flat || !keys %$flat);
 		$config_cache = $flat;
+		$_raw_layers{1} = $raw;
 		for my $k (keys %$flat)
 		{
 			$config_sources->{$k} = { source => $default_fn, layer => 1, section => $smap->{$k} };
 		}
 	}
 
-	# --- Layer 2: conf/Config.nmis (site config) ---
+	# --- Layer 2: conf/Config.nmis (local config) ---
 	if (-r $fn && $fn ne $default_fn)
 	{
-		my ($flat, $smap) = _load_and_flatten($fn);
+		my ($flat, $smap, $raw) = _load_and_flatten($fn);
 		if ($flat && keys %$flat)
 		{
 			_merge_config($config_cache, $flat, 0);
+			$_raw_layers{2} = $raw;
 			for my $k (keys %$flat)
 			{
 				$config_sources->{$k} = { source => $fn, layer => 2, section => $smap->{$k} };
 			}
-			# Track exclusive keys claimed by site config
+			# Track exclusive keys claimed by local config
 			for my $ek (@exclusive_keys)
 			{
 				$exclusive_source{$ek} = $fn if (exists $flat->{$ek});
@@ -847,9 +851,10 @@ sub loadConfTable
 	# --- Layer 3: conf/conf.d/*.nmis (fragments, override-only) ---
 	my $partialconf_dir = Cwd::abs_path("$dir/conf.d");
 	my $external_files = get_external_files(dir => $partialconf_dir);
+	$_raw_layers{3} = {};
 	for my $extfile (@$external_files)
 	{
-		my ($flat, $smap) = _load_and_flatten($extfile);
+		my ($flat, $smap, $raw) = _load_and_flatten($extfile);
 		next if (!$flat || !keys %$flat);
 
 		# Enforce exclusive keys: skip if already defined by an earlier non-default file
@@ -861,6 +866,10 @@ sub loadConfTable
 				{
 					warn("Exclusive property '$ek' in $extfile ignored — already defined in $exclusive_source{$ek}\n");
 					delete $flat->{$ek};
+					# Also remove from raw so it doesn't leak into layer 3 storage
+					for my $s (keys %$raw) {
+						delete $raw->{$s}{$ek} if ref($raw->{$s}) eq 'HASH';
+					}
 				}
 				else
 				{
@@ -873,6 +882,15 @@ sub loadConfTable
 		for my $k (@$changed)
 		{
 			$config_sources->{$k} = { source => $extfile, layer => 3, section => $smap->{$k} };
+		}
+		# Merge raw into layer 3 storage (only keys that were actually merged)
+		for my $s (keys %$raw)
+		{
+			next unless ref($raw->{$s}) eq 'HASH';
+			for my $k (keys %{$raw->{$s}})
+			{
+				$_raw_layers{3}{$s}{$k} = $raw->{$s}{$k} if grep { $_ eq $k } @$changed;
+			}
 		}
 	}
 
@@ -896,12 +914,10 @@ sub loadConfTable
 		$config_cache->{info} = $verbosity =~ /^(debug|\d)+/? $verbosity : 0;
 	}
 
-	# Set configfile key (points to conf/Config.nmis or fallback)
-	$config_cache->{configfile} = (-r $fn) ? $fn : $default_fn;
+	# Set configfile key — always points to conf/Config.nmis (the write target),
+	# even if it doesn't exist yet (writeConfData will create it)
+	$config_cache->{configfile} = $fn;
 	$cached_configfile_fn = $fn;
-
-	# Snapshot pre-macro values for getConfDeep to use when writing back
-	$NMISNG::Util::_config_pre_macros = { %$config_cache };
 
 	# Replace macros once across entire config
 	$config_cache = replace_macros( config_cache => $config_cache );
@@ -949,8 +965,16 @@ sub getConfigSources
 	return $sources;
 }
 
+# Returns the default config values (layer 1) as a two-level hash.
+# returns: hashref { section => { key => value } }
+sub getConfigDefaults
+{
+	loadConfTable(); # ensure loaded
+	return $_raw_layers{1} // {};
+}
+
 # Load a .nmis config file and flatten its two-level hash to a single level.
-# Returns: ($flattened_hashref, $section_map_hashref) where section_map maps each key to its section name
+# Returns: ($flattened_hashref, $section_map_hashref, $raw_two_level_hashref)
 sub _load_and_flatten
 {
 	my ($filepath) = @_;
@@ -958,13 +982,12 @@ sub _load_and_flatten
 	if ($@)
 	{
 		warn("configuration file $filepath unparseable: $@");
-		return (undef, undef);
+		return (undef, undef, undef);
 	}
 	if (!%deepdata)
 	{
-		# do() might return empty list on certain errors
 		warn("configuration file $filepath returned no data");
-		return (undef, undef);
+		return (undef, undef, undef);
 	}
 
 	my %flat;
@@ -980,7 +1003,7 @@ sub _load_and_flatten
 			}
 		}
 	}
-	return (\%flat, \%section_map);
+	return (\%flat, \%section_map, \%deepdata);
 }
 
 # Merge overlay keys into base.
@@ -1026,7 +1049,7 @@ sub _apply_env_overrides
 		}
 
 		warn("ENV $envkey overriding config key '$config_key' from source '$sources->{$config_key}{source}'\n")
-			if (exists $config->{$config_key} && $sources->{$config_key});
+			if (exists $config->{$config_key} && $sources->{$config_key} && $sources->{$config_key}{layer} > 1);
 		my $prev_section = $sources->{$config_key} ? $sources->{$config_key}{section} : undef;
 		$config->{$config_key} = $ENV{$envkey};
 		$sources->{$config_key} = { source => "ENV:$envkey", layer => 4, section => $prev_section };
@@ -1866,28 +1889,42 @@ sub getdebug_cli
 # difference to loadConfTable: loadconftable flattens and adds a few entries
 # args: only_local eq 1 loads only local config (Not by default)
 # returns: hashref-or-errormessage, file name
-# Reconstruct two-level config hash from loadConfTable + getConfigSources.
-# Replaces readConfData — no file I/O, uses cached layered config.
-# args: only_local => 1 (exclude conf.d layer 3 and ENV layer 4 keys)
+# Reconstruct two-level config hash from stored raw layer data.
+# No file I/O — uses layer data cached during loadConfTable.
+# args: only_local => 1 (only layer 2 / local config keys)
 # returns: ($deep_hashref, $configfile_path)
 sub getConfDeep
 {
 	my %args = @_;
-	my $C = loadConfTable();
-	my $sources = getConfigSources();
-	my $raw = $NMISNG::Util::_config_pre_macros;
+	my $C = loadConfTable(); # ensure loaded
 	my %deep;
 
-	for my $k (keys %$C)
+	# Merge raw layers in order: defaults(1), site(2), conf.d(3)
+	for my $layer (1, 2, 3)
 	{
-		my $src = $sources->{$k};
-		next unless $src && defined $src->{section};
+		next unless ref($_raw_layers{$layer}) eq 'HASH';
+		next if ($args{only_local} && $layer != 2);
+		for my $section (keys %{$_raw_layers{$layer}})
+		{
+			next unless ref($_raw_layers{$layer}{$section}) eq 'HASH';
+			for my $key (keys %{$_raw_layers{$layer}{$section}})
+			{
+				$deep{$section}{$key} = $_raw_layers{$layer}{$section}{$key};
+			}
+		}
+	}
 
-		# only_local: only include site config (layer 2) keys
-		next if ($args{only_local} && $src->{layer} != 2);
-
-		# Use pre-macro value if available to preserve macro references in written files
-		$deep{$src->{section}}{$k} = exists $raw->{$k} ? $raw->{$k} : $C->{$k};
+	# Apply ENV overrides (layer 4) so values round-trip correctly through writeConfData
+	if (!$args{only_local})
+	{
+		my $sources = getConfigSources();
+		for my $k (keys %$sources)
+		{
+			next unless $sources->{$k}{layer} == 4;
+			my $section = $sources->{$k}{section};
+			next unless defined $section;
+			$deep{$section}{$k} = $C->{$k};
+		}
 	}
 
 	return (\%deep, $C->{configfile});
@@ -1909,13 +1946,10 @@ sub writeConfData
 	my $C = NMISNG::Util::loadConfTable();
 	my $configfile = $C->{configfile};
 	my $sources = NMISNG::Util::getConfigSources();
-	my $raw = $NMISNG::Util::_config_pre_macros;
+	my $defaults = $_raw_layers{1} // {};
+	my $confd = $_raw_layers{3} // {};
 
-	# Load defaults for comparison
-	my $default_file = $C->{'<nmis_conf_default>'} . "/Config.nmis";
-	my ($defaults, undef) = _load_and_flatten($default_file);
-
-	# Filter data based on source tracking and default comparison
+	# Filter data: skip defaults, error on managed keys, keep only site overrides
 	my %filtered;
 	for my $section (keys %$CC)
 	{
@@ -1924,11 +1958,23 @@ sub writeConfData
 		{
 			my $src = $sources->{$key};
 
-			# ENV-sourced or conf.d-sourced: error if value changed, skip if unchanged
-			# Compare against pre-macro values to avoid false positives from macro expansion
-			if ($src && ($src->{layer} == 3 || $src->{layer} == 4))
+			# conf.d-sourced: error if value changed, skip if unchanged
+			if ($src && $src->{layer} == 3)
 			{
-				if (!_config_values_equal($CC->{$section}{$key}, $raw->{$key}))
+				my $raw_val = ref($confd->{$src->{section}}) eq 'HASH'
+					? $confd->{$src->{section}}{$key} : undef;
+				if (!_config_values_equal($CC->{$section}{$key}, $raw_val))
+				{
+					return "Cannot modify property '$key' — it is managed by $src->{source}";
+				}
+				next;
+			}
+
+			# ENV-sourced: error if value changed, skip if unchanged
+			if ($src && $src->{layer} == 4)
+			{
+				# ENV values are literal strings, compare against current effective value
+				if (!_config_values_equal($CC->{$section}{$key}, $C->{$key}))
 				{
 					return "Cannot modify property '$key' — it is managed by $src->{source}";
 				}
@@ -1936,8 +1982,9 @@ sub writeConfData
 			}
 
 			# Skip keys whose value matches the default — no need to persist
-			next if ($defaults && exists $defaults->{$key}
-				&& _config_values_equal($CC->{$section}{$key}, $defaults->{$key}));
+			next if (ref($defaults->{$section}) eq 'HASH'
+				&& exists $defaults->{$section}{$key}
+				&& _config_values_equal($CC->{$section}{$key}, $defaults->{$section}{$key}));
 
 			$filtered{$section}{$key} = $CC->{$section}{$key};
 		}
@@ -1991,22 +2038,17 @@ sub configChanged
 	return ($mtime > $NMISNG::Util::_config_load_time) ? 1 : 0;
 }
 
-# Compare conf/Config.nmis against conf-default/Config.nmis and return
+# Compare local config (layer 2) against defaults (layer 1) and return
 # a stripped version containing only keys that differ from or don't exist in defaults.
-# args: conf (optional, loadConfTable result)
+# Uses stored raw layer data — no file I/O.
 # returns: ($stripped_data, $removals)
 #   $stripped_data: deep two-level hashref ready for writeConfData
 #   $removals: arrayref of { section => $s, key => $k, value => $v }
 sub stripDefaults
 {
-	my %args = @_;
-	my $C = $args{conf} // NMISNG::Util::loadConfTable();
-
-	my $default_file = $C->{'<nmis_conf_default>'} . "/Config.nmis";
-	my $site_file = $C->{configfile};
-
-	my $defaults = NMISNG::Util::readFiletoHash(file => $default_file);
-	my $site = NMISNG::Util::readFiletoHash(file => $site_file);
+	loadConfTable(); # ensure loaded
+	my $defaults = $_raw_layers{1} // {};
+	my $site = $_raw_layers{2} // {};
 
 	my %stripped;
 	my @removals;

--- a/lib/NMISNG/Util.pm
+++ b/lib/NMISNG/Util.pm
@@ -78,6 +78,8 @@ our $_config_sources_ref = {};
 our $_config_cache_invalid = 0;
 # Epoch when config was last loaded (not cache hit) — used by configChanged()
 our $_config_load_time = 0;
+# Snapshot of config values before macro expansion — used by getConfDeep/writeConfData
+our $_config_pre_macros = {};
 
 sub TODO
 {
@@ -898,6 +900,9 @@ sub loadConfTable
 	$config_cache->{configfile} = (-r $fn) ? $fn : $default_fn;
 	$cached_configfile_fn = $fn;
 
+	# Snapshot pre-macro values for getConfDeep to use when writing back
+	$NMISNG::Util::_config_pre_macros = { %$config_cache };
+
 	# Replace macros once across entire config
 	$config_cache = replace_macros( config_cache => $config_cache );
 
@@ -1022,8 +1027,9 @@ sub _apply_env_overrides
 
 		warn("ENV $envkey overriding config key '$config_key' from source '$sources->{$config_key}{source}'\n")
 			if (exists $config->{$config_key} && $sources->{$config_key});
+		my $prev_section = $sources->{$config_key} ? $sources->{$config_key}{section} : undef;
 		$config->{$config_key} = $ENV{$envkey};
-		$sources->{$config_key} = { source => "ENV:$envkey", layer => 4, section => undef };
+		$sources->{$config_key} = { source => "ENV:$envkey", layer => 4, section => $prev_section };
 	}
 }
 
@@ -1869,6 +1875,7 @@ sub getConfDeep
 	my %args = @_;
 	my $C = loadConfTable();
 	my $sources = getConfigSources();
+	my $raw = $NMISNG::Util::_config_pre_macros;
 	my %deep;
 
 	for my $k (keys %$C)
@@ -1876,18 +1883,20 @@ sub getConfDeep
 		my $src = $sources->{$k};
 		next unless $src && defined $src->{section};
 
-		# only_local: skip conf.d (layer 3) and ENV (layer 4) keys
-		next if ($args{only_local} && $src->{layer} >= 3);
+		# only_local: only include site config (layer 2) keys
+		next if ($args{only_local} && $src->{layer} != 2);
 
-		$deep{$src->{section}}{$k} = $C->{$k};
+		# Use pre-macro value if available to preserve macro references in written files
+		$deep{$src->{section}}{$k} = exists $raw->{$k} ? $raw->{$k} : $C->{$k};
 	}
 
 	return (\%deep, $C->{configfile});
 }
 
 # Writes config data to conf/Config.nmis, filtering keys by their source:
-# - ENV-sourced keys (layer 4): silently excluded
-# - conf.d-sourced keys (layer 3): error if value changed, silently skipped if unchanged
+# - ENV-sourced keys (layer 4): error if changed, skipped if unchanged
+# - conf.d-sourced keys (layer 3): error if changed, skipped if unchanged
+# - Keys matching defaults (layer 1): skipped (no need to persist)
 # - All other keys: written to conf/Config.nmis
 # If resulting data is empty, backs up and removes the config file.
 # args: data (two-level hashref), required
@@ -1900,8 +1909,13 @@ sub writeConfData
 	my $C = NMISNG::Util::loadConfTable();
 	my $configfile = $C->{configfile};
 	my $sources = NMISNG::Util::getConfigSources();
+	my $raw = $NMISNG::Util::_config_pre_macros;
 
-	# Filter data based on source tracking
+	# Load defaults for comparison
+	my $default_file = $C->{'<nmis_conf_default>'} . "/Config.nmis";
+	my ($defaults, undef) = _load_and_flatten($default_file);
+
+	# Filter data based on source tracking and default comparison
 	my %filtered;
 	for my $section (keys %$CC)
 	{
@@ -1911,14 +1925,19 @@ sub writeConfData
 			my $src = $sources->{$key};
 
 			# ENV-sourced or conf.d-sourced: error if value changed, skip if unchanged
+			# Compare against pre-macro values to avoid false positives from macro expansion
 			if ($src && ($src->{layer} == 3 || $src->{layer} == 4))
 			{
-				if (!_config_values_equal($CC->{$section}{$key}, $C->{$key}))
+				if (!_config_values_equal($CC->{$section}{$key}, $raw->{$key}))
 				{
 					return "Cannot modify property '$key' — it is managed by $src->{source}";
 				}
 				next;
 			}
+
+			# Skip keys whose value matches the default — no need to persist
+			next if ($defaults && exists $defaults->{$key}
+				&& _config_values_equal($CC->{$section}{$key}, $defaults->{$key}));
 
 			$filtered{$section}{$key} = $CC->{$section}{$key};
 		}

--- a/lib/NMISNG/Util.pm
+++ b/lib/NMISNG/Util.pm
@@ -1999,7 +1999,7 @@ sub writeConfData
 	{
 		unlink($configfile) if (-e $configfile);
 		$NMISNG::Util::_config_cache_invalid = 1;
-		_notify_config_changed();
+		_notify_config_changed($C->{'<nmis_var>'});
 		return undef;
 	}
 
@@ -2007,16 +2007,17 @@ sub writeConfData
 	if (!$error)
 	{
 		$NMISNG::Util::_config_cache_invalid = 1;
-		_notify_config_changed();
+		_notify_config_changed($C->{'<nmis_var>'});
 	}
 	return $error;
 }
 
 # Write a marker file so other processes can detect config has changed on disk.
+# args: var_dir (the resolved <nmis_var> path)
 sub _notify_config_changed
 {
-	my $C = loadConfTable();
-	my $dir = $C->{'<nmis_var>'} . "/nmis_system";
+	my ($var_dir) = @_;
+	my $dir = "$var_dir/nmis_system";
 	mkpath($dir, { verbose => 0, mode => 0755 }) if (!-d $dir);
 	my $marker = "$dir/config_changed";
 	open(my $fh, ">", $marker) or do {
@@ -2029,9 +2030,11 @@ sub _notify_config_changed
 
 # Returns true if config on disk has changed since this process loaded it.
 # Processes can poll this to decide whether to restart or reload.
+# args: conf (required, loadConfTable result)
 sub configChanged
 {
-	my $C = loadConfTable();
+	my (%args) = @_;
+	my $C = $args{conf} or return 0;
 	my $marker = $C->{'<nmis_var>'} . "/nmis_system/config_changed";
 	my $mtime = (CORE::stat($marker))[9];
 	return 0 if (!defined $mtime);

--- a/lib/NMISNG/Util.pm
+++ b/lib/NMISNG/Util.pm
@@ -72,6 +72,9 @@ $Data::Dumper::Sortkeys=1;
 
 use NMISNG::Log;					# for parse_debug_level
 
+# Package-level storage for config source tracking (populated by loadConfTable)
+our $_config_sources_ref = {};
+
 sub TODO
 {
 	my (@stuff) = @_;
@@ -762,146 +765,248 @@ sub getServerRole {
 	return $config->{server_role} || "Standalone";
 }
 
-# reads and returns the nmis config file data
-# reads from the given directory or the default one; uses cached data if possible.
-# ATTENTION: no dir argument on a subsequent call means that the PREVIOUS
-# dir and file are checked!
-#
-# attention: this massages in certain values: info, debug  etc!
-# this function must be self-contained, as most stuff in NMISNG::Util:: calls loadconftable
+# Layered configuration loading with source tracking.
+# Loading order: conf-default/Config.nmis -> conf/Config.nmis -> conf/conf.d/*.nmis -> NMIS_* env vars
+# Config is immutable for process lifetime (load-once, no mtime checks).
+# Process restart required to pick up config changes.
 #
 # args: dir, debug (all optional)
 # returns: hash ref, dies (verbosely) on failure
 sub loadConfTable
 {
 	my %args = @_;
-	state ($config_cache);
+	state ($config_cache, $cached_configfile);
 
 	my $dir = $args{dir} || "$FindBin::RealBin/../conf";
-	# abspath and friends don't work properly if the dirs in question don't exist;
 	mkpath($dir, { verbose  => 0, mode => 0755} ) if (!-d $dir);
 
-	my $fn = Cwd::abs_path("$dir/Config.nmis");			# the one and only...
-	# ...but the caller may have given us a dir in a previous call and NONE now
-	# in which case we assume they want the cached goodies, so we look at
-	# the file of the previous call.
-	$fn = $config_cache->{configfile} if (ref($config_cache) eq "HASH"
-																				&& $config_cache->{configfile}
-																				&& !defined $args{dir});
-	my $fallbackfn;								# only set if falling back
-	# Directory for the partial configuration files (From Master)
-	my $partialconf_dir = Cwd::abs_path("$dir/conf.d");
-	my $stat = stat($fn);
-	# try conf-default if that doesn't work
-	if (!$stat)
+	my $fn = Cwd::abs_path("$dir/Config.nmis");
+	# if caller gave us a dir previously but not now, use the cached path
+	$fn = $cached_configfile if ($cached_configfile && !defined $args{dir});
+
+	# return cached config if already loaded for this path
+	if ($config_cache && $cached_configfile && $cached_configfile eq $fn)
 	{
-		$fallbackfn = ($args{dir}?
-									 "$args{dir}/../conf-default/"
-									 : "$FindBin::RealBin/../conf-default/") ."Config.nmis";
-		$stat = stat($fallbackfn);
-	}
-	if (!$stat)
-	{
-		# no config, no hope, no future
-		warn_die("all configuration files ($fn, $fallbackfn) are unreadable: $!");
+		return $config_cache;
 	}
 
-	my $external_files = get_external_files(dir => $partialconf_dir);
+	# --- Layer 1: conf-default/Config.nmis (defaults) ---
+	my $default_dir = $args{dir} ? "$args{dir}/../conf-default" : "$FindBin::RealBin/../conf-default";
+	my $default_fn = Cwd::abs_path("$default_dir/Config.nmis") // "$default_dir/Config.nmis";
 
-	# read the file if not read yet, or different dir requested
-	if ( !$config_cache
-			 or $config_cache->{configfile} ne $fn
-			 or $stat->mtime > $config_cache->{mtime} )
+	$config_cache = {};
+	my $config_sources = {};
+
+	if (-r $default_fn)
 	{
-		$config_cache = {};				# clear it
-		# note: cannot use readfiletohash here: infinite recursion as
-		# most helper functions (have to) call loadConfTable first!
-
-		# lock the file or config writing (which truncates) could cause race conditions
-		my $whichfile = $fallbackfn? $fallbackfn : $fn;
-	
-		$config_cache = read_load_cache(whichfile => $whichfile, cachefile => $config_cache, master => "true", fn => $fn );
-		$stat = stat($fn);
-						 
-		# certain values get massaged in/to the config
-		$config_cache->{conf} = "Config"; # fixme9: this is no longer very useful, only one config supported
-		$config_cache->{auth_require} = 1; # auth_require false is no longer supported
-		# ensure hide_groups is present (saves us checking the ref all over the place)
-		$config_cache->{hide_groups} //= [];
-
-		# fixme9: saving this back is likely a bad idea, config vs. command line
-		# fixme: none of this is nmisng::log compatible, where info is only t/f,
-		# and verbosity is from fatal..info..debug..1-9.
-		my $verbosity = NMISNG::Log::parse_debug_level(debug => $args{debug});
-		$config_cache->{debug} = $verbosity =~ /^(debug|\d)+/? $verbosity : 0;
-		# info is only consulted if debug isn't
-		if (!$config_cache->{debug})
+		my ($flat, $smap) = _load_and_flatten($default_fn);
+		warn_die("configuration file $default_fn unparseable or empty") if (!$flat || !keys %$flat);
+		$config_cache = $flat;
+		for my $k (keys %$flat)
 		{
-			$verbosity = NMISNG::Log::parse_debug_level(debug => $args{info});
-			$config_cache->{info} = $verbosity =~ /^(debug|\d)+/? $verbosity : 0;
+			$config_sources->{$k} = { source => $default_fn, layer => 1, section => $smap->{$k} };
 		}
-
-		$config_cache->{configfile} = $fn; # fixperms also wants that
-		$config_cache->{mtime} = $stat->mtime;
-		# config is loaded, all plain <xyz> -> "static stuff" macros need to be resolved
-		# walk all things in need of macro expansion and fix them up as much as possible each iteration
-		
-		$config_cache = replace_macros( config_cache => $config_cache );
-		# a little safety net (for init/systemd and other stuff that needs to find pidfiles etc):
-		# if the var directory configuration is non-standard,
-		# then maintain a symlink to the configured directory
-		# note: if var is reconfigured back to normal but symlink is correct, then no action is taken
-		my $confdvar = $config_cache->{'<nmis_var>'};
-		my @confdstat = (CORE::stat($confdvar))[0,1]; # device and inode
-		my $normalvar = "$config_cache->{'<nmis_base>'}/var";
-		my @normalstat = (CORE::stat($normalvar))[0,1]; # device and inode
-
-		if (-d $confdvar and ($confdstat[0] != $normalstat[0]
-													or $confdstat[1] != $normalstat[1]))
-		{
-			rename($normalvar, "$normalvar.deconfigured.$$") if (-e $normalvar);
-			symlink($confdvar, $normalvar)
-					or warn_die("cannot symlink $normalvar to configured $confdvar: $!");
-		}
-		
-	} else {
-		#warn("\n>>> Reading cache");
 	}
-	
-	if (scalar @$external_files > 0)
+
+	# --- Layer 2: conf/Config.nmis (site config) ---
+	if (-r $fn && $fn ne $default_fn)
 	{
-		# Now that we finish loading all the values, lets load overriding partial files
-		# conf.d directory
-		my $properties = properties_never_override();	
-		foreach (@$external_files) {
-			my $stat = stat($_);
-			if ($stat->mtime > $config_cache->{@_}) {
-				my $local_config_cache;
-				push @{$config_cache->{configpeerfiles}}, $_;
-				$local_config_cache = read_load_cache(whichfile => $_, cachefile => $local_config_cache, master => 0, fn => $_ );	
-				# Merge with local cache
-				while ( my ($k,$v) = each(%{$local_config_cache}) ) {
-					# Never let the master change this value(s)
-					next if ( grep( /^$k$/, @$properties ));
-					$config_cache->{$k} = $v;
-				}
-				$config_cache = replace_macros( config_cache => $config_cache );
-				$config_cache->{@_} = $stat->mtime; # remember
+		my ($flat, $smap) = _load_and_flatten($fn);
+		if ($flat && keys %$flat)
+		{
+			_merge_full($config_cache, $flat);
+			for my $k (keys %$flat)
+			{
+				$config_sources->{$k} = { source => $fn, layer => 2, section => $smap->{$k} };
 			}
 		}
 	}
+	elsif (!-r $fn && !keys %$config_cache)
+	{
+		warn_die("all configuration files ($fn, $default_fn) are unreadable: $!");
+	}
 
-	$config_cache->{db_username} = $ENV{NMIS_DB_USERNAME} if(defined($ENV{NMIS_DB_USERNAME}));
-	$config_cache->{db_password} = $ENV{NMIS_DB_PASSWORD} if(defined($ENV{NMIS_DB_PASSWORD}));
-	$config_cache->{db_server} = $ENV{NMIS_DB_SERVER} if(defined($ENV{NMIS_DB_SERVER}));
-	$config_cache->{server_name} = $ENV{NMIS_SERVER_NAME} if(defined($ENV{NMIS_SERVER_NAME}));
-	$config_cache->{cluster_id} = $ENV{NMIS_CLUSTER_ID} if(defined($ENV{NMIS_CLUSTER_ID}));
-	$config_cache->{'<cgi_url_base>'} = $ENV{NMIS_URL_BASE} if(defined($ENV{NMIS_URL_BASE}));
+	# --- Layer 3: conf/conf.d/*.nmis (fragments, override-only) ---
+	my $partialconf_dir = Cwd::abs_path("$dir/conf.d");
+	my $external_files = get_external_files(dir => $partialconf_dir);
+	for my $extfile (@$external_files)
+	{
+		my ($flat, $smap) = _load_and_flatten($extfile);
+		next if (!$flat || !keys %$flat);
+		my $changed = _merge_override($config_cache, $flat);
+		for my $k (@$changed)
+		{
+			$config_sources->{$k} = { source => $extfile, layer => 3, section => $smap->{$k} };
+		}
+	}
+
+	# --- Layer 4: Environment variables (NMIS_*) ---
+	_apply_env_overrides($config_cache, $config_sources);
+
+	# --- Post-merge processing ---
+	# Hardcoded values
+	$config_cache->{conf} = "Config";
+	$config_sources->{conf} = { source => "hardcoded", layer => 0, section => undef };
+	$config_cache->{auth_require} = 1;
+	$config_sources->{auth_require} = { source => "hardcoded", layer => 0, section => undef };
+	$config_cache->{hide_groups} //= [];
+
+	# Parse debug/info from args
+	my $verbosity = NMISNG::Log::parse_debug_level(debug => $args{debug});
+	$config_cache->{debug} = $verbosity =~ /^(debug|\d)+/? $verbosity : 0;
+	if (!$config_cache->{debug})
+	{
+		$verbosity = NMISNG::Log::parse_debug_level(debug => $args{info});
+		$config_cache->{info} = $verbosity =~ /^(debug|\d)+/? $verbosity : 0;
+	}
+
+	# Set configfile key (points to conf/Config.nmis or fallback)
+	$config_cache->{configfile} = (-r $fn) ? $fn : $default_fn;
+	$cached_configfile = $fn;
+
+	# Replace macros once across entire config
+	$config_cache = replace_macros( config_cache => $config_cache );
+
+	# Var directory symlink management
+	my $confdvar = $config_cache->{'<nmis_var>'};
+	my @confdstat = (CORE::stat($confdvar))[0,1];
+	my $normalvar = "$config_cache->{'<nmis_base>'}/var";
+	my @normalstat = (CORE::stat($normalvar))[0,1];
+
+	if (-d $confdvar and ($confdstat[0] != $normalstat[0]
+												or $confdstat[1] != $normalstat[1]))
+	{
+		rename($normalvar, "$normalvar.deconfigured.$$") if (-e $normalvar);
+		symlink($confdvar, $normalvar)
+				or warn_die("cannot symlink $normalvar to configured $confdvar: $!");
+	}
+
+	# Cluster ID: if missing, generate UUID and write to conf/conf.d/system.nmis
+	if (!$config_cache->{cluster_id})
+	{
+		$config_cache->{cluster_id} = create_uuid_as_string(UUID_RANDOM);
+		$config_sources->{cluster_id} = { source => "generated", layer => 0, section => "id" };
+		_write_cluster_id_to_confd($dir, $config_cache->{cluster_id});
+	}
+
+	# Store sources in package variable for getConfigSources access
+	$NMISNG::Util::_config_sources_ref = $config_sources;
 
 	return $config_cache;
 }
 
-# Get external configuration files
+# Returns source tracking info for config keys.
+# args: optional key => "keyname" to get info for a single key
+# returns: hashref of { key => { source, layer, section } } or single key's info
+sub getConfigSources
+{
+	my %args = @_;
+	my $sources = $NMISNG::Util::_config_sources_ref // {};
+	if (defined $args{key})
+	{
+		return $sources->{$args{key}};
+	}
+	return $sources;
+}
+
+# Load a .nmis config file and flatten its two-level hash to a single level.
+# Returns: ($flattened_hashref, $section_map_hashref) where section_map maps each key to its section name
+sub _load_and_flatten
+{
+	my ($filepath) = @_;
+	my %deepdata = do($filepath);
+	if ($@)
+	{
+		warn("configuration file $filepath unparseable: $@");
+		return (undef, undef);
+	}
+	if (!%deepdata)
+	{
+		# do() might return empty list on certain errors
+		warn("configuration file $filepath returned no data");
+		return (undef, undef);
+	}
+
+	my %flat;
+	my %section_map;
+	for my $section (keys %deepdata)
+	{
+		if (ref($deepdata{$section}) eq 'HASH')
+		{
+			for my $k (keys %{$deepdata{$section}})
+			{
+				$flat{$k} = $deepdata{$section}{$k};
+				$section_map{$k} = $section;
+			}
+		}
+	}
+	return (\%flat, \%section_map);
+}
+
+# Full merge: copies all keys from overlay into base (add + override)
+sub _merge_full
+{
+	my ($base, $overlay) = @_;
+	for my $k (keys %$overlay)
+	{
+		$base->{$k} = $overlay->{$k};
+	}
+}
+
+# Override-only merge: only replaces keys that already exist in base
+# Returns: arrayref of keys that were actually overridden
+sub _merge_override
+{
+	my ($base, $overlay) = @_;
+	my @changed;
+	for my $k (keys %$overlay)
+	{
+		if (exists $base->{$k})
+		{
+			$base->{$k} = $overlay->{$k};
+			push @changed, $k;
+		}
+	}
+	return \@changed;
+}
+
+# Scan %ENV for NMIS_* variables and apply as override-only to config
+sub _apply_env_overrides
+{
+	my ($config, $sources) = @_;
+
+	for my $envkey (keys %ENV)
+	{
+		next unless $envkey =~ /^NMIS_(.+)$/;
+		my $suffix = lc($1);
+		my $config_key = exists $config->{$suffix} ? $suffix : "<$suffix>";
+
+		if (exists $config->{$config_key})
+		{
+			$config->{$config_key} = $ENV{$envkey};
+			$sources->{$config_key} = { source => "ENV:$envkey", layer => 4, section => undef };
+		}
+	}
+}
+
+# Write cluster_id to conf/conf.d/system.nmis
+sub _write_cluster_id_to_confd
+{
+	my ($conf_dir, $cluster_id) = @_;
+	my $confd_dir = "$conf_dir/conf.d";
+	mkpath($confd_dir, { verbose => 0, mode => 0755 }) if (!-d $confd_dir);
+
+	my $system_file = "$confd_dir/system.nmis";
+	my %data = ( 'id' => { 'cluster_id' => $cluster_id } );
+	open(my $fh, ">", $system_file) or do {
+		warn("cannot write cluster_id to $system_file: $!");
+		return;
+	};
+	print $fh Data::Dumper->Dump([\%data], [qw(*hash)]);
+	close $fh;
+}
+
+# Get external configuration files (sorted for deterministic merge order)
 sub get_external_files
 {
 	my %args = @_;
@@ -913,71 +1018,15 @@ sub get_external_files
 			# Only .nmis files
 			next unless ($filename =~ m/\.nmis$/);
 			my $path = $dir . "/" . $filename;
-			push @files, $path; 
+			push @files, $path;
 		}
 		closedir(DIR);
 	}
+	@files = sort @files;
 	return \@files;
 }
 
-# Read a configuration file, block and load cache
-sub read_load_cache
-{
-	my %args = @_;
-	my $whichfile = $args{whichfile};
-	my $config_cache = $args{cachefile};
-	my $is_master = $args{master};
-	my $fn = $args{fn};
-
-	open(X, $whichfile) or warn_die("cannot open configuration file $whichfile: $!") if $is_master;
-	flock(X, LOCK_SH) or warn_die("cannot lock configuration file $whichfile: $!") if $is_master;
-
-	my %deepdata = do ($whichfile);
-	# should the file have unwanted gunk after the %hash = ();
-	# it'll most likely be a '1;' and do returns the last statement result...
-	if ($@)
-	{
-		my $nmisng = Compat::NMIS::new_nmisng();
-		$nmisng->log->info(&NMISNG::Log::trace()." MAKERRDNAME") if ($nmisng);
-		warn_die("configuration file $fn unparseable: $@ $is_master") if $is_master;
-		warn(">> configuration file $fn unparseable: $@");
-		close(X);	
-	}
-	elsif (keys %deepdata < 2 and $is_master)
-	{
-		my $nmisng = Compat::NMIS::new_nmisng();
-		$nmisng->log->info(&NMISNG::Log::trace()." MAKERRDNAME");
-		warn_die("configuration $whichfile does not have enough depth, only ". (scalar keys %deepdata). " entries!") if $is_master;
-	} else {
-		close(X);	
-		# strip the outer of two levels, does not flatten any deeper structure
-		for my $k (keys %deepdata)
-		{
-			for my $kk (keys %{$deepdata{$k}})
-			{
-				warn("Config section \"$k\" contains clashing config entry \"$kk\"!\n")
-						if (defined($config_cache->{$kk})); # not terminal
-				$config_cache->{$kk} = $deepdata{$k}->{$kk};
-			}
-		}
-		
-		# this one is vital for NMIS9 in particular: the cluster_id must be unique AND not change
-		if (!$config_cache->{cluster_id} && $is_master && !$ENV{NMIS_CLUSTER_ID})
-		{
-			$deepdata{id}->{cluster_id} = $config_cache->{cluster_id} = create_uuid_as_string(UUID_RANDOM);
-			# and write back the updated config file - cannot use writehashtofile yet!
-			open(F, (-e $fn? "+<": ">"), $fn) or warn_die("cannot write configuration file $fn: $!");
-			seek(F,0,0);							# only relevant when opening existing file
-			truncate(F,0);						# ditto
-			flock(F, LOCK_EX) or warn_die("cannot lock configuration file $fn: $!");
-			print F Data::Dumper->Dump([\%deepdata], [qw(*hash)]);
-			close F;									# which unlocks
-			# and restat to get the new mtime
-		}
-	}
-	
-	return $config_cache;
-}
+# read_load_cache has been replaced by _load_and_flatten
 
 # small helper function that is going to replace macros
 # args: error message
@@ -1765,15 +1814,6 @@ sub getdebug_cli
 	return ((defined($val)) ? (($val =~ /(^true$)|(^yes$)|(^t$)|(^y$)|(^1$)/i) ? 1 : (($val =~ /(^false$)|(^no$)|(^f$)|(^n$)|(^0$)/i) ? 0 : (($val =~ /^verbose$/i) ? 9 : (($val =~ /^[0-9]$/) ? $val : die "Invalid debug value: '$val'\n" )))) : 0);
 }
 
-# Send an array with the properties never overrided by the conf master files
-# Hardcoded as we dont want them to be overrided
-# Could be a mess
-sub properties_never_override
-{
-	my @properties = ('cluster_id', 'server_name', 'nmis_host');
-	return \@properties;
-}
-
 # trivial wrapper around readfiletohash
 # difference to loadConfTable: loadconftable flattens and adds a few entries
 # args: only_local eq 1 loads only local config (Not by default)
@@ -1785,11 +1825,10 @@ sub readConfData
 
 	my $C = loadConfTable;
 	my $fn = $C->{configfile};
-	
+
 	my $rawdata = NMISNG::Util::readFiletoHash(file => $fn);
 
-	my $fnp = $C->{configpeerfiles};
-	if (defined($args{log})) 
+	if (defined($args{log}))
 	{
 		$logger = $args{log};
 	}
@@ -1798,15 +1837,19 @@ sub readConfData
 		my $nmisng = Compat::NMIS::new_nmisng();
 		$logger  = $nmisng->log;
 	}
-	
+
 	if ($args{only_local} ne 1)
 	{
-		$logger->info("Reading config properties from master. ");
+		$logger->info("Reading config properties from conf.d files. ");
+		# Determine conf.d directory from the configfile path
+		my $conf_dir = File::Basename::dirname($fn);
+		my $confd_dir = "$conf_dir/conf.d";
+		my $confd_files = get_external_files(dir => $confd_dir);
 		eval {
-			foreach ( @{$fnp} ) {
-			
+			foreach ( @$confd_files ) {
+
 				my $rawpartialdata = NMISNG::Util::readFiletoHash(file => $_);
-		
+
 				# strip the outer of two levels, does not flatten any deeper structure
 				# merge
 				for my $k (keys %{$rawpartialdata})
@@ -1815,8 +1858,7 @@ sub readConfData
 					{
 						if (ref($rawpartialdata->{$k}->{$kk}) ne "HASH" )
 						{
-							next if (grep( /^$kk$/, properties_never_override()));
-							$rawdata->{$k}->{$kk} =$rawpartialdata->{$k}->{$kk};
+							$rawdata->{$k}->{$kk} = $rawpartialdata->{$k}->{$kk};
 						}
 						else
 						{

--- a/lib/NMISNG/Util.pm
+++ b/lib/NMISNG/Util.pm
@@ -1904,10 +1904,13 @@ sub readConfData
 	return ($rawdata, $fn);
 }
 
-# trivial wrapper around writeHashtoFile
-# If data is empty (no keys or all sections empty), backs up and removes the config file.
-# args: data, required
-# returns: undef or error message
+# Writes config data to conf/Config.nmis, filtering keys by their source:
+# - ENV-sourced keys (layer 4): silently excluded
+# - conf.d-sourced keys (layer 3): error if value changed, silently skipped if unchanged
+# - All other keys: written to conf/Config.nmis
+# If resulting data is empty, backs up and removes the config file.
+# args: data (two-level hashref), required
+# returns: undef on success, or error message string
 sub writeConfData
 {
 	my %args = @_;
@@ -1915,32 +1918,46 @@ sub writeConfData
 
 	my $C = NMISNG::Util::loadConfTable();
 	my $configfile = $C->{configfile};
+	my $sources = NMISNG::Util::getConfigSources();
 
-	# save old one
-	File::Copy::cp($configfile, "$configfile.bak") # this overwrites any existing backup file
-			if (-r "$configfile");
-
-	# If data has no meaningful keys, remove the config file instead of writing an empty one
-	my $has_keys = 0;
-	if (ref($CC) eq 'HASH')
+	# Filter data based on source tracking
+	my %filtered;
+	for my $section (keys %$CC)
 	{
-		for my $section (keys %$CC)
+		next unless ref($CC->{$section}) eq 'HASH';
+		for my $key (keys %{$CC->{$section}})
 		{
-			if (ref($CC->{$section}) eq 'HASH' && keys %{$CC->{$section}})
+			my $src = $sources->{$key};
+
+			# ENV-sourced: skip silently
+			next if ($src && $src->{layer} == 4);
+
+			# conf.d-sourced: error if value changed, skip if unchanged
+			if ($src && $src->{layer} == 3)
 			{
-				$has_keys = 1;
-				last;
+				if (!_config_values_equal($CC->{$section}{$key}, $C->{$key}))
+				{
+					return "Cannot modify property '$key' — it is managed by conf.d file $src->{source}";
+				}
+				next;
 			}
+
+			$filtered{$section}{$key} = $CC->{$section}{$key};
 		}
 	}
 
+	# Backup
+	File::Copy::cp($configfile, "$configfile.bak") if (-r "$configfile");
+
+	# If no keys remain, remove the config file
+	my $has_keys = grep { ref($filtered{$_}) eq 'HASH' && keys %{$filtered{$_}} } keys %filtered;
 	if (!$has_keys)
 	{
 		unlink($configfile) if (-e $configfile);
 		return undef;
 	}
 
-	return NMISNG::Util::writeHashtoFile(file=>$configfile, data=>$CC);
+	return NMISNG::Util::writeHashtoFile(file => $configfile, data => \%filtered);
 }
 
 # Compare conf/Config.nmis against conf-default/Config.nmis and return

--- a/lib/NMISNG/Util.pm
+++ b/lib/NMISNG/Util.pm
@@ -76,6 +76,8 @@ use NMISNG::Log;					# for parse_debug_level
 our $_config_sources_ref = {};
 # Set to 1 to force loadConfTable to reload on next call
 our $_config_cache_invalid = 0;
+# Epoch when config was last loaded (not cache hit) — used by configChanged()
+our $_config_load_time = 0;
 
 sub TODO
 {
@@ -923,6 +925,7 @@ sub loadConfTable
 
 	# Store sources in package variable for getConfigSources access
 	$NMISNG::Util::_config_sources_ref = $config_sources;
+	$NMISNG::Util::_config_load_time = time();
 
 	return $config_cache;
 }
@@ -1930,12 +1933,43 @@ sub writeConfData
 	{
 		unlink($configfile) if (-e $configfile);
 		$NMISNG::Util::_config_cache_invalid = 1;
+		_notify_config_changed();
 		return undef;
 	}
 
 	my $error = NMISNG::Util::writeHashtoFile(file => $configfile, data => \%filtered);
-	$NMISNG::Util::_config_cache_invalid = 1 if (!$error);
+	if (!$error)
+	{
+		$NMISNG::Util::_config_cache_invalid = 1;
+		_notify_config_changed();
+	}
 	return $error;
+}
+
+# Write a marker file so other processes can detect config has changed on disk.
+sub _notify_config_changed
+{
+	my $C = loadConfTable();
+	my $dir = $C->{'<nmis_var>'} . "/nmis_system";
+	mkpath($dir, { verbose => 0, mode => 0755 }) if (!-d $dir);
+	my $marker = "$dir/config_changed";
+	open(my $fh, ">", $marker) or do {
+		warn("cannot write config change marker $marker: $!");
+		return;
+	};
+	print $fh time() . "\n";
+	close $fh;
+}
+
+# Returns true if config on disk has changed since this process loaded it.
+# Processes can poll this to decide whether to restart or reload.
+sub configChanged
+{
+	my $C = loadConfTable();
+	my $marker = $C->{'<nmis_var>'} . "/nmis_system/config_changed";
+	my $mtime = (CORE::stat($marker))[9];
+	return 0 if (!defined $mtime);
+	return ($mtime > $NMISNG::Util::_config_load_time) ? 1 : 0;
 }
 
 # Compare conf/Config.nmis against conf-default/Config.nmis and return

--- a/lib/NMISNG/Util.pm
+++ b/lib/NMISNG/Util.pm
@@ -940,17 +940,26 @@ sub loadConfTable
 				or warn_die("cannot symlink $normalvar to configured $confdvar: $!");
 	}
 
+	# Store sources in package variable for getConfigSources access
+	# (must happen before cluster_id block so writeConfData/getConfDeep can work)
+	$NMISNG::Util::_config_sources_ref = $config_sources;
+	$NMISNG::Util::_config_load_time = time();
+
 	# Cluster ID: if missing, generate UUID and write to conf/Config.nmis
 	if (!$config_cache->{cluster_id})
 	{
 		$config_cache->{cluster_id} = create_uuid_as_string(UUID_RANDOM);
 		$config_sources->{cluster_id} = { source => $config_cache->{configfile}, layer => 2, section => "id" };
-		_write_cluster_id_to_config($config_cache->{configfile}, $config_cache->{cluster_id});
+		# Add to raw layer 2 so getConfDeep includes it
+		$_raw_layers{2} //= {};
+		$_raw_layers{2}{id}{cluster_id} = $config_cache->{cluster_id};
+		# Write through the standard config pipeline
+		my ($deep, undef) = getConfDeep();
+		my $error = writeConfData(data => $deep);
+		warn("cannot persist cluster_id: $error") if $error;
+		# writeConfData invalidates cache, but we're still building it — clear the flag
+		$NMISNG::Util::_config_cache_invalid = 0;
 	}
-
-	# Store sources in package variable for getConfigSources access
-	$NMISNG::Util::_config_sources_ref = $config_sources;
-	$NMISNG::Util::_config_load_time = time();
 
 	return $config_cache;
 }
@@ -1077,26 +1086,6 @@ sub _apply_env_overrides
 	}
 }
 
-# Write cluster_id to conf/Config.nmis (reads existing content, merges, writes back)
-sub _write_cluster_id_to_config
-{
-	my ($configfile, $cluster_id) = @_;
-	my %data;
-	if (-r $configfile)
-	{
-		%data = do($configfile);
-		%data = () if ($@ || !%data);
-	}
-	$data{id}{cluster_id} = $cluster_id;
-
-	open(my $fh, ">", $configfile) or do {
-		warn("cannot write cluster_id to $configfile: $!");
-		return;
-	};
-	flock($fh, LOCK_EX) or warn("cannot lock $configfile: $!");
-	print $fh Data::Dumper->Dump([\%data], [qw(*hash)]);
-	close $fh;
-}
 
 # Get external configuration files (sorted for deterministic merge order)
 sub get_external_files
@@ -1588,7 +1577,33 @@ sub getModelFile
 }
 
 
+# Write formatted data to an open file handle.
+# Returns undef on success, error message on failure.
+sub _write_data_to_handle
+{
+	my ($fh, $data, $filename, $useJson, $pretty) = @_;
+	if ($useJson && $pretty)
+	{
+		# make sure that all json files contain valid utf8-encoded json, as required by rfc7159
+		return "cannot write data object to file $filename: $!"
+			unless print $fh JSON::XS->new->utf8(1)->pretty(1)->encode($data);
+	}
+	elsif ($useJson)
+	{
+		# encode_json already ensures utf8-encoded json
+		eval { print $fh encode_json($data) };
+		return "cannot write data object to $filename: $@" if $@;
+	}
+	else
+	{
+		return "cannot write to file $filename: $!"
+			unless print $fh Data::Dumper->Dump([$data], [qw(*hash)]);
+	}
+	return undef;
+}
+
 # write hash data to file in suitable format
+# Uses atomic write (temp file + rename) to prevent 0-length files on disk-full or crash.
 # returns: undef or error message
 sub writeHashtoFile
 {
@@ -1626,51 +1641,61 @@ sub writeHashtoFile
 
 	if ($handle eq "")
 	{
-		if (open($handle, "+<$file"))
-		{
-			flock($handle, LOCK_EX) or return("writeHashtoFile: can't lock $file: $!");
+		# --- Atomic write path: write to temp file, then rename over target ---
+		my $tmpfile = "$file.tmp.$$";
 
-			seek($handle,0,0) or return("writeHashtoFile: can't seek in $file: $!");
-			truncate($handle,0) or return("writeHashtoFileL can't truncate $file: $!");
+		# Lock target file for mutual exclusion (don't truncate it)
+		my $lockhandle;
+		if (-e $file)
+		{
+			open($lockhandle, "+<", $file)
+				or return("writeHashtoFile: cannot open $file for locking: $!");
 		}
 		else
 		{
-			open($handle, ">$file")  or return("writeHashtoFile: cannot write to $file: $!\n");
-			flock($handle, LOCK_EX) or return("writeHashtoFile: can't lock file $file: $!\n");
+			open($lockhandle, ">", $file)
+				or return("writeHashtoFile: cannot create $file for locking: $!");
 		}
+		flock($lockhandle, LOCK_EX)
+			or return("writeHashtoFile: can't lock $file: $!");
+
+		# Write to temp file in same directory (ensures same filesystem for atomic rename)
+		open(my $tmphandle, ">", $tmpfile)
+			or do { close($lockhandle);
+					return("writeHashtoFile: cannot create temp file $tmpfile: $!"); };
+
+		my $errormsg = _write_data_to_handle($tmphandle, $data, $file, $useJson, $pretty);
+
+		# close flushes buffers — check for write errors (e.g. disk full)
+		if (!close($tmphandle) && !$errormsg)
+		{
+			$errormsg = "cannot close temp file $tmpfile: $!";
+		}
+
+		if ($errormsg)
+		{
+			unlink($tmpfile);
+			close($lockhandle);
+			return("writeHashtoFile: $errormsg");
+		}
+
+		# Atomic replace: rename is atomic on POSIX within same filesystem
+		rename($tmpfile, $file)
+			or do { unlink($tmpfile); close($lockhandle);
+					return("writeHashtoFile: cannot rename $tmpfile to $file: $!"); };
+
+		close($lockhandle);
 	}
 	else
 	{
-		seek($handle,0,0) or return("writeHashtoFile: can't seek in $file: $!");
-		truncate($handle,0) or return("writeHashtoFile: can't truncate $file: $!");
-	}
+		# --- Legacy handle path: caller manages locking ---
+		seek($handle, 0, 0) or return("writeHashtoFile: can't seek in $file: $!");
+		truncate($handle, 0) or return("writeHashtoFile: can't truncate $file: $!");
 
-	# write out the data, but defer error reporting until after the lock is released
-	my $errormsg;
-	if ( $useJson and $pretty )
-	{
-		# make sure that all json files contain valid utf8-encoded json, as required by rfc7159
-		if ( not print $handle JSON::XS->new->utf8(1)->pretty(1)->encode($data) )
-		{
-			$errormsg = "cannot write data object to file $file: $!";
-		}
+		my $errormsg = _write_data_to_handle($handle, $data, $file, $useJson, $pretty);
+		close $handle;
+		return("writeHashtoFile: $errormsg") if ($errormsg);
 	}
-	elsif ( $useJson )
-	{
-		# encode_json already ensures utf8-encoded json
-		eval { print $handle encode_json($data) } ;
-		if ( $@ ) {
-			$errormsg = "cannot write data object to $file: $@";
-		}
-	}
-	elsif ( not print $handle Data::Dumper->Dump([$data], [qw(*hash)]) ) {
-		$errormsg = "cannot write to file $file: $!";
-	}
-	close $handle;
-
-	# now it's safe to handle the error
-	return("writeHashtoFile: $errormsg")
-			if ($errormsg);
 
 	if (my $error = NMISNG::Util::setFileProtDiag(file =>$file, conf => $C))
 	{

--- a/lib/NMISNG/Util.pm
+++ b/lib/NMISNG/Util.pm
@@ -797,6 +797,10 @@ sub loadConfTable
 	$config_cache = {};
 	my $config_sources = {};
 
+	# Properties that may only be defined in one non-default config file
+	my @exclusive_keys = ('cluster_id', 'server_name', 'nmis_host');
+	my %exclusive_source;
+
 	if (-r $default_fn)
 	{
 		my ($flat, $smap) = _load_and_flatten($default_fn);
@@ -814,10 +818,15 @@ sub loadConfTable
 		my ($flat, $smap) = _load_and_flatten($fn);
 		if ($flat && keys %$flat)
 		{
-			_merge_full($config_cache, $flat);
+			_merge_config($config_cache, $flat, 0);
 			for my $k (keys %$flat)
 			{
 				$config_sources->{$k} = { source => $fn, layer => 2, section => $smap->{$k} };
+			}
+			# Track exclusive keys claimed by site config
+			for my $ek (@exclusive_keys)
+			{
+				$exclusive_source{$ek} = $fn if (exists $flat->{$ek});
 			}
 		}
 	}
@@ -833,7 +842,25 @@ sub loadConfTable
 	{
 		my ($flat, $smap) = _load_and_flatten($extfile);
 		next if (!$flat || !keys %$flat);
-		my $changed = _merge_override($config_cache, $flat);
+
+		# Enforce exclusive keys: skip if already defined by an earlier non-default file
+		for my $ek (@exclusive_keys)
+		{
+			if (exists $flat->{$ek})
+			{
+				if (exists $exclusive_source{$ek})
+				{
+					warn("Exclusive property '$ek' in $extfile ignored — already defined in $exclusive_source{$ek}\n");
+					delete $flat->{$ek};
+				}
+				else
+				{
+					$exclusive_source{$ek} = $extfile;
+				}
+			}
+		}
+
+		my $changed = _merge_config($config_cache, $flat, 1);
 		for my $k (@$changed)
 		{
 			$config_sources->{$k} = { source => $extfile, layer => 3, section => $smap->{$k} };
@@ -841,7 +868,7 @@ sub loadConfTable
 	}
 
 	# --- Layer 4: Environment variables (NMIS_*) ---
-	_apply_env_overrides($config_cache, $config_sources);
+	_apply_env_overrides($config_cache, $config_sources, \@exclusive_keys, \%exclusive_source);
 
 	# --- Post-merge processing ---
 	# Hardcoded values
@@ -943,49 +970,52 @@ sub _load_and_flatten
 	return (\%flat, \%section_map);
 }
 
-# Full merge: copies all keys from overlay into base (add + override)
-sub _merge_full
+# Merge overlay keys into base.
+# If override_only is true, only replaces keys that already exist in base.
+# Returns: arrayref of keys that were actually set.
+sub _merge_config
 {
-	my ($base, $overlay) = @_;
-	for my $k (keys %$overlay)
-	{
-		$base->{$k} = $overlay->{$k};
-	}
-}
-
-# Override-only merge: only replaces keys that already exist in base
-# Returns: arrayref of keys that were actually overridden
-sub _merge_override
-{
-	my ($base, $overlay) = @_;
+	my ($base, $overlay, $override_only) = @_;
 	my @changed;
 	for my $k (keys %$overlay)
 	{
-		if (exists $base->{$k})
-		{
-			$base->{$k} = $overlay->{$k};
-			push @changed, $k;
-		}
+		next if ($override_only && !exists $base->{$k});
+		$base->{$k} = $overlay->{$k};
+		push @changed, $k;
 	}
 	return \@changed;
 }
 
-# Scan %ENV for NMIS_* variables and apply as override-only to config
+# Scan %ENV for NMIS_* variables and apply to config (can override or add new keys)
+# Exclusive keys are enforced if exclusive_keys/exclusive_source are provided.
 sub _apply_env_overrides
 {
-	my ($config, $sources) = @_;
+	my ($config, $sources, $exclusive_keys, $exclusive_source) = @_;
 
 	for my $envkey (keys %ENV)
 	{
 		next unless $envkey =~ /^NMIS_(.+)$/;
 		my $suffix = lc($1);
-		my $config_key = exists $config->{$suffix} ? $suffix : "<$suffix>";
+		# Resolution: plain key if exists, then <angle_bracket> if exists, otherwise plain key (new)
+		my $config_key = exists $config->{$suffix} ? $suffix
+			: exists $config->{"<$suffix>"} ? "<$suffix>"
+			: $suffix;
 
-		if (exists $config->{$config_key})
+		# Enforce exclusive keys
+		if ($exclusive_keys && grep { $_ eq $config_key } @$exclusive_keys)
 		{
-			$config->{$config_key} = $ENV{$envkey};
-			$sources->{$config_key} = { source => "ENV:$envkey", layer => 4, section => undef };
+			if ($exclusive_source && exists $exclusive_source->{$config_key})
+			{
+				warn("Exclusive property '$config_key' from ENV:$envkey ignored — already defined in $exclusive_source->{$config_key}\n");
+				next;
+			}
+			$exclusive_source->{$config_key} = "ENV:$envkey" if $exclusive_source;
 		}
+
+		warn("ENV $envkey overriding config key '$config_key' from source '$sources->{$config_key}{source}'\n")
+			if (exists $config->{$config_key} && $sources->{$config_key});
+		$config->{$config_key} = $ENV{$envkey};
+		$sources->{$config_key} = { source => "ENV:$envkey", layer => 4, section => undef };
 	}
 }
 

--- a/lib/NMISx.pm
+++ b/lib/NMISx.pm
@@ -9,7 +9,7 @@ sub startup {
 
   my $url_base = "/cgi-nmis9";
   #Overide the config 
-  $ENV{NMIS_URL_BASE} = $url_base;
+  $ENV{NMIS_CGI_URL_BASE} = $url_base;
 
   $self->plugin(CGI => [ "$url_base/nmiscgi.pl" => "/usr/local/nmis9/cgi-bin/nmiscgi.pl" ]);
 

--- a/test/t_nmis_config.pl
+++ b/test/t_nmis_config.pl
@@ -349,6 +349,28 @@ is($confd_unchanged_test, "OK", "writeConfData skips unchanged conf.d keys witho
     rename(\$bak, \$C->{configfile}) if -e \$bak;
 ' 2>/dev/null`;
 
+# --- Test 21: configChanged returns false when no change has occurred ---
+my $no_change_test = `perl -I$FindBin::Bin/../lib -e '
+    use NMISNG::Util;
+    my \$C = NMISNG::Util::loadConfTable();
+    print NMISNG::Util::configChanged() ? "CHANGED" : "OK";
+' 2>/dev/null`;
+is($no_change_test, "OK", "configChanged returns false when no change has occurred");
+
+# --- Test 22: configChanged returns true after another process writes config ---
+my $change_test = `perl -I$FindBin::Bin/../lib -e '
+    use NMISNG::Util;
+    my \$C = NMISNG::Util::loadConfTable();
+    # Simulate another process writing the marker in the future
+    sleep(1);
+    my \$marker = \$C->{"<nmis_var>"} . "/nmis_system/config_changed";
+    open(my \$fh, ">", \$marker) or die "cannot write marker: \$!";
+    print \$fh time() . "\n";
+    close \$fh;
+    print NMISNG::Util::configChanged() ? "CHANGED" : "FAIL";
+' 2>/dev/null`;
+is($change_test, "CHANGED", "configChanged returns true after marker is updated");
+
 # Cleanup
 unlink $test_file;
 

--- a/test/t_nmis_config.pl
+++ b/test/t_nmis_config.pl
@@ -280,22 +280,17 @@ my $env_new_key_test = `NMIS_BRAND_NEW_TEST_KEY=hello perl -I$FindBin::Bin/../li
 ' 2>/dev/null`;
 is($env_new_key_test, "hello", "ENV can add new keys not in config");
 
-# --- Test 17: writeConfData excludes ENV-sourced keys from written file ---
+# --- Test 17: writeConfData returns error for modified ENV-sourced key ---
 my $env_write_test = `NMIS_DB_SERVER=envhost perl -I$FindBin::Bin/../lib -e '
     use NMISNG::Util;
     my \$C = NMISNG::Util::loadConfTable();
     my (\$rawdata, \$fn) = NMISNG::Util::readConfData(only_local => 1);
+    # Change the ENV-managed key to a different value
+    \$rawdata->{database}{db_server} = "changed_host";
     my \$error = NMISNG::Util::writeConfData(data => \$rawdata);
-    die "writeConfData failed: \$error" if \$error;
-    # Read back the written file and check db_server is not in it
-    my \$written = NMISNG::Util::readFiletoHash(file => \$C->{configfile});
-    my \$found = 0;
-    for my \$s (keys %\$written) {
-        \$found = 1 if ref(\$written->{\$s}) eq "HASH" && exists \$written->{\$s}{db_server};
-    }
-    print \$found ? "FOUND" : "EXCLUDED";
+    print defined(\$error) ? "ERROR:\$error" : "OK";
 ' 2>/dev/null`;
-is($env_write_test, "EXCLUDED", "writeConfData excludes ENV-sourced keys from written file");
+like($env_write_test, qr/ERROR:.*db_server/, "writeConfData returns error for modified ENV-sourced key");
 
 # --- Test 18: writeConfData returns error for modified conf.d key ---
 {

--- a/test/t_nmis_config.pl
+++ b/test/t_nmis_config.pl
@@ -57,9 +57,15 @@ make_path($test_conf, "$test_conf/conf.d", $test_conf_default);
 symlink("$FindBin::Bin/../conf-default/Config.nmis", "$test_conf_default/Config.nmis")
 	or die "Cannot symlink defaults: $!";
 
-# Also symlink the var directory so configChanged marker works
+# Redirect <nmis_var> to temp dir via conf.d override (persists across site config changes)
 my $test_var = "$tmpdir/var";
 make_path("$test_var/nmis_system");
+{
+	my $dir_override_file = "$test_conf/conf.d/00_test_dirs.nmis";
+	open(my $fh, '>', $dir_override_file) or die "Cannot write dir overrides: $!";
+	print $fh Data::Dumper->Dump([{ 'directories' => { '<nmis_base>' => $tmpdir, '<nmis_var>' => $test_var } }], [qw(*hash)]);
+	close $fh;
+}
 
 # Helper: force config reload from disk
 sub reload_config {
@@ -310,7 +316,7 @@ $C = reload_config();
 
 # --- Test 24: configChanged returns false when no change has occurred ---
 {
-	ok(!NMISNG::Util::configChanged(), "configChanged returns false when no change has occurred");
+	ok(!NMISNG::Util::configChanged(conf => $C), "configChanged returns false when no change has occurred");
 }
 
 # --- Test 25: configChanged returns true after marker is updated ---
@@ -321,7 +327,7 @@ $C = reload_config();
 	open(my $fh, ">", $marker) or die "cannot write marker: $!";
 	print $fh time() . "\n";
 	close $fh;
-	ok(NMISNG::Util::configChanged(), "configChanged returns true after marker is updated");
+	ok(NMISNG::Util::configChanged(conf => $C), "configChanged returns true after marker is updated");
 }
 
 # --- Test 26: writeConfData preserves site keys and adds new overrides without defaults ---

--- a/test/t_nmis_config.pl
+++ b/test/t_nmis_config.pl
@@ -284,7 +284,7 @@ is($env_new_key_test, "hello", "ENV can add new keys not in config");
 my $env_write_test = `NMIS_DB_SERVER=envhost perl -I$FindBin::Bin/../lib -e '
     use NMISNG::Util;
     my \$C = NMISNG::Util::loadConfTable();
-    my (\$rawdata, \$fn) = NMISNG::Util::readConfData(only_local => 1);
+    my (\$rawdata, \$fn) = NMISNG::Util::getConfDeep(only_local => 1);
     # Change the ENV-managed key to a different value
     \$rawdata->{database}{db_server} = "changed_host";
     my \$error = NMISNG::Util::writeConfData(data => \$rawdata);
@@ -301,7 +301,7 @@ like($env_write_test, qr/ERROR:.*db_server/, "writeConfData returns error for mo
 my $confd_write_test = `perl -I$FindBin::Bin/../lib -e '
     use NMISNG::Util;
     my \$C = NMISNG::Util::loadConfTable();
-    my (\$rawdata, \$fn) = NMISNG::Util::readConfData(only_local => 1);
+    my (\$rawdata, \$fn) = NMISNG::Util::getConfDeep(only_local => 1);
     # Change the conf.d-managed key
     \$rawdata->{authentication}{auth_expire} = "+99min";
     my \$error = NMISNG::Util::writeConfData(data => \$rawdata);
@@ -313,7 +313,7 @@ like($confd_write_test, qr/ERROR:.*auth_expire/, "writeConfData returns error fo
 my $normal_write_test = `perl -I$FindBin::Bin/../lib -e '
     use NMISNG::Util;
     my \$C = NMISNG::Util::loadConfTable();
-    my (\$rawdata, \$fn) = NMISNG::Util::readConfData(only_local => 1);
+    my (\$rawdata, \$fn) = NMISNG::Util::getConfDeep(only_local => 1);
     \$rawdata->{email}{mail_domain} = "test-changed.example.com";
     my \$error = NMISNG::Util::writeConfData(data => \$rawdata);
     die "writeConfData failed: \$error" if \$error;
@@ -334,7 +334,7 @@ is($normal_write_test, "OK", "writeConfData allows writing normal keys");
 my $confd_unchanged_test = `perl -I$FindBin::Bin/../lib -e '
     use NMISNG::Util;
     my \$C = NMISNG::Util::loadConfTable();
-    my (\$rawdata, \$fn) = NMISNG::Util::readConfData(only_local => 1);
+    my (\$rawdata, \$fn) = NMISNG::Util::getConfDeep(only_local => 1);
     # Pass data unchanged (includes conf.d merged values)
     my \$error = NMISNG::Util::writeConfData(data => \$rawdata);
     print defined(\$error) ? "ERROR:\$error" : "OK";

--- a/test/t_nmis_config.pl
+++ b/test/t_nmis_config.pl
@@ -29,11 +29,10 @@
 # *****************************************************************************
 
 # Test NMISNG config loading (layered config system)
-# Tests the load-once layered config with source tracking.
-# Note: since config is load-once per process, tests that require different
-# conf.d content run in subprocesses.
+# Uses a temp directory for all config writes to protect system config.
+# The real conf-default/Config.nmis is symlinked as layer 1 defaults.
 use strict;
-our $VERSION = "2.0.0";
+our $VERSION = "4.0.0";
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
@@ -44,24 +43,48 @@ use NMISNG;
 use NMISNG::Log;
 use NMISNG::Util;
 use Compat::Timing;
-use IO::File;
-use File::Path qw( make_path remove_tree );
+use File::Path qw( make_path );
+use File::Copy;
+use File::Temp qw( tempdir );
 use Data::Dumper;
 
-my $t = Compat::Timing->new();
+# --- Setup temp directory ---
+# Structure: $tmpdir/conf/ (layer 2 + conf.d), $tmpdir/conf-default/ (symlink to real defaults)
+my $tmpdir = tempdir("nmis_test_XXXX", TMPDIR => 1, CLEANUP => 1);
+my $test_conf = "$tmpdir/conf";
+my $test_conf_default = "$tmpdir/conf-default";
+make_path($test_conf, "$test_conf/conf.d", $test_conf_default);
+symlink("$FindBin::Bin/../conf-default/Config.nmis", "$test_conf_default/Config.nmis")
+	or die "Cannot symlink defaults: $!";
 
-# --- Test 1: Basic config loading ---
-my $time = $t->elapTime();
-my $C = NMISNG::Util::loadConfTable();
-$time = $t->elapTime() - $time;
-print $time. " time load config \n";
+# Also symlink the var directory so configChanged marker works
+my $test_var = "$tmpdir/var";
+make_path("$test_var/nmis_system");
 
-is($C->{'auth_expire'}, "+30min", "Config file loaded" );
+# Helper: force config reload from disk
+sub reload_config {
+	$NMISNG::Util::_config_cache_invalid = 1;
+	return NMISNG::Util::loadConfTable(dir => $test_conf);
+}
+
+# Helper: restore config from .bak file
+sub restore_config {
+	my $C = NMISNG::Util::loadConfTable(dir => $test_conf);
+	my $bak = $C->{configfile} . ".bak";
+	File::Copy::move($bak, $C->{configfile}) if -e $bak;
+	reload_config();
+}
+
+my $test_file = "$test_conf/conf.d/TEST.nmis";
+
+# --- Test 1: Basic config loading (defaults only, no site config) ---
+my $C = NMISNG::Util::loadConfTable(dir => $test_conf);
+is($C->{'auth_expire'}, "+30min", "Config file loaded from defaults");
 ok(defined $C->{'db_server'}, "db_server is present");
 ok(defined $C->{'<nmis_base>'}, "nmis_base directory macro is present");
 
 # --- Test 2: Caching - second call returns same ref ---
-my $C2 = NMISNG::Util::loadConfTable();
+my $C2 = NMISNG::Util::loadConfTable(dir => $test_conf);
 is($C, $C2, "Second loadConfTable call returns cached ref");
 
 # --- Test 3: Source tracking ---
@@ -81,297 +104,271 @@ ok(defined $conf_source, "getConfigSources returns info for hardcoded 'conf'");
 is($conf_source->{source}, "hardcoded", "conf source is 'hardcoded'");
 
 # --- Test 5: Macro replacement ---
-is($C->{'syslog_log'}, $C->{'<nmis_logs>'}."/cisco.log", "Replacing macros from master config OK" );
+is($C->{'syslog_log'}, $C->{'<nmis_logs>'} . "/cisco.log", "Replacing macros from master config OK");
 
-# --- Test 6: cluster_id is present ---
+# --- Test 6: cluster_id is generated when missing ---
 ok(defined $C->{cluster_id} && $C->{cluster_id} ne '', "cluster_id is present and non-empty");
 
-# --- Test 7: conf.d override-only (run in subprocess) ---
-my $conf_d_dir = $C->{'<nmis_conf>'} . "/conf.d";
-if ( !-d $conf_d_dir ) {
-    make_path $conf_d_dir or die "Failed to create path: $conf_d_dir";
-}
-
-my $test_file = "$conf_d_dir/TEST.nmis";
-
-# Write a conf.d file that overrides an existing key
+# --- Test 7: conf.d override of existing key ---
 {
-    open(my $fh, '>', $test_file) or die "Could not open file '$test_file' $!";
-    print $fh "%hash = ('authentication'=>{'auth_expire'=>'+2min'});\n";
-    close $fh;
+	open(my $fh, '>', $test_file) or die "Could not open $test_file: $!";
+	print $fh "%hash = ('authentication'=>{'auth_expire'=>'+2min'});\n";
+	close $fh;
+
+	$C = reload_config();
+	is($C->{auth_expire}, "+2min", "conf.d override of existing key works");
 }
 
-# Test override in a subprocess (since config is load-once per process)
-my $override_result = `perl -I$FindBin::Bin/../lib -e '
-    use NMISNG::Util;
-    my \$C = NMISNG::Util::loadConfTable();
-    print \$C->{auth_expire};
-' 2>/dev/null`;
-is($override_result, "+2min", "conf.d override of existing key works (subprocess)");
-
-# Test that conf.d cannot add new keys (override-only)
+# --- Test 8: conf.d cannot add new keys (override-only) ---
 {
-    open(my $fh, '>', $test_file) or die "Could not open file '$test_file' $!";
-    print $fh "%hash = ('authentication'=>{'auth_expire'=>'+2min', 'brand_new_key'=>'should_not_appear'});\n";
-    close $fh;
+	open(my $fh, '>', $test_file) or die "Could not open $test_file: $!";
+	print $fh "%hash = ('authentication'=>{'auth_expire'=>'+2min', 'brand_new_key'=>'should_not_appear'});\n";
+	close $fh;
+
+	$C = reload_config();
+	ok(!defined $C->{brand_new_key}, "conf.d cannot add new keys (override-only)");
 }
 
-my $newkey_result = `perl -I$FindBin::Bin/../lib -e '
-    use NMISNG::Util;
-    my \$C = NMISNG::Util::loadConfTable();
-    print defined(\$C->{brand_new_key}) ? "FOUND" : "NOT_FOUND";
-' 2>/dev/null`;
-is($newkey_result, "NOT_FOUND", "conf.d cannot add new keys (override-only)");
-
-# Test that conf.d override is tracked in source
-my $source_result = `perl -I$FindBin::Bin/../lib -e '
-    use NMISNG::Util;
-    my \$C = NMISNG::Util::loadConfTable();
-    my \$s = NMISNG::Util::getConfigSources(key => "auth_expire");
-    print \$s->{layer} if \$s;
-' 2>/dev/null`;
-is($source_result, "3", "conf.d override tracked as layer 3");
-
-# --- Test 8: ENV override ---
-my $env_result = `NMIS_DB_SERVER=testhost perl -I$FindBin::Bin/../lib -e '
-    use NMISNG::Util;
-    my \$C = NMISNG::Util::loadConfTable();
-    print \$C->{db_server};
-' 2>/dev/null`;
-is($env_result, "testhost", "ENV NMIS_DB_SERVER override works");
-
-# ENV override tracked as layer 4
-my $env_source_result = `NMIS_DB_SERVER=testhost perl -I$FindBin::Bin/../lib -e '
-    use NMISNG::Util;
-    my \$C = NMISNG::Util::loadConfTable();
-    my \$s = NMISNG::Util::getConfigSources(key => "db_server");
-    print \$s->{layer} if \$s;
-' 2>/dev/null`;
-is($env_source_result, "4", "ENV override tracked as layer 4");
-
-# ENV URL_BASE backward compat
-my $urlbase_result = `NMIS_URL_BASE=/test-cgi perl -I$FindBin::Bin/../lib -e '
-    use NMISNG::Util;
-    my \$C = NMISNG::Util::loadConfTable();
-    print \$C->{"<cgi_url_base>"};
-' 2>/dev/null`;
-is($urlbase_result, "/test-cgi", "ENV NMIS_URL_BASE maps to <cgi_url_base>");
-
-# --- Test 9: stripDefaults returns valid structure ---
-my $strip_test = `perl -I$FindBin::Bin/../lib -e '
-    use NMISNG::Util;
-    my \$C = NMISNG::Util::loadConfTable();
-    my (\$stripped, \$removals) = NMISNG::Util::stripDefaults();
-    die "stripped not hash" unless ref(\$stripped) eq "HASH";
-    die "removals not array" unless ref(\$removals) eq "ARRAY";
-    # stripped should have section keys (deep structure)
-    my \$has_sections = grep { ref(\$stripped->{\$_}) eq "HASH" } keys %\$stripped;
-    die "no sections in stripped" unless \$has_sections;
-    # each removal should have section and key
-    for my \$r (@\$removals) {
-        die "bad removal entry" unless defined \$r->{section} && defined \$r->{key};
-    }
-    print "OK";
-' 2>/dev/null`;
-is($strip_test, "OK", "stripDefaults returns valid structure");
-
-# --- Test 10: stripDefaults removals only contain values matching defaults ---
-my $strip_match_test = `perl -I$FindBin::Bin/../lib -e '
-    use NMISNG::Util;
-    my \$C = NMISNG::Util::loadConfTable();
-    my \$default_file = \$C->{"<nmis_conf_default>"} . "/Config.nmis";
-    my \$defaults = NMISNG::Util::readFiletoHash(file => \$default_file);
-    my (\$stripped, \$removals) = NMISNG::Util::stripDefaults();
-    # every removal must exist in defaults with the same value
-    for my \$r (@\$removals) {
-        my \$s = \$r->{section};
-        my \$k = \$r->{key};
-        die "removal \$s/\$k not in defaults" unless ref(\$defaults->{\$s}) eq "HASH"
-            && exists \$defaults->{\$s}{\$k};
-    }
-    print "OK";
-' 2>/dev/null`;
-is($strip_match_test, "OK", "stripDefaults removals all exist in defaults");
-
-# --- Test 11: stripDefaults keeps site-only keys ---
-# Write a conf.d file with an override, then verify stripDefaults keeps overridden values
+# --- Test 9: conf.d override tracked as layer 3 ---
 {
-    open(my $fh, '>', $test_file) or die "Could not open file '$test_file' $!";
-    print $fh "%hash = ('authentication'=>{'auth_expire'=>'+99min'});\n";
-    close $fh;
+	my $s = NMISNG::Util::getConfigSources(key => "auth_expire");
+	is($s->{layer}, 3, "conf.d override tracked as layer 3");
 }
-my $strip_keep_test = `perl -I$FindBin::Bin/../lib -e '
-    use NMISNG::Util;
-    my \$C = NMISNG::Util::loadConfTable();
-    my (\$stripped, \$removals) = NMISNG::Util::stripDefaults();
-    # auth_expire in conf/Config.nmis should match the default (+30min),
-    # so it should be in removals (the conf.d override is separate from conf/Config.nmis)
-    # Verify stripped + defaults covers all keys from site config
-    my \$site = NMISNG::Util::readFiletoHash(file => \$C->{configfile});
-    for my \$section (keys %\$site) {
-        next unless ref(\$site->{\$section}) eq "HASH";
-        for my \$key (keys %{\$site->{\$section}}) {
-            my \$in_stripped = ref(\$stripped->{\$section}) eq "HASH"
-                && exists \$stripped->{\$section}{\$key};
-            my \$in_removals = grep { \$_->{section} eq \$section && \$_->{key} eq \$key } @\$removals;
-            die "key \$section/\$key lost" unless \$in_stripped || \$in_removals;
-        }
-    }
-    print "OK";
-' 2>/dev/null`;
-is($strip_keep_test, "OK", "stripDefaults: every site key is either kept or in removals");
 
-# --- Test 12: stripDefaults empty sections are removed ---
-my $strip_empty_test = `perl -I$FindBin::Bin/../lib -e '
-    use NMISNG::Util;
-    my \$C = NMISNG::Util::loadConfTable();
-    my (\$stripped, \$removals) = NMISNG::Util::stripDefaults();
-    # no empty sections should exist in stripped
-    for my \$section (keys %\$stripped) {
-        next unless ref(\$stripped->{\$section}) eq "HASH";
-        die "empty section \$section" unless keys %{\$stripped->{\$section}};
-    }
-    print "OK";
-' 2>/dev/null`;
-is($strip_empty_test, "OK", "stripDefaults: no empty sections in result");
-
-# --- Test 13: Exclusive property in conf.d ignored when already in conf/Config.nmis ---
-# cluster_id exists in conf/Config.nmis, so conf.d should not override it
-{
-    open(my $fh, '>', $test_file) or die "Could not open file '$test_file' $!";
-    print $fh "%hash = ('id'=>{'cluster_id'=>'FAIL_FROM_CONFD'});\n";
-    close $fh;
-}
-my $exclusive_test = `perl -I$FindBin::Bin/../lib -e '
-    use NMISNG::Util;
-    my \$C = NMISNG::Util::loadConfTable();
-    print (\$C->{cluster_id} ne "FAIL_FROM_CONFD" ? "OK" : "FAIL");
-' 2>&1`;
-# Check both that value was not overridden and that a warning was emitted
-like($exclusive_test, qr/OK/, "Exclusive property cluster_id in conf.d ignored when already in site config");
-like($exclusive_test, qr/Exclusive property/, "Warning emitted for duplicate exclusive property");
-
-# --- Test 14: ENV cannot override exclusive property already claimed by a config file ---
-my $env_exclusive_test = `NMIS_CLUSTER_ID=ENV_OVERRIDE perl -I$FindBin::Bin/../lib -e '
-    use NMISNG::Util;
-    my \$C = NMISNG::Util::loadConfTable();
-    print (\$C->{cluster_id} ne "ENV_OVERRIDE" ? "OK" : "FAIL");
-' 2>&1`;
-like($env_exclusive_test, qr/OK/, "ENV exclusive property cluster_id ignored when already in site config");
-like($env_exclusive_test, qr/Exclusive property/, "Warning emitted for ENV exclusive property override");
-
-# --- Test 15: Exclusive property accepted in conf.d when not in conf/Config.nmis ---
-# Write a conf.d file with server_name; this test only works if server_name is NOT in conf/Config.nmis
-# We test with a fresh key to avoid depending on site config state
-my $exclusive_accept_test = `perl -I$FindBin::Bin/../lib -e '
-    use NMISNG::Util;
-    my \$C = NMISNG::Util::loadConfTable();
-    # If server_name came from conf.d, there should be no exclusive warning for it
-    # Just verify the config loaded without dying
-    print "OK" if defined \$C;
-' 2>&1`;
-like($exclusive_accept_test, qr/OK/, "Config loads successfully with exclusive keys");
-
-# --- Test 16: ENV can add new keys not in config ---
-my $env_new_key_test = `NMIS_BRAND_NEW_TEST_KEY=hello perl -I$FindBin::Bin/../lib -e '
-    use NMISNG::Util;
-    my \$C = NMISNG::Util::loadConfTable();
-    print \$C->{brand_new_test_key} // "MISSING";
-' 2>/dev/null`;
-is($env_new_key_test, "hello", "ENV can add new keys not in config");
-
-# --- Test 17: writeConfData returns error for modified ENV-sourced key ---
-my $env_write_test = `NMIS_DB_SERVER=envhost perl -I$FindBin::Bin/../lib -e '
-    use NMISNG::Util;
-    my \$C = NMISNG::Util::loadConfTable();
-    my (\$rawdata, \$fn) = NMISNG::Util::getConfDeep(only_local => 1);
-    # Change the ENV-managed key to a different value
-    \$rawdata->{database}{db_server} = "changed_host";
-    my \$error = NMISNG::Util::writeConfData(data => \$rawdata);
-    print defined(\$error) ? "ERROR:\$error" : "OK";
-' 2>/dev/null`;
-like($env_write_test, qr/ERROR:.*db_server/, "writeConfData returns error for modified ENV-sourced key");
-
-# --- Test 18: writeConfData returns error for modified conf.d key ---
-{
-    open(my $fh, '>', $test_file) or die "Could not open file '$test_file' $!";
-    print $fh "%hash = ('authentication'=>{'auth_expire'=>'+5min'});\n";
-    close $fh;
-}
-my $confd_write_test = `perl -I$FindBin::Bin/../lib -e '
-    use NMISNG::Util;
-    my \$C = NMISNG::Util::loadConfTable();
-    my (\$rawdata, \$fn) = NMISNG::Util::getConfDeep(only_local => 1);
-    # Change the conf.d-managed key
-    \$rawdata->{authentication}{auth_expire} = "+99min";
-    my \$error = NMISNG::Util::writeConfData(data => \$rawdata);
-    print defined(\$error) ? "ERROR:\$error" : "OK";
-' 2>/dev/null`;
-like($confd_write_test, qr/ERROR:.*auth_expire/, "writeConfData returns error for modified conf.d key");
-
-# --- Test 19: writeConfData allows writing normal keys ---
-my $normal_write_test = `perl -I$FindBin::Bin/../lib -e '
-    use NMISNG::Util;
-    my \$C = NMISNG::Util::loadConfTable();
-    my (\$rawdata, \$fn) = NMISNG::Util::getConfDeep(only_local => 1);
-    \$rawdata->{email}{mail_domain} = "test-changed.example.com";
-    my \$error = NMISNG::Util::writeConfData(data => \$rawdata);
-    die "writeConfData failed: \$error" if \$error;
-    my \$written = NMISNG::Util::readFiletoHash(file => \$C->{configfile});
-    print(\$written->{email}{mail_domain} eq "test-changed.example.com" ? "OK" : "FAIL");
-' 2>/dev/null`;
-is($normal_write_test, "OK", "writeConfData allows writing normal keys");
-
-# Restore config after test 19
-`perl -I$FindBin::Bin/../lib -e '
-    use NMISNG::Util;
-    my \$C = NMISNG::Util::loadConfTable();
-    my \$bak = \$C->{configfile} . ".bak";
-    rename(\$bak, \$C->{configfile}) if -e \$bak;
-' 2>/dev/null`;
-
-# --- Test 20: writeConfData skips unchanged conf.d keys without error ---
-my $confd_unchanged_test = `perl -I$FindBin::Bin/../lib -e '
-    use NMISNG::Util;
-    my \$C = NMISNG::Util::loadConfTable();
-    my (\$rawdata, \$fn) = NMISNG::Util::getConfDeep(only_local => 1);
-    # Pass data unchanged (includes conf.d merged values)
-    my \$error = NMISNG::Util::writeConfData(data => \$rawdata);
-    print defined(\$error) ? "ERROR:\$error" : "OK";
-' 2>/dev/null`;
-is($confd_unchanged_test, "OK", "writeConfData skips unchanged conf.d keys without error");
-
-# Restore config after test 20
-`perl -I$FindBin::Bin/../lib -e '
-    use NMISNG::Util;
-    my \$C = NMISNG::Util::loadConfTable();
-    my \$bak = \$C->{configfile} . ".bak";
-    rename(\$bak, \$C->{configfile}) if -e \$bak;
-' 2>/dev/null`;
-
-# --- Test 21: configChanged returns false when no change has occurred ---
-my $no_change_test = `perl -I$FindBin::Bin/../lib -e '
-    use NMISNG::Util;
-    my \$C = NMISNG::Util::loadConfTable();
-    print NMISNG::Util::configChanged() ? "CHANGED" : "OK";
-' 2>/dev/null`;
-is($no_change_test, "OK", "configChanged returns false when no change has occurred");
-
-# --- Test 22: configChanged returns true after another process writes config ---
-my $change_test = `perl -I$FindBin::Bin/../lib -e '
-    use NMISNG::Util;
-    my \$C = NMISNG::Util::loadConfTable();
-    # Simulate another process writing the marker in the future
-    sleep(1);
-    my \$marker = \$C->{"<nmis_var>"} . "/nmis_system/config_changed";
-    open(my \$fh, ">", \$marker) or die "cannot write marker: \$!";
-    print \$fh time() . "\n";
-    close \$fh;
-    print NMISNG::Util::configChanged() ? "CHANGED" : "FAIL";
-' 2>/dev/null`;
-is($change_test, "CHANGED", "configChanged returns true after marker is updated");
-
-# Cleanup
+# Clean up conf.d
 unlink $test_file;
+$C = reload_config();
+
+# --- Test 10: ENV override ---
+{
+	local $ENV{NMIS_DB_SERVER} = "testhost";
+	$C = reload_config();
+	is($C->{db_server}, "testhost", "ENV NMIS_DB_SERVER override works");
+}
+
+# --- Test 11: ENV override tracked as layer 4 ---
+{
+	local $ENV{NMIS_DB_SERVER} = "testhost";
+	$C = reload_config();
+	my $s = NMISNG::Util::getConfigSources(key => "db_server");
+	is($s->{layer}, 4, "ENV override tracked as layer 4");
+}
+$C = reload_config();
+
+# --- Test 12: ENV NMIS_URL_BASE maps to <url_base> ---
+{
+	local $ENV{NMIS_URL_BASE} = "/test-url";
+	$C = reload_config();
+	is($C->{'<url_base>'}, "/test-url", "ENV NMIS_URL_BASE maps to <url_base>");
+}
+$C = reload_config();
+
+# --- Test 13: stripDefaults returns valid structure ---
+{
+	my ($stripped, $removals) = NMISNG::Util::stripDefaults();
+	ok(ref($stripped) eq 'HASH', "stripDefaults returns hashref");
+	ok(ref($removals) eq 'ARRAY', "stripDefaults returns arrayref of removals");
+	my $has_sections = grep { ref($stripped->{$_}) eq 'HASH' } keys %$stripped;
+	ok($has_sections || !keys %$stripped, "stripDefaults result has section keys or is empty");
+	my $all_valid = 1;
+	for my $r (@$removals) {
+		$all_valid = 0 unless defined $r->{section} && defined $r->{key};
+	}
+	ok($all_valid, "stripDefaults removals all have section and key");
+}
+
+# --- Test 14: stripDefaults removals match defaults ---
+{
+	my $defaults = NMISNG::Util::getConfigDefaults();
+	my ($stripped, $removals) = NMISNG::Util::stripDefaults();
+	my $all_in_defaults = 1;
+	for my $r (@$removals) {
+		unless (ref($defaults->{$r->{section}}) eq 'HASH' && exists $defaults->{$r->{section}}{$r->{key}}) {
+			$all_in_defaults = 0;
+			last;
+		}
+	}
+	ok($all_in_defaults, "stripDefaults removals all exist in defaults");
+}
+
+# --- Test 15: stripDefaults with site config ---
+{
+	# Write a site config with a non-default value
+	my %site = ( "email" => { "mail_domain" => "custom.example.com" } );
+	NMISNG::Util::writeHashtoFile(file => "$test_conf/Config.nmis", data => \%site);
+	$C = reload_config();
+
+	my ($stripped, $removals) = NMISNG::Util::stripDefaults();
+	ok(ref($stripped->{email}) eq 'HASH' && $stripped->{email}{mail_domain} eq "custom.example.com",
+		"stripDefaults keeps non-default site key");
+
+	unlink "$test_conf/Config.nmis";
+	$C = reload_config();
+}
+
+# --- Test 16: stripDefaults: no empty sections ---
+{
+	my ($stripped, $removals) = NMISNG::Util::stripDefaults();
+	my $no_empty = 1;
+	for my $section (keys %$stripped) {
+		next unless ref($stripped->{$section}) eq 'HASH';
+		$no_empty = 0 unless keys %{$stripped->{$section}};
+	}
+	ok($no_empty, "stripDefaults: no empty sections in result");
+}
+
+# --- Test 17: Exclusive property in conf.d ignored when already in local config ---
+{
+	# Write site config with cluster_id
+	my %site = ( "id" => { "cluster_id" => "my-site-cluster-id" } );
+	NMISNG::Util::writeHashtoFile(file => "$test_conf/Config.nmis", data => \%site);
+
+	# Write conf.d with conflicting cluster_id
+	open(my $fh, '>', $test_file) or die "Could not open $test_file: $!";
+	print $fh "%hash = ('id'=>{'cluster_id'=>'FAIL_FROM_CONFD'});\n";
+	close $fh;
+
+	my @warnings;
+	local $SIG{__WARN__} = sub { push @warnings, $_[0] };
+	$C = reload_config();
+
+	is($C->{cluster_id}, "my-site-cluster-id", "Exclusive property cluster_id in conf.d ignored");
+	ok(grep(/Exclusive property/, @warnings), "Warning emitted for duplicate exclusive property");
+}
+
+# --- Test 18: ENV cannot override exclusive property already claimed ---
+{
+	local $ENV{NMIS_CLUSTER_ID} = "ENV_OVERRIDE";
+	my @warnings;
+	local $SIG{__WARN__} = sub { push @warnings, $_[0] };
+	$C = reload_config();
+
+	is($C->{cluster_id}, "my-site-cluster-id", "ENV exclusive property cluster_id ignored");
+	ok(grep(/Exclusive property/, @warnings), "Warning emitted for ENV exclusive property override");
+}
+
+# Clean up
+unlink $test_file;
+unlink "$test_conf/Config.nmis";
+$C = reload_config();
+
+# --- Test 19: ENV can add new keys not in config ---
+{
+	local $ENV{NMIS_BRAND_NEW_TEST_KEY} = "hello";
+	$C = reload_config();
+	is($C->{brand_new_test_key}, "hello", "ENV can add new keys not in config");
+}
+$C = reload_config();
+
+# --- Test 20: writeConfData returns error for modified ENV-sourced key ---
+{
+	local $ENV{NMIS_DB_SERVER} = "envhost";
+	$C = reload_config();
+	my ($rawdata, $fn) = NMISNG::Util::getConfDeep(only_local => 1);
+	$rawdata->{database}{db_server} = "changed_host";
+	my $error = NMISNG::Util::writeConfData(data => $rawdata);
+	like($error, qr/db_server/, "writeConfData returns error for modified ENV-sourced key");
+}
+$C = reload_config();
+
+# --- Test 21: writeConfData returns error for modified conf.d key ---
+{
+	open(my $fh, '>', $test_file) or die "Could not open $test_file: $!";
+	print $fh "%hash = ('authentication'=>{'auth_expire'=>'+5min'});\n";
+	close $fh;
+	$C = reload_config();
+
+	my ($rawdata, $fn) = NMISNG::Util::getConfDeep();
+	$rawdata->{authentication}{auth_expire} = "+99min";
+	my $error = NMISNG::Util::writeConfData(data => $rawdata);
+	like($error, qr/auth_expire/, "writeConfData returns error for modified conf.d key");
+}
+
+# --- Test 22: writeConfData allows writing normal keys ---
+{
+	my ($rawdata, $fn) = NMISNG::Util::getConfDeep();
+	$rawdata->{email}{mail_domain} = "test-changed.example.com";
+	my $error = NMISNG::Util::writeConfData(data => $rawdata);
+	ok(!$error, "writeConfData allows writing normal keys");
+
+	$C = reload_config();
+	is($C->{mail_domain}, "test-changed.example.com", "Written value is correct after reload");
+	restore_config();
+}
+
+# --- Test 23: writeConfData skips unchanged conf.d keys without error ---
+{
+	my ($rawdata, $fn) = NMISNG::Util::getConfDeep();
+	my $error = NMISNG::Util::writeConfData(data => $rawdata);
+	ok(!$error, "writeConfData skips unchanged conf.d keys without error");
+	restore_config();
+}
+
+# Clean up conf.d
+unlink $test_file;
+$C = reload_config();
+
+# --- Test 24: configChanged returns false when no change has occurred ---
+{
+	ok(!NMISNG::Util::configChanged(), "configChanged returns false when no change has occurred");
+}
+
+# --- Test 25: configChanged returns true after marker is updated ---
+{
+	sleep(1);
+	my $marker = $C->{'<nmis_var>'} . "/nmis_system/config_changed";
+	make_path(File::Basename::dirname($marker));
+	open(my $fh, ">", $marker) or die "cannot write marker: $!";
+	print $fh time() . "\n";
+	close $fh;
+	ok(NMISNG::Util::configChanged(), "configChanged returns true after marker is updated");
+}
+
+# --- Test 26: writeConfData preserves site keys and adds new overrides without defaults ---
+{
+	my $configfile = "$test_conf/Config.nmis";
+
+	# Write a known starting site config
+	my %initial = (
+		"email"  => { "mail_domain" => "mycompany.com", "mail_from" => 'test@mycompany.com' },
+		"system" => { "nmis_user" => "testuser" },
+	);
+	NMISNG::Util::writeHashtoFile(file => $configfile, data => \%initial);
+	$C = reload_config();
+
+	# Get full effective config and modify two default values
+	my ($full, undef) = NMISNG::Util::getConfDeep();
+	$full->{system}{ping_timeout} = "9999";
+	$full->{logging}{log_level} = "debug";
+
+	my $error = NMISNG::Util::writeConfData(data => $full);
+	ok(!$error, "writeConfData succeeds with mixed site + new overrides");
+
+	# Read back the file
+	my $written = NMISNG::Util::readFiletoHash(file => $configfile);
+
+	# Existing site keys preserved
+	is($written->{email}{mail_domain}, "mycompany.com", "Existing site key mail_domain preserved");
+	is($written->{email}{mail_from}, 'test@mycompany.com', "Existing site key mail_from preserved");
+	is($written->{system}{nmis_user}, "testuser", "Existing site key nmis_user preserved");
+
+	# New overrides added
+	is($written->{system}{ping_timeout}, "9999", "New override ping_timeout added");
+	is($written->{logging}{log_level}, "debug", "New override log_level added");
+
+	# Default values NOT in file
+	ok(!exists $written->{database}{db_port}, "Default db_port not in written file");
+	ok(!exists $written->{authentication}{auth_expire}, "Default auth_expire not in written file");
+
+	restore_config();
+}
+
+# --- Test 27: getConfigDefaults returns layer 1 data ---
+{
+	my $defaults = NMISNG::Util::getConfigDefaults();
+	ok(ref($defaults) eq 'HASH', "getConfigDefaults returns hashref");
+	ok(ref($defaults->{database}) eq 'HASH', "getConfigDefaults has database section");
+	ok(exists $defaults->{database}{db_server}, "getConfigDefaults has db_server in database");
+}
 
 done_testing();

--- a/test/t_nmis_config.pl
+++ b/test/t_nmis_config.pl
@@ -235,6 +235,51 @@ my $strip_empty_test = `perl -I$FindBin::Bin/../lib -e '
 ' 2>/dev/null`;
 is($strip_empty_test, "OK", "stripDefaults: no empty sections in result");
 
+# --- Test 13: Exclusive property in conf.d ignored when already in conf/Config.nmis ---
+# cluster_id exists in conf/Config.nmis, so conf.d should not override it
+{
+    open(my $fh, '>', $test_file) or die "Could not open file '$test_file' $!";
+    print $fh "%hash = ('id'=>{'cluster_id'=>'FAIL_FROM_CONFD'});\n";
+    close $fh;
+}
+my $exclusive_test = `perl -I$FindBin::Bin/../lib -e '
+    use NMISNG::Util;
+    my \$C = NMISNG::Util::loadConfTable();
+    print (\$C->{cluster_id} ne "FAIL_FROM_CONFD" ? "OK" : "FAIL");
+' 2>&1`;
+# Check both that value was not overridden and that a warning was emitted
+like($exclusive_test, qr/OK/, "Exclusive property cluster_id in conf.d ignored when already in site config");
+like($exclusive_test, qr/Exclusive property/, "Warning emitted for duplicate exclusive property");
+
+# --- Test 14: ENV cannot override exclusive property already claimed by a config file ---
+my $env_exclusive_test = `NMIS_CLUSTER_ID=ENV_OVERRIDE perl -I$FindBin::Bin/../lib -e '
+    use NMISNG::Util;
+    my \$C = NMISNG::Util::loadConfTable();
+    print (\$C->{cluster_id} ne "ENV_OVERRIDE" ? "OK" : "FAIL");
+' 2>&1`;
+like($env_exclusive_test, qr/OK/, "ENV exclusive property cluster_id ignored when already in site config");
+like($env_exclusive_test, qr/Exclusive property/, "Warning emitted for ENV exclusive property override");
+
+# --- Test 15: Exclusive property accepted in conf.d when not in conf/Config.nmis ---
+# Write a conf.d file with server_name; this test only works if server_name is NOT in conf/Config.nmis
+# We test with a fresh key to avoid depending on site config state
+my $exclusive_accept_test = `perl -I$FindBin::Bin/../lib -e '
+    use NMISNG::Util;
+    my \$C = NMISNG::Util::loadConfTable();
+    # If server_name came from conf.d, there should be no exclusive warning for it
+    # Just verify the config loaded without dying
+    print "OK" if defined \$C;
+' 2>&1`;
+like($exclusive_accept_test, qr/OK/, "Config loads successfully with exclusive keys");
+
+# --- Test 16: ENV can add new keys not in config ---
+my $env_new_key_test = `NMIS_BRAND_NEW_TEST_KEY=hello perl -I$FindBin::Bin/../lib -e '
+    use NMISNG::Util;
+    my \$C = NMISNG::Util::loadConfTable();
+    print \$C->{brand_new_test_key} // "MISSING";
+' 2>/dev/null`;
+is($env_new_key_test, "hello", "ENV can add new keys not in config");
+
 # Cleanup
 unlink $test_file;
 

--- a/test/t_nmis_config.pl
+++ b/test/t_nmis_config.pl
@@ -4,7 +4,7 @@
 #
 #  ALL CODE MODIFICATIONS MUST BE SENT TO CODE@OPMANTEK.COM
 #
-#  This file is part of Network Management Information System (“NMIS”).
+#  This file is part of Network Management Information System ("NMIS").
 #
 #  NMIS is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -28,11 +28,12 @@
 #
 # *****************************************************************************
 
-# Test NMISNG fuctions
-# creates (and removes) a mongo database called t_nmisg-<timestamp>
-#  in whatever mongodb is configured in ../conf/
+# Test NMISNG config loading (layered config system)
+# Tests the load-once layered config with source tracking.
+# Note: since config is load-once per process, tests that require different
+# conf.d content run in subprocesses.
 use strict;
-our $VERSION = "1.1.0";
+our $VERSION = "2.0.0";
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
@@ -44,82 +45,119 @@ use NMISNG::Log;
 use NMISNG::Util;
 use Compat::Timing;
 use IO::File;
-use File::Path qw( make_path );
+use File::Path qw( make_path remove_tree );
 use Data::Dumper;
 
 my $t = Compat::Timing->new();
+
+# --- Test 1: Basic config loading ---
 my $time = $t->elapTime();
 my $C = NMISNG::Util::loadConfTable();
 $time = $t->elapTime() - $time;
 print $time. " time load config \n";
 
-# log to stdout
-my $logger = NMISNG::Log->new( level => 'debug' );
-
 is($C->{'auth_expire'}, "+30min", "Config file loaded" );
+ok(defined $C->{'db_server'}, "db_server is present");
+ok(defined $C->{'<nmis_base>'}, "nmis_base directory macro is present");
 
+# --- Test 2: Caching - second call returns same ref ---
+my $C2 = NMISNG::Util::loadConfTable();
+is($C, $C2, "Second loadConfTable call returns cached ref");
+
+# --- Test 3: Source tracking ---
+my $sources = NMISNG::Util::getConfigSources();
+ok(ref($sources) eq 'HASH', "getConfigSources returns hashref");
+ok(scalar keys %$sources > 0, "getConfigSources has entries");
+
+my $db_source = NMISNG::Util::getConfigSources(key => 'db_server');
+ok(defined $db_source, "getConfigSources returns info for db_server");
+ok($db_source->{layer} >= 1 && $db_source->{layer} <= 4, "db_server has valid layer");
+ok(defined $db_source->{section}, "db_server has section info");
+is($db_source->{section}, "database", "db_server section is 'database'");
+
+# --- Test 4: Hardcoded values tracked ---
+my $conf_source = NMISNG::Util::getConfigSources(key => 'conf');
+ok(defined $conf_source, "getConfigSources returns info for hardcoded 'conf'");
+is($conf_source->{source}, "hardcoded", "conf source is 'hardcoded'");
+
+# --- Test 5: Macro replacement ---
+is($C->{'syslog_log'}, $C->{'<nmis_logs>'}."/cisco.log", "Replacing macros from master config OK" );
+
+# --- Test 6: cluster_id is present ---
+ok(defined $C->{cluster_id} && $C->{cluster_id} ne '', "cluster_id is present and non-empty");
+
+# --- Test 7: conf.d override-only (run in subprocess) ---
 my $conf_d_dir = $C->{'<nmis_conf>'} . "/conf.d";
 if ( !-d $conf_d_dir ) {
     make_path $conf_d_dir or die "Failed to create path: $conf_d_dir";
 }
 
-my $file = "$conf_d_dir/TEST.nmis";
+my $test_file = "$conf_d_dir/TEST.nmis";
 
-my $content = "%hash = (\'authentication\'=>{\'auth_expire\'=>\'+2min\',
-\'test\'=>2});";
-
-my $fn;
-open($fn, '>', $file) or die "Could not open file '$file' $!";
-
-print $fn $content;
-close $fn;
-
-sub cleanup_db
+# Write a conf.d file that overrides an existing key
 {
-    unlink $file;
-	# Remove conf file
+    open(my $fh, '>', $test_file) or die "Could not open file '$test_file' $!";
+    print $fh "%hash = ('authentication'=>{'auth_expire'=>'+2min'});\n";
+    close $fh;
 }
 
-$time = $t->elapTime();
-$C = NMISNG::Util::loadConfTable();
-$time = $t->elapTime() - $time;
-print $time. " time load new config \n";
+# Test override in a subprocess (since config is load-once per process)
+my $override_result = `perl -I$FindBin::Bin/../lib -e '
+    use NMISNG::Util;
+    my \$C = NMISNG::Util::loadConfTable();
+    print \$C->{auth_expire};
+' 2>/dev/null`;
+is($override_result, "+2min", "conf.d override of existing key works (subprocess)");
 
-is($C->{'auth_expire'}, "+2min", "External config file loaded" );
+# Test that conf.d cannot add new keys (override-only)
+{
+    open(my $fh, '>', $test_file) or die "Could not open file '$test_file' $!";
+    print $fh "%hash = ('authentication'=>{'auth_expire'=>'+2min', 'brand_new_key'=>'should_not_appear'});\n";
+    close $fh;
+}
 
-# Try to edit not editable configs
-$content = "%hash = (\'id\'=>{\'cluster_id\'=>\'FAIL\'});";
-#my $fn;
-open($fn, '>', $file) or die "Could not open file '$file' $!";
+my $newkey_result = `perl -I$FindBin::Bin/../lib -e '
+    use NMISNG::Util;
+    my \$C = NMISNG::Util::loadConfTable();
+    print defined(\$C->{brand_new_key}) ? "FOUND" : "NOT_FOUND";
+' 2>/dev/null`;
+is($newkey_result, "NOT_FOUND", "conf.d cannot add new keys (override-only)");
 
-print $fn $content;
-close $fn;
-$time = $t->elapTime();
-$C = NMISNG::Util::loadConfTable();
-$time = $t->elapTime() - $time;
-print $time. " time load new config \n";
+# Test that conf.d override is tracked in source
+my $source_result = `perl -I$FindBin::Bin/../lib -e '
+    use NMISNG::Util;
+    my \$C = NMISNG::Util::loadConfTable();
+    my \$s = NMISNG::Util::getConfigSources(key => "auth_expire");
+    print \$s->{layer} if \$s;
+' 2>/dev/null`;
+is($source_result, "3", "conf.d override tracked as layer 3");
 
-is($C->{'cluster_id'}, "a5159999-0d11-4bcb-a402-39a460012345", "Non modificable properties OK" );
+# --- Test 8: ENV override ---
+my $env_result = `NMIS_DB_SERVER=testhost perl -I$FindBin::Bin/../lib -e '
+    use NMISNG::Util;
+    my \$C = NMISNG::Util::loadConfTable();
+    print \$C->{db_server};
+' 2>/dev/null`;
+is($env_result, "testhost", "ENV NMIS_DB_SERVER override works");
 
-# Test for replacing macros in the file
-open($fn, '>', $file) or die "Could not open file '$file' $!";
+# ENV override tracked as layer 4
+my $env_source_result = `NMIS_DB_SERVER=testhost perl -I$FindBin::Bin/../lib -e '
+    use NMISNG::Util;
+    my \$C = NMISNG::Util::loadConfTable();
+    my \$s = NMISNG::Util::getConfigSources(key => "db_server");
+    print \$s->{layer} if \$s;
+' 2>/dev/null`;
+is($env_source_result, "4", "ENV override tracked as layer 4");
 
-$content = "%hash = (\'authentication\'=>{\'auth_htpasswd_file\'=>\'<nmis_conf>/users.dat\'});";
-close $fn;
-$time = $t->elapTime();
-$C = NMISNG::Util::loadConfTable();
-$time = $t->elapTime() - $time;
-print $time. " time load new config \n";
-# Check values
-#print Dumper($C);
+# ENV URL_BASE backward compat
+my $urlbase_result = `NMIS_URL_BASE=/test-cgi perl -I$FindBin::Bin/../lib -e '
+    use NMISNG::Util;
+    my \$C = NMISNG::Util::loadConfTable();
+    print \$C->{"<cgi_url_base>"};
+' 2>/dev/null`;
+is($urlbase_result, "/test-cgi", "ENV NMIS_URL_BASE maps to <cgi_url_base>");
 
-# We need to add here the real values as we need to know if the values are correctly replaced
-is($C->{'auth_htpasswd_file'}, "/usr/local/nmis9_josunec/conf/users.dat", "Replacing Macros from external conf OK" );
-is($C->{'auth_htpasswd_file'}, $C->{'<nmis_conf>'}."/users.dat", "Replacing Macros from external conf OK" );
-is($C->{'syslog_log'}, "/usr/local/nmis9_josunec/logs/cisco.log", "Replacing Macros from master config OK" );
-is($C->{'syslog_log'}, $C->{'<nmis_logs>'}."/cisco.log", "Replacing Macros from master config OK" );
-# Read again to see if it is loading the cache
-#my $C = NMISNG::Util::loadConfTable();
+# Cleanup
+unlink $test_file;
 
-cleanup_db();
 done_testing();

--- a/test/t_nmis_config.pl
+++ b/test/t_nmis_config.pl
@@ -43,6 +43,7 @@ use NMISNG;
 use NMISNG::Log;
 use NMISNG::Util;
 use Compat::Timing;
+use File::Basename;
 use File::Path qw( make_path );
 use File::Copy;
 use File::Temp qw( tempdir );

--- a/test/t_nmis_config.pl
+++ b/test/t_nmis_config.pl
@@ -280,6 +280,80 @@ my $env_new_key_test = `NMIS_BRAND_NEW_TEST_KEY=hello perl -I$FindBin::Bin/../li
 ' 2>/dev/null`;
 is($env_new_key_test, "hello", "ENV can add new keys not in config");
 
+# --- Test 17: writeConfData excludes ENV-sourced keys from written file ---
+my $env_write_test = `NMIS_DB_SERVER=envhost perl -I$FindBin::Bin/../lib -e '
+    use NMISNG::Util;
+    my \$C = NMISNG::Util::loadConfTable();
+    my (\$rawdata, \$fn) = NMISNG::Util::readConfData(only_local => 1);
+    my \$error = NMISNG::Util::writeConfData(data => \$rawdata);
+    die "writeConfData failed: \$error" if \$error;
+    # Read back the written file and check db_server is not in it
+    my \$written = NMISNG::Util::readFiletoHash(file => \$C->{configfile});
+    my \$found = 0;
+    for my \$s (keys %\$written) {
+        \$found = 1 if ref(\$written->{\$s}) eq "HASH" && exists \$written->{\$s}{db_server};
+    }
+    print \$found ? "FOUND" : "EXCLUDED";
+' 2>/dev/null`;
+is($env_write_test, "EXCLUDED", "writeConfData excludes ENV-sourced keys from written file");
+
+# --- Test 18: writeConfData returns error for modified conf.d key ---
+{
+    open(my $fh, '>', $test_file) or die "Could not open file '$test_file' $!";
+    print $fh "%hash = ('authentication'=>{'auth_expire'=>'+5min'});\n";
+    close $fh;
+}
+my $confd_write_test = `perl -I$FindBin::Bin/../lib -e '
+    use NMISNG::Util;
+    my \$C = NMISNG::Util::loadConfTable();
+    my (\$rawdata, \$fn) = NMISNG::Util::readConfData(only_local => 1);
+    # Change the conf.d-managed key
+    \$rawdata->{authentication}{auth_expire} = "+99min";
+    my \$error = NMISNG::Util::writeConfData(data => \$rawdata);
+    print defined(\$error) ? "ERROR:\$error" : "OK";
+' 2>/dev/null`;
+like($confd_write_test, qr/ERROR:.*auth_expire/, "writeConfData returns error for modified conf.d key");
+
+# --- Test 19: writeConfData allows writing normal keys ---
+my $normal_write_test = `perl -I$FindBin::Bin/../lib -e '
+    use NMISNG::Util;
+    my \$C = NMISNG::Util::loadConfTable();
+    my (\$rawdata, \$fn) = NMISNG::Util::readConfData(only_local => 1);
+    \$rawdata->{email}{mail_domain} = "test-changed.example.com";
+    my \$error = NMISNG::Util::writeConfData(data => \$rawdata);
+    die "writeConfData failed: \$error" if \$error;
+    my \$written = NMISNG::Util::readFiletoHash(file => \$C->{configfile});
+    print(\$written->{email}{mail_domain} eq "test-changed.example.com" ? "OK" : "FAIL");
+' 2>/dev/null`;
+is($normal_write_test, "OK", "writeConfData allows writing normal keys");
+
+# Restore config after test 19
+`perl -I$FindBin::Bin/../lib -e '
+    use NMISNG::Util;
+    my \$C = NMISNG::Util::loadConfTable();
+    my \$bak = \$C->{configfile} . ".bak";
+    rename(\$bak, \$C->{configfile}) if -e \$bak;
+' 2>/dev/null`;
+
+# --- Test 20: writeConfData skips unchanged conf.d keys without error ---
+my $confd_unchanged_test = `perl -I$FindBin::Bin/../lib -e '
+    use NMISNG::Util;
+    my \$C = NMISNG::Util::loadConfTable();
+    my (\$rawdata, \$fn) = NMISNG::Util::readConfData(only_local => 1);
+    # Pass data unchanged (includes conf.d merged values)
+    my \$error = NMISNG::Util::writeConfData(data => \$rawdata);
+    print defined(\$error) ? "ERROR:\$error" : "OK";
+' 2>/dev/null`;
+is($confd_unchanged_test, "OK", "writeConfData skips unchanged conf.d keys without error");
+
+# Restore config after test 20
+`perl -I$FindBin::Bin/../lib -e '
+    use NMISNG::Util;
+    my \$C = NMISNG::Util::loadConfTable();
+    my \$bak = \$C->{configfile} . ".bak";
+    rename(\$bak, \$C->{configfile}) if -e \$bak;
+' 2>/dev/null`;
+
 # Cleanup
 unlink $test_file;
 

--- a/test/t_nmis_config.pl
+++ b/test/t_nmis_config.pl
@@ -157,6 +157,84 @@ my $urlbase_result = `NMIS_URL_BASE=/test-cgi perl -I$FindBin::Bin/../lib -e '
 ' 2>/dev/null`;
 is($urlbase_result, "/test-cgi", "ENV NMIS_URL_BASE maps to <cgi_url_base>");
 
+# --- Test 9: stripDefaults returns valid structure ---
+my $strip_test = `perl -I$FindBin::Bin/../lib -e '
+    use NMISNG::Util;
+    my \$C = NMISNG::Util::loadConfTable();
+    my (\$stripped, \$removals) = NMISNG::Util::stripDefaults();
+    die "stripped not hash" unless ref(\$stripped) eq "HASH";
+    die "removals not array" unless ref(\$removals) eq "ARRAY";
+    # stripped should have section keys (deep structure)
+    my \$has_sections = grep { ref(\$stripped->{\$_}) eq "HASH" } keys %\$stripped;
+    die "no sections in stripped" unless \$has_sections;
+    # each removal should have section and key
+    for my \$r (@\$removals) {
+        die "bad removal entry" unless defined \$r->{section} && defined \$r->{key};
+    }
+    print "OK";
+' 2>/dev/null`;
+is($strip_test, "OK", "stripDefaults returns valid structure");
+
+# --- Test 10: stripDefaults removals only contain values matching defaults ---
+my $strip_match_test = `perl -I$FindBin::Bin/../lib -e '
+    use NMISNG::Util;
+    my \$C = NMISNG::Util::loadConfTable();
+    my \$default_file = \$C->{"<nmis_conf_default>"} . "/Config.nmis";
+    my \$defaults = NMISNG::Util::readFiletoHash(file => \$default_file);
+    my (\$stripped, \$removals) = NMISNG::Util::stripDefaults();
+    # every removal must exist in defaults with the same value
+    for my \$r (@\$removals) {
+        my \$s = \$r->{section};
+        my \$k = \$r->{key};
+        die "removal \$s/\$k not in defaults" unless ref(\$defaults->{\$s}) eq "HASH"
+            && exists \$defaults->{\$s}{\$k};
+    }
+    print "OK";
+' 2>/dev/null`;
+is($strip_match_test, "OK", "stripDefaults removals all exist in defaults");
+
+# --- Test 11: stripDefaults keeps site-only keys ---
+# Write a conf.d file with an override, then verify stripDefaults keeps overridden values
+{
+    open(my $fh, '>', $test_file) or die "Could not open file '$test_file' $!";
+    print $fh "%hash = ('authentication'=>{'auth_expire'=>'+99min'});\n";
+    close $fh;
+}
+my $strip_keep_test = `perl -I$FindBin::Bin/../lib -e '
+    use NMISNG::Util;
+    my \$C = NMISNG::Util::loadConfTable();
+    my (\$stripped, \$removals) = NMISNG::Util::stripDefaults();
+    # auth_expire in conf/Config.nmis should match the default (+30min),
+    # so it should be in removals (the conf.d override is separate from conf/Config.nmis)
+    # Verify stripped + defaults covers all keys from site config
+    my \$site = NMISNG::Util::readFiletoHash(file => \$C->{configfile});
+    for my \$section (keys %\$site) {
+        next unless ref(\$site->{\$section}) eq "HASH";
+        for my \$key (keys %{\$site->{\$section}}) {
+            my \$in_stripped = ref(\$stripped->{\$section}) eq "HASH"
+                && exists \$stripped->{\$section}{\$key};
+            my \$in_removals = grep { \$_->{section} eq \$section && \$_->{key} eq \$key } @\$removals;
+            die "key \$section/\$key lost" unless \$in_stripped || \$in_removals;
+        }
+    }
+    print "OK";
+' 2>/dev/null`;
+is($strip_keep_test, "OK", "stripDefaults: every site key is either kept or in removals");
+
+# --- Test 12: stripDefaults empty sections are removed ---
+my $strip_empty_test = `perl -I$FindBin::Bin/../lib -e '
+    use NMISNG::Util;
+    my \$C = NMISNG::Util::loadConfTable();
+    my (\$stripped, \$removals) = NMISNG::Util::stripDefaults();
+    # no empty sections should exist in stripped
+    for my \$section (keys %\$stripped) {
+        next unless ref(\$stripped->{\$section}) eq "HASH";
+        die "empty section \$section" unless keys %{\$stripped->{\$section}};
+    }
+    print "OK";
+' 2>/dev/null`;
+is($strip_empty_test, "OK", "stripDefaults: no empty sections in result");
+
 # Cleanup
 unlink $test_file;
 


### PR DESCRIPTION
The configuration system uses layered loading with source tracking. Config files use a two-level Perl hash format (%hash = (section => {key => value, ...}, ...)). At runtime, the two-level structure is flattened into a single hash with macro expansion for path references.