### PR TITLE
Fix/dev container snmpd

### DIFF
--- a/docker-dev/compose-dev.yaml
+++ b/docker-dev/compose-dev.yaml
@@ -43,6 +43,7 @@ services:
       - ../:/usr/local/nmis9
     ports:
       - "8080:8080"
+      - "10001:161/udp"
     networks:
       - nmis_net
 networks:

--- a/docker-dev/docker-entrypoint-dev.sh
+++ b/docker-dev/docker-entrypoint-dev.sh
@@ -85,9 +85,23 @@ dev_user_map() {
     -exec chown "$DEV_UID:$DEV_GID" {} +
 }
 
+start_apps() {
+  services=("snmpd")
+    for service in "${services[@]}"; do
+      echo "Starting $service daemon..."
+      service $service start
+      if [ $? -eq 0 ]; then
+          echo "$service service started successfully."
+      else
+          echo "Failed to start $service service."
+      fi
+    done
+}
+
 run() {
   setup
   setup_db
+  start_apps
   dev_user_map
   nmis_frontend
   # Tail something to keep the container alive

--- a/docker-dev/dockerfile-dev
+++ b/docker-dev/dockerfile-dev
@@ -142,6 +142,8 @@ RUN git clone https://github.com/gdraheim/docker-systemctl-replacement && \
 RUN addgroup --gid ${NMIS_USER_GID} ${NMIS_GROUP} && \
     useradd --uid ${NMIS_USER_UID} --gid ${NMIS_GROUP} --shell /bin/bash ${NMIS_USER}
 
+COPY ../conf-default/snmpd/snmpd.conf ../conf-default/snmpd/snmptrapd.conf  /etc/snmp/
+
 WORKDIR ${NMIS_HOME}
 
 # NMIS Web 8080


### PR DESCRIPTION
* Copy NMIS9 default snmpd.conf and snmpdtrap.conf into the container
* Have snmpd service running in docker-entrypoint-dev.sh