### PR TITLE
Test polling infrastructure

### DIFF
--- a/ci/scripts/perl_tests.sh
+++ b/ci/scripts/perl_tests.sh
@@ -18,6 +18,8 @@ working_tests=(
     t_model_data.pl
     t_db_stats.pl
     nmisng_log.t
+    t_sys.pl
+    t_polling.pl
 )
 
 for i in "${working_tests[@]}"; do

--- a/models-default/Model-TestSnmp.nmis
+++ b/models-default/Model-TestSnmp.nmis
@@ -1,0 +1,296 @@
+#
+# Model-TestSnmp.nmis - Test model for SNMP polling pipeline validation
+# This model is used by test/t_polling.pl and should not be assigned to real devices.
+#
+%hash = (
+	'-common-' => {
+		'class' => {
+			'database' => {
+				'common-model' => 'database'
+			}
+		}
+	},
+	'system' => {
+		'nodegraph' => 'health,response',
+		'nodeModel' => 'TestSnmp',
+		'nodeType'  => 'generic',
+		'sys' => {
+			'standard' => {
+				'snmp' => {
+					'sysDescr' => {
+						'oid' => 'sysDescr',
+						'title' => 'Description'
+					},
+					'sysObjectID' => {
+						'oid' => 'sysObjectID'
+					},
+					'sysUpTime' => {
+						'oid' => 'sysUpTime',
+						'title' => 'Uptime'
+					},
+					'ifNumber' => {
+						'oid' => 'ifNumber',
+						'title' => 'Interfaces'
+					},
+					'sysName' => {
+						'oid' => 'sysName',
+						'title' => 'System Name'
+					},
+					'sysLocation' => {
+						'oid' => 'sysLocation',
+						'title' => 'Location'
+					},
+					'sysContact' => {
+						'oid' => 'sysContact',
+						'title' => 'Contact'
+					}
+				}
+			}
+		},
+		'rrd' => {
+			'mib2ip' => {
+				'graphtype' => 'ip,fwd',
+				'snmp' => {
+					'ipInReceives' => {
+						'oid' => 'ipInReceives',
+						'option' => 'counter,0:U',
+						'title' => 'IP In Receives'
+					},
+					'ipInDelivers' => {
+						'oid' => 'ipInDelivers',
+						'option' => 'counter,0:U',
+						'title' => 'IP In Delivers'
+					},
+					'ipOutRequests' => {
+						'oid' => 'ipOutRequests',
+						'option' => 'counter,0:U',
+						'title' => 'IP Out Requests',
+						'alert' => {
+							'test' => '$r > 1000000',
+							'event' => 'High IP Traffic',
+							'level' => 'Warning'
+						}
+					}
+				}
+			},
+			'testProcessing' => {
+				'graphtype' => 'testProcessing',
+				'snmp' => {
+					'rawCounter' => {
+						'oid' => '1.3.6.1.4.1.99999.2.1.0',
+						'option' => 'gauge,0:U',
+						'title' => 'Raw Counter'
+					},
+					'calcValue' => {
+						'oid' => '1.3.6.1.4.1.99999.2.2.0',
+						'option' => 'gauge,0:U',
+						'title' => 'Calculated Value',
+						'calculate' => 'CVAR1=rawCounter;return int($r / 10) + $CVAR1;'
+					},
+					'fmtValue' => {
+						'oid' => '1.3.6.1.4.1.99999.2.3.0',
+						'option' => 'gauge,0:U',
+						'title' => 'Formatted Value',
+						'format' => '%.2f'
+					},
+					'replValue' => {
+						'oid' => '1.3.6.1.4.1.99999.2.4.0',
+						'option' => 'gauge,0:U',
+						'title' => 'Replaced Value',
+						'replace' => {
+							'1' => 'Up',
+							'2' => 'Down',
+							'unknown' => 'Other'
+						}
+					},
+					'replNoFallback' => {
+						'oid' => '1.3.6.1.4.1.99999.2.5.0',
+						'option' => 'gauge,0:U',
+						'title' => 'Replace No Fallback',
+						'replace' => {
+							'1' => 'Up',
+							'2' => 'Down'
+						}
+					},
+					'nosaveValue' => {
+						'oid' => '1.3.6.1.4.1.99999.2.6.0',
+						'option' => 'nosave',
+						'title' => 'Nosave Value',
+						'alert' => {
+							'test' => '$r > 0',
+							'event' => 'Nosave Alert Should Not Fire',
+							'level' => 'Critical'
+						}
+					},
+					'htmlValue' => {
+						'oid' => '1.3.6.1.4.1.99999.2.7.0',
+						'option' => 'nosave',
+						'title' => 'HTML Value'
+					},
+					'calcUndef' => {
+						'oid' => '1.3.6.1.4.1.99999.2.8.0',
+						'option' => 'gauge,0:U',
+						'title' => 'Calc Undef',
+						'calculate' => 'return undef;',
+						'alert' => {
+							'test' => '$r > 0',
+							'event' => 'CalcUndef Alert Should Not Fire',
+							'level' => 'Critical'
+						}
+					}
+				}
+			},
+			'testSkipped' => {
+				'graphtype' => 'testSkipped',
+				'control' => '$nodeModel eq "NeverMatch"',
+				'snmp' => {
+					'skippedItem' => {
+						'oid' => '1.3.6.1.4.1.99999.2.20.0',
+						'option' => 'gauge,0:U',
+						'title' => 'Should Be Skipped'
+					}
+				}
+			},
+			'testSkipCollect' => {
+				'graphtype' => 'testSkipCollect',
+				'skip_collect' => 'true',
+				'snmp' => {
+					'skipCollectItem' => {
+						'oid' => '1.3.6.1.4.1.99999.2.21.0',
+						'option' => 'gauge,0:U',
+						'title' => 'Should Be Skip Collected'
+					}
+				}
+			}
+		}
+	},
+	'systemHealth' => {
+		'sections' => 'testSensor,testCalcOid',
+		'sys' => {
+			'testCalcOid' => {
+				'indexed' => 'testCalcOidName',
+				'index_oid' => '1.3.6.1.4.1.99999.3.2',
+				'headers' => 'testCalcOidName',
+				'snmp' => {
+					'testCalcOidName' => {
+						'oid' => '1.3.6.1.4.1.99999.3.2',
+						'title' => 'CalcOid Name',
+						'sysObjectName' => 'testCalcOidName'
+					}
+				}
+			},
+			'testSensor' => {
+				'indexed' => 'testSensorName',
+				'index_oid' => '1.3.6.1.4.1.99999.1.1.1.2',
+				'headers' => 'testSensorName,testSensorStatus',
+				'snmp' => {
+					'testSensorName' => {
+						'oid' => '1.3.6.1.4.1.99999.1.1.1.2',
+						'title' => 'Sensor Name',
+						'sysObjectName' => 'testSensorName'
+					},
+					'testSensorStatus' => {
+						'oid' => '1.3.6.1.4.1.99999.1.1.1.4',
+						'title' => 'Sensor Status',
+						'sysObjectName' => 'testSensorStatus'
+					}
+				}
+			}
+		},
+		'rrd' => {
+			'testSensor' => {
+				'graphtype' => 'testSensor',
+				'indexed' => 'true',
+				'threshold' => 'testSensorUtil',
+				'snmp' => {
+					'testSensorValue' => {
+						'oid' => '1.3.6.1.4.1.99999.1.1.1.3',
+						'option' => 'gauge,0:U',
+						'title' => 'Sensor Value',
+						'sysObjectName' => 'testSensorValue',
+						'alert' => {
+							'test' => '$r > 90',
+							'event' => 'High Sensor Value',
+							'level' => 'Warning'
+						}
+					}
+				}
+			},
+			'testCalcOid' => {
+				'graphtype' => 'testCalcOid',
+				'indexed' => 'true',
+				'snmp' => {
+					'calcOidValue' => {
+						'oid' => '1.3.6.1.4.1.99999.3.1',
+						'option' => 'gauge,0:U',
+						'title' => 'Calc OID Value',
+						'calculate_index' => 'CVAR1=index;return "$CVAR1.0";'
+					}
+				}
+			}
+		}
+	},
+	'alerts' => {
+		'testSensor' => {
+			'testSensorTestAlert' => {
+				'type' => 'test',
+				'test' => 'CVAR1=testSensorValue;$CVAR1 > 80',
+				'value' => 'CVAR1=testSensorValue;$CVAR1',
+				'event' => 'Custom Sensor Alert',
+				'unit' => '',
+				'level' => 'Minor',
+				'element' => 'testSensorName'
+			},
+			'testSensorThresholdAlert' => {
+				'type' => 'threshold-rising',
+				'threshold' => {
+					'Warning' => '70',
+					'Minor' => '80',
+					'Major' => '90',
+					'Critical' => '95',
+					'Fatal' => '99'
+				},
+				'value' => 'CVAR1=testSensorValue;$CVAR1',
+				'event' => 'Custom Sensor Threshold',
+				'unit' => '',
+				'element' => 'testSensorName'
+			}
+		}
+	},
+	'threshold' => {
+		'name' => {
+			'testSensorUtil' => {
+				'item' => 'testSensorUtil',
+				'event' => 'Proactive Sensor Utilisation',
+				'select' => {
+					'default' => {
+						'value' => {
+							'warning' => '80',
+							'minor' => '85',
+							'major' => '90',
+							'critical' => '95',
+							'fatal' => '99'
+						}
+					}
+				},
+				'title' => 'Sensor Utilisation',
+				'unit' => '%'
+			}
+		}
+	},
+	'stats' => {
+		'type' => {
+			'testSensor' => [
+				'DEF:val=$database:testSensorValue:AVERAGE',
+				'CDEF:testSensorUtil=val,1,*',
+				'PRINT:testSensorUtil:AVERAGE:testSensorUtil=%1.2lf'
+			],
+			'health' => [
+				'DEF:reachability=$database:reachability:AVERAGE',
+				'DEF:availability=$database:availability:AVERAGE',
+				'PRINT:reachability:AVERAGE:reachability=%1.2lf',
+				'PRINT:availability:AVERAGE:availability=%1.2lf'
+			]
+		}
+	}
+);

--- a/models-default/Model-TestWmi.nmis
+++ b/models-default/Model-TestWmi.nmis
@@ -1,0 +1,179 @@
+#
+# Model-TestWmi.nmis - Test model for WMI polling pipeline validation
+# This model is used by test/t_polling.pl and should not be assigned to real devices.
+#
+%hash = (
+	'-common-' => {
+		'class' => {
+			'database' => {
+				'common-model' => 'database'
+			}
+		}
+	},
+	'system' => {
+		'nodegraph' => 'health,response',
+		'nodeModel' => 'TestWmi',
+		'nodeType'  => 'server',
+		'sys' => {
+			'standard' => {
+				'wmi' => {
+					'winosname' => {
+						'query' => 'select Caption from Win32_OperatingSystem',
+						'field' => 'Caption',
+						'title' => 'OS Name'
+					},
+					'winversion' => {
+						'query' => 'select Version from Win32_OperatingSystem',
+						'field' => 'Version',
+						'title' => 'OS Version'
+					},
+					'winbuild' => {
+						'query' => 'select BuildNumber from Win32_OperatingSystem',
+						'field' => 'BuildNumber',
+						'title' => 'Build Number'
+					},
+					'winsysname' => {
+						'query' => 'select CSName from Win32_OperatingSystem',
+						'field' => 'CSName',
+						'title' => 'System Name'
+					},
+					'wintime' => {
+						'query' => 'select LocalDateTime from Win32_OperatingSystem',
+						'field' => 'LocalDateTime',
+						'title' => 'Local Time',
+						'calculate' => 'return time();'
+					},
+					'winboottime' => {
+						'query' => 'select LastBootUpTime from Win32_OperatingSystem',
+						'field' => 'LastBootUpTime',
+						'title' => 'Boot Time',
+						'calculate' => 'return time() - 86400;'
+					}
+				}
+			}
+		},
+		'rrd' => {
+			'wmiCpu' => {
+				'graphtype' => 'wmiCpu',
+				'wmi' => {
+					'percentProcessor' => {
+						'query' => "select PercentProcessorTime from Win32_PerfFormattedData_PerfOS_Processor where Name='_Total'",
+						'field' => 'PercentProcessorTime',
+						'option' => 'gauge,0:U',
+						'title' => 'CPU Usage',
+						'alert' => {
+							'test' => '$r > 90',
+							'event' => 'High WMI CPU',
+							'level' => 'Warning'
+						}
+					}
+				}
+			}
+		}
+	},
+	'systemHealth' => {
+		'sections' => 'wmiDisk',
+		'sys' => {
+			'wmiDisk' => {
+				'indexed' => 'Name',
+				'headers' => 'Name,wmiDiskSize',
+				'wmi' => {
+					'Name' => {
+						'query' => 'select Name,Size,FreeSpace from Win32_LogicalDisk where DriveType=3',
+						'field' => 'Name',
+						'title' => 'Disk Name',
+						'indexed' => 'true'
+					},
+					'wmiDiskSize' => {
+						'query' => 'select Name,Size,FreeSpace from Win32_LogicalDisk where DriveType=3',
+						'field' => 'Size',
+						'title' => 'Disk Size'
+					}
+				}
+			}
+		},
+		'rrd' => {
+			'wmiDisk' => {
+				'graphtype' => 'wmiDisk',
+				'indexed' => 'Name',
+				'threshold' => 'wmiDiskUtil',
+				'wmi' => {
+					'wmiDiskFreeSpace' => {
+						'query' => 'select Name,Size,FreeSpace from Win32_LogicalDisk where DriveType=3',
+						'field' => 'FreeSpace',
+						'option' => 'gauge,0:U',
+						'title' => 'Free Space',
+						'alert' => {
+							'test' => '$r < 1073741824',
+							'event' => 'Low Disk Space',
+							'level' => 'Warning'
+						}
+					}
+				}
+			}
+		}
+	},
+	'alerts' => {
+		'wmiDisk' => {
+			'wmiDiskTestAlert' => {
+				'type' => 'test',
+				'test' => 'CVAR1=wmiDiskFreeSpace;$CVAR1 < 5368709120',
+				'value' => 'CVAR1=wmiDiskFreeSpace;$CVAR1',
+				'event' => 'Custom Disk Alert',
+				'unit' => 'bytes',
+				'level' => 'Minor',
+				'element' => 'Name'
+			},
+			'wmiDiskThresholdAlert' => {
+				'type' => 'threshold-rising',
+				'threshold' => {
+					'Warning' => '70',
+					'Minor' => '80',
+					'Major' => '90',
+					'Critical' => '95',
+					'Fatal' => '99'
+				},
+				'value' => 'CVAR1=wmiDiskFreeSpace;CVAR2=wmiDiskSize;return sprintf("%.0f", (1 - $CVAR1/$CVAR2) * 100)',
+				'event' => 'Custom Disk Threshold',
+				'unit' => '%',
+				'element' => 'Name'
+			}
+		}
+	},
+	'threshold' => {
+		'name' => {
+			'wmiDiskUtil' => {
+				'item' => 'wmiDiskUtil',
+				'event' => 'Proactive Disk Utilisation',
+				'select' => {
+					'default' => {
+						'value' => {
+							'warning' => '80',
+							'minor' => '85',
+							'major' => '90',
+							'critical' => '95',
+							'fatal' => '99'
+						}
+					}
+				},
+				'title' => 'Disk Utilisation',
+				'unit' => '%'
+			}
+		}
+	},
+	'stats' => {
+		'type' => {
+			'wmiDisk' => [
+				'DEF:free=$database:wmiDiskFreeSpace:AVERAGE',
+				'CDEF:wmiDiskUtil=free,1,*',
+				'PRINT:wmiDiskUtil:AVERAGE:wmiDiskUtil=%1.2lf'
+			],
+			'health' => [
+				'DEF:reachability=$database:reachability:AVERAGE',
+				'DEF:availability=$database:availability:AVERAGE',
+				'PRINT:reachability:AVERAGE:reachability=%1.2lf',
+				'PRINT:availability:AVERAGE:availability=%1.2lf'
+			]
+		}
+	}
+);

--- a/test/lib/NMISNG/Snmp/Mock.pm
+++ b/test/lib/NMISNG/Snmp/Mock.pm
@@ -1,0 +1,312 @@
+package NMISNG::Snmp::Mock;
+# Mock SNMP class for testing - implements the NMISNG::Snmp interface
+# but returns data from an in-memory hash instead of real SNMP queries.
+
+use strict;
+use warnings;
+use Scalar::Util;
+use NMISNG::MIB;
+
+sub new
+{
+	my ($class, %arg) = @_;
+
+	my $self = bless({
+		name      => $arg{name} || 'mock',
+		walk_data => $arg{walk_data} || {},
+		_nmisng   => $arg{nmisng},
+		error     => undef,
+		session   => 0,
+		config    => {},
+		actual_version      => 'snmpv2c',
+		actual_max_msg_size => 1472,
+	}, $class);
+
+	Scalar::Util::weaken $self->{_nmisng}
+		if ($self->{_nmisng} && !Scalar::Util::isweak($self->{_nmisng}));
+
+	return $self;
+}
+
+sub nmisng { return shift->{_nmisng}; }
+
+sub name
+{
+	my ($self, $newname) = @_;
+	$self->{name} = $newname if defined $newname;
+	return $self->{name};
+}
+
+sub error
+{
+	my ($self) = @_;
+	return $self->{_forced_error} if defined $self->{_forced_error};
+	return $self->{error};
+}
+
+sub version
+{
+	my ($self) = @_;
+	return $self->{session} ? $self->{actual_version} : undef;
+}
+
+sub max_msg_size
+{
+	my ($self) = @_;
+	return $self->{session} ? $self->{actual_max_msg_size} : undef;
+}
+
+sub isopen
+{
+	my ($self) = @_;
+	return $self->{session} ? 1 : 0;
+}
+
+# Delegate to real MIB resolution
+sub name_to_oid
+{
+	my ($self, $zero, $name) = @_;
+	my $oid;
+
+	if ($name =~ /^(\w+)(.*)$/)
+	{
+		$oid = NMISNG::MIB::name2oid($self->nmisng, $1) . $2;
+	}
+	else
+	{
+		$oid = NMISNG::MIB::name2oid($self->nmisng, $name);
+	}
+
+	if (defined($oid))
+	{
+		$oid .= ".0" if ($zero && $name !~ /\./);
+		return $oid;
+	}
+	else
+	{
+		$self->{error} = "Mib name $name does not exist!";
+		return undef;
+	}
+}
+
+# Translate OID keys to names
+sub keys2name
+{
+	my ($self, $hash) = @_;
+	my %rewritten;
+	for my $oid (keys %{$hash})
+	{
+		my $name = NMISNG::MIB::oid2name($self->nmisng, $oid) || $oid;
+		$rewritten{$name} = $hash->{$oid};
+	}
+	return \%rewritten;
+}
+
+# Force an error state for testing error handling paths.
+# When set, getarray() returns undef and error() returns the forced string.
+# Call with undef to clear.
+sub force_error
+{
+	my ($self, $error_string) = @_;
+	$self->{_forced_error} = $error_string;
+}
+
+# Open: just store config and mark session as open
+sub open
+{
+	my ($self, %args) = @_;
+
+	if (ref($args{config}) eq "HASH")
+	{
+		$self->{config} = $args{config};
+	}
+	else
+	{
+		$self->{config} = \%args;
+	}
+	$self->{config}{oidpkt} ||= 10;
+	$self->{session} = 1;
+	$self->{error} = undef;
+	return 1;
+}
+
+sub close
+{
+	my ($self) = @_;
+	$self->{session} = 0;
+	return undef;
+}
+
+# Test session by checking if sysObjectID.0 exists in walk data
+sub testsession
+{
+	my ($self) = @_;
+	my $oid = "1.3.6.1.2.1.1.2.0";
+	my $result = $self->get($oid);
+	return (ref($result) eq "HASH" && $result->{$oid}) ? 1 : 0;
+}
+
+# Get: look up each OID in walk_data, return hashref
+sub get
+{
+	my ($self, @vars) = @_;
+
+	if (!$self->{session})
+	{
+		$self->{error} = "No session open, cannot perform get!";
+		return undef;
+	}
+
+	my @certainlyoids;
+	for my $var (@vars)
+	{
+		if ($var =~ /^(\.?\d+)+$/)
+		{
+			push @certainlyoids, $var;
+		}
+		else
+		{
+			if (my $oid = $self->name_to_oid(1, $var))
+			{
+				push @certainlyoids, $oid;
+			}
+			else
+			{
+				return undef;
+			}
+		}
+	}
+
+	my %result;
+	for my $oid (@certainlyoids)
+	{
+		if (exists $self->{walk_data}{$oid})
+		{
+			$result{$oid} = $self->{walk_data}{$oid};
+		}
+		else
+		{
+			# SNMP returns noSuchInstance for missing OIDs but doesn't fail the whole request
+			$result{$oid} = "NOSUCHINSTANCE";
+		}
+	}
+
+	$self->{error} = undef;
+	return \%result;
+}
+
+# Getarray: return values in input order
+sub getarray
+{
+	my ($self, @vars) = @_;
+
+	if (!$self->{session})
+	{
+		$self->{error} = "No session open, cannot perform getarray!";
+		return undef;
+	}
+
+	# If a forced error is set, simulate transport failure
+	return undef if defined $self->{_forced_error};
+
+	my @certainlyoids;
+	for my $var (@vars)
+	{
+		if ($var =~ /^(\.?\d+)+$/)
+		{
+			push @certainlyoids, $var;
+		}
+		else
+		{
+			if (my $oid = $self->name_to_oid(1, $var))
+			{
+				push @certainlyoids, $oid;
+			}
+			else
+			{
+				return undef;
+			}
+		}
+	}
+
+	my @retvals;
+	for my $oid (@certainlyoids)
+	{
+		if (exists $self->{walk_data}{$oid})
+		{
+			push @retvals, $self->{walk_data}{$oid};
+		}
+		else
+		{
+			push @retvals, "NOSUCHINSTANCE";
+		}
+	}
+
+	$self->{error} = undef;
+	return @retvals;
+}
+
+# Gettable: return all OIDs in walk_data with matching prefix
+sub gettable
+{
+	my ($self, $name, $maxrepetitions, $rewritekeys) = @_;
+
+	if (!$self->{session})
+	{
+		$self->{error} = "No session open, cannot perform gettable!";
+		return undef;
+	}
+
+	# Translate name to numeric OID if needed
+	if ($name !~ /^(\.?\d+)+$/)
+	{
+		if (my $oid = $self->name_to_oid(0, $name))
+		{
+			$name = $oid;
+		}
+		else
+		{
+			$self->{error} = "Incorrect mib name, could not translate name:$name to oid";
+			return undef;
+		}
+	}
+
+	my %result;
+	for my $oid (keys %{$self->{walk_data}})
+	{
+		# Match OIDs that start with the base OID followed by a dot
+		if ($oid =~ /^\Q$name\E\./)
+		{
+			$result{$oid} = $self->{walk_data}{$oid};
+		}
+	}
+
+	if (!%result)
+	{
+		$self->{error} = "Requested table $name is empty or does not exist";
+		return undef;
+	}
+
+	if ($rewritekeys)
+	{
+		for my $fullkey (keys %result)
+		{
+			my $newkey = $fullkey;
+			$newkey =~ s/^\Q$name\E\.//;
+			$result{$newkey} = $result{$fullkey};
+			delete $result{$fullkey};
+		}
+	}
+
+	$self->{error} = undef;
+	return \%result;
+}
+
+# Getindex: gettable with rewritekeys=1
+sub getindex
+{
+	my ($self, $name, $maxrepetitions) = @_;
+	return $self->gettable($name, $maxrepetitions, 1);
+}
+
+1;

--- a/test/lib/NMISNG/WMI/Mock.pm
+++ b/test/lib/NMISNG/WMI/Mock.pm
@@ -1,0 +1,148 @@
+package NMISNG::WMI::Mock;
+# Mock WMI class for testing - implements the NMISNG::WMI interface
+# but returns data from an in-memory hash instead of real WMI queries.
+
+use strict;
+use warnings;
+
+# Constructor
+# args: wmi_data => { "WQL query" => [ { field => value, ... }, ... ], ... }
+sub new
+{
+	my ($class, %arg) = @_;
+
+	# Match real WMI.pm: return error string on missing required args
+	return "NMISNG::WMI::Mock requires wmi_data argument" if (!$arg{wmi_data});
+
+	my $self = bless({
+		wmi_data => $arg{wmi_data} || {},
+		host     => $arg{host} || 'mock',
+		error    => undef,
+	}, $class);
+
+	return $self;
+}
+
+# Get single row result
+# args: wql => query, fields => [field list] (optional)
+# returns: (undef, {field => value}, {classname => "Mock"}) on success
+#      or: ("error message") on failure
+sub get
+{
+	my ($self, %args) = @_;
+	my $query = $args{wql};
+	my $fields = $args{fields};
+
+	if (!$query)
+	{
+		return "No WQL query provided";
+	}
+
+	# Look up exact query match first, then try case-insensitive
+	my $rows = $self->{wmi_data}{$query};
+	if (!$rows)
+	{
+		for my $key (keys %{$self->{wmi_data}})
+		{
+			if (lc($key) eq lc($query))
+			{
+				$rows = $self->{wmi_data}{$key};
+				last;
+			}
+		}
+	}
+
+	if (!$rows || !@$rows)
+	{
+		return "No mock data found for query: $query";
+	}
+
+	my $row = $rows->[0];
+
+	# Filter fields if requested
+	if ($fields && @$fields)
+	{
+		my %filtered;
+		for my $f (@$fields)
+		{
+			$filtered{$f} = $row->{$f} if exists $row->{$f};
+		}
+		$row = \%filtered;
+	}
+
+	return (undef, $row, { classname => "MockClass" });
+}
+
+# Get table (multiple rows) indexed by a field
+# args: wql => query, index => field_name, fields => [field list] (optional)
+# returns: (undef, { index_value => {field => value} }, {classname => "Mock", index => field}) on success
+#      or: ("error message") on failure
+sub gettable
+{
+	my ($self, %args) = @_;
+	my $query      = $args{wql};
+	my $index_field = $args{index};
+	my $fields     = $args{fields};
+
+	if (!$query)
+	{
+		return "No WQL query provided";
+	}
+
+	# Look up query
+	my $rows = $self->{wmi_data}{$query};
+	if (!$rows)
+	{
+		for my $key (keys %{$self->{wmi_data}})
+		{
+			if (lc($key) eq lc($query))
+			{
+				$rows = $self->{wmi_data}{$key};
+				last;
+			}
+		}
+	}
+
+	if (!$rows || !@$rows)
+	{
+		return "No mock data found for query: $query";
+	}
+
+	my %result;
+	my $used_index = $index_field;
+	my $row_num = 0;
+
+	for my $row (@$rows)
+	{
+		my $idx;
+		if ($index_field && exists $row->{$index_field})
+		{
+			$idx = $row->{$index_field};
+		}
+		else
+		{
+			# Fall back to row number
+			$idx = $row_num;
+			$used_index = undef;
+		}
+
+		# Filter fields if requested
+		my $data = $row;
+		if ($fields && @$fields)
+		{
+			my %filtered;
+			for my $f (@$fields)
+			{
+				$filtered{$f} = $row->{$f} if exists $row->{$f};
+			}
+			$data = \%filtered;
+		}
+
+		$result{$idx} = $data;
+		$row_num++;
+	}
+
+	return (undef, \%result, { classname => "MockClass", index => $used_index });
+}
+
+1;

--- a/test/t_polling.pl
+++ b/test/t_polling.pl
@@ -1,0 +1,1072 @@
+#!/usr/bin/perl
+#
+# t_polling.pl - Test the NMIS9 polling pipeline with mock SNMP/WMI data.
+# Creates a temporary MongoDB database, exercises update and collect sub-functions
+# using mock objects, and validates inventory, alerts, thresholds, and stats.
+#
+
+use strict;
+use warnings;
+our $VERSION = "1.0.0";
+
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use lib "$FindBin::Bin/lib";
+
+use Test::More;
+use Test::Deep;
+use Data::Dumper;
+use JSON::XS;
+use File::Slurp;
+use File::Path qw(make_path remove_tree);
+use Clone qw(clone);
+
+use NMISNG;
+use NMISNG::Node;
+use NMISNG::Sys;
+use NMISNG::Log;
+use NMISNG::Util;
+use NMISNG::Status;
+use NMISNG::Inventory;
+use Compat::NMIS;
+use Compat::Timing;
+
+use NMISNG::Snmp::Mock;
+use NMISNG::WMI::Mock;
+use NMISNG::rrdfunc;
+use RRDs;
+
+# ============================================================
+# Phase 1: Setup
+# ============================================================
+my $C = NMISNG::Util::loadConfTable();
+die "Cannot load config" if (!$C);
+
+# Test-specific database
+$C->{db_name} = "t_polling-" . time;
+
+# Temp RRD directory
+my $tmp_rrd_dir = "/tmp/t_polling_rrd_$$";
+make_path($tmp_rrd_dir);
+my $orig_db_root = $C->{database_root};
+
+# Enable thresholds
+$C->{global_threshold} = 'true';
+$C->{threshold_poll_node} = 'true';
+
+my $logger = NMISNG::Log->new(level => 'info');
+my $nmisng = NMISNG->new(config => $C, log => $logger);
+die "NMISNG object required" if (!$nmisng);
+
+sub cleanup
+{
+	$nmisng->get_db()->drop();
+	remove_tree($tmp_rrd_dir) if -d $tmp_rrd_dir;
+}
+
+# Load walk data
+my $snmp_walk_json = read_file("$FindBin::Bin/testdata/snmpwalk_test.json");
+my $snmp_walk_raw = decode_json($snmp_walk_json);
+# Strip comment keys
+my %snmp_walk;
+for my $k (keys %$snmp_walk_raw) {
+	$snmp_walk{$k} = $snmp_walk_raw->{$k} unless $k =~ /^_/;
+}
+
+my $wmi_data_json = read_file("$FindBin::Bin/testdata/wmi_test.json");
+my $wmi_data_raw = decode_json($wmi_data_json);
+my %wmi_data;
+for my $k (keys %$wmi_data_raw) {
+	$wmi_data{$k} = $wmi_data_raw->{$k} unless $k =~ /^_/;
+}
+
+# Monkey-patch create_update_rrd to skip actual RRD I/O but record storage
+{
+	no warnings 'redefine';
+	my $orig_create_update_rrd = \&NMISNG::Sys::create_update_rrd;
+	*NMISNG::Sys::create_update_rrd = sub {
+		my ($self, %args) = @_;
+		if (ref($args{inventory}))
+		{
+			my $type = $args{type} || 'unknown';
+			my $db_path = "/nodes/$self->{name}/mock-$type.rrd";
+			$args{inventory}->set_subconcept_type_storage(
+				subconcept => $type, type => 'rrd',
+				data => $db_path
+			);
+		}
+		return 1;
+	};
+}
+
+# Monkey-patch getSubconceptStats to return deterministic values
+my %mock_stats;
+{
+	no warnings 'redefine';
+	*Compat::NMIS::getSubconceptStats = sub {
+		my %args = @_;
+		my $subconcept = $args{subconcept};
+		my $stats_section = $args{stats_section} // $subconcept;
+		if (exists $mock_stats{$stats_section})
+		{
+			return clone($mock_stats{$stats_section});
+		}
+		return {};
+	};
+}
+
+# OID constants for readability when referencing walk data
+use constant {
+	OID_sysDescr     => '1.3.6.1.2.1.1.1.0',
+	OID_sysObjectID  => '1.3.6.1.2.1.1.2.0',
+	OID_sysUpTime    => '1.3.6.1.2.1.1.3.0',
+	OID_sysContact   => '1.3.6.1.2.1.1.4.0',
+	OID_sysName      => '1.3.6.1.2.1.1.5.0',
+	OID_sysLocation  => '1.3.6.1.2.1.1.6.0',
+	OID_ifNumber     => '1.3.6.1.2.1.2.1.0',
+	OID_sensorName1  => '1.3.6.1.4.1.99999.1.1.1.2.1',
+	OID_sensorName2  => '1.3.6.1.4.1.99999.1.1.1.2.2',
+	OID_sensorVal1   => '1.3.6.1.4.1.99999.1.1.1.3.1',
+	OID_sensorVal2   => '1.3.6.1.4.1.99999.1.1.1.3.2',
+	OID_sensorStat1  => '1.3.6.1.4.1.99999.1.1.1.4.1',
+	OID_sensorStat2  => '1.3.6.1.4.1.99999.1.1.1.4.2',
+	OID_sensorName3  => '1.3.6.1.4.1.99999.1.1.1.2.3',
+	OID_sensorStat3  => '1.3.6.1.4.1.99999.1.1.1.4.3',
+	OID_sensorVal3   => '1.3.6.1.4.1.99999.1.1.1.3.3',
+};
+
+# Default mock stats
+$mock_stats{health} = {
+	reachability => 100,
+	availability => 100,
+};
+$mock_stats{testSensor} = {
+	testSensorUtil => 50,
+};
+$mock_stats{wmiDisk} = {
+	wmiDiskUtil => 50,
+};
+
+# ============================================================
+# Helper: create and init a Sys object with mock SNMP injected
+# ============================================================
+sub setup_snmp_sys
+{
+	my (%args) = @_;
+	my $node = $args{node};
+	my $update = $args{update} || 0;
+	my $catchall_inv = $args{catchall_inventory};
+
+	my $S = NMISNG::Sys->new(nmisng => $nmisng);
+	my $init_ok = $S->init(
+		node => $node,
+		snmp => 1,
+		wmi  => 0,
+		update => ($update ? 'true' : 0),
+		force  => ($update ? 1 : 0),
+		catchall_inventory => $catchall_inv,
+	);
+
+	# Inject mock SNMP
+	my $mock_snmp = NMISNG::Snmp::Mock->new(
+		nmisng    => $nmisng,
+		name      => $node->name,
+		walk_data => \%snmp_walk,
+	);
+	$S->{snmp} = $mock_snmp;
+
+	return $S;
+}
+
+# ============================================================
+# Helper: create and init a Sys object with mock WMI injected
+# ============================================================
+sub setup_wmi_sys
+{
+	my (%args) = @_;
+	my $node = $args{node};
+	my $update = $args{update} || 0;
+	my $catchall_inv = $args{catchall_inventory};
+
+	my $S = NMISNG::Sys->new(nmisng => $nmisng);
+	my $init_ok = $S->init(
+		node => $node,
+		snmp => 0,
+		wmi  => 1,
+		update => ($update ? 'true' : 0),
+		force  => ($update ? 1 : 0),
+		catchall_inventory => $catchall_inv,
+	);
+
+	# Inject mock WMI
+	my $mock_wmi = NMISNG::WMI::Mock->new(
+		wmi_data => \%wmi_data,
+		host     => '127.0.0.2',
+		username => 'testuser',
+	);
+	$S->{wmi} = $mock_wmi;
+
+	return $S;
+}
+
+# ============================================================
+# Create SNMP test node
+# ============================================================
+my $snmp_node = NMISNG::Node->new(uuid => NMISNG::Util::getUUID($C->{host_uuid_prefix}), nmisng => $nmisng);
+$snmp_node->cluster_id($C->{cluster_id});
+$snmp_node->name("test_snmp_node");
+$snmp_node->configuration({
+	host       => "127.0.0.1",
+	group      => "TestGroup",
+	netType    => "default",
+	roleType   => "default",
+	threshold  => 1,
+	model      => "TestSnmp",
+	collect    => "true",
+	ping       => "false",
+	community  => "public",
+	version    => "snmpv2c",
+});
+my ($op, $err) = $snmp_node->save();
+ok(!$err, "SNMP test node saved without error") or diag("Save error: $err");
+
+# Create WMI test node
+my $wmi_node = NMISNG::Node->new(uuid => NMISNG::Util::getUUID($C->{host_uuid_prefix}), nmisng => $nmisng);
+$wmi_node->cluster_id($C->{cluster_id});
+$wmi_node->name("test_wmi_node");
+$wmi_node->configuration({
+	host        => "127.0.0.2",
+	group       => "TestGroup",
+	netType     => "default",
+	roleType    => "default",
+	threshold   => 1,
+	model       => "TestWmi",
+	collect     => "true",
+	ping        => "false",
+	wmiusername => "testuser",
+	wmipassword => "testpass",
+});
+($op, $err) = $wmi_node->save();
+ok(!$err, "WMI test node saved without error") or diag("Save error: $err");
+
+# ============================================================
+# Phase 2: Test SNMP Update Pipeline
+# ============================================================
+diag("=== Phase 2: SNMP Update Pipeline ===");
+
+my ($snmp_catchall_inv, $cinv_err) = $snmp_node->inventory(concept => "catchall", model_class => "system");
+ok(!$cinv_err, "SNMP catchall inventory created") or diag("Error: $cinv_err");
+
+my $S = setup_snmp_sys(node => $snmp_node, update => 1, catchall_inventory => $snmp_catchall_inv);
+ok($S, "SNMP Sys object created");
+
+# Open the mock session
+ok($S->open(), "Mock SNMP session opened");
+
+# update_node_info
+my $result = $snmp_node->update_node_info(sys => $S, catchall_inventory => $snmp_catchall_inv);
+ok($result->{success}, "update_node_info succeeded") or diag("Result: " . Dumper($result));
+
+my $cd = $snmp_catchall_inv->data_live();
+is($cd->{sysDescr}, $snmp_walk{OID_sysDescr()}, "sysDescr populated correctly");
+is($cd->{sysObjectID}, $snmp_walk{OID_sysObjectID()}, "sysObjectID populated correctly");
+ok($cd->{sysUpTime}, "sysUpTime populated");
+is($cd->{nodeModel}, "TestSnmp", "nodeModel set to TestSnmp");
+is($cd->{ifNumber}, $snmp_walk{OID_ifNumber()}, "ifNumber matches walk data");
+is($cd->{sysName}, $snmp_walk{OID_sysName()}, "sysName populated");
+is($cd->{sysLocation}, $snmp_walk{OID_sysLocation()}, "sysLocation populated");
+
+# collect_systemhealth_info
+$snmp_node->collect_systemhealth_info(sys => $S, catchall_inventory => $snmp_catchall_inv);
+
+my $sensor_model = $snmp_node->get_inventory_model(concept => "testSensor", filter => { historic => 0 });
+ok(!$sensor_model->error, "testSensor inventory query ok") or diag("Error: " . $sensor_model->error);
+is($sensor_model->count, 2, "Found 2 testSensor indices");
+
+# Validate each sensor
+my $sensor_objects = $sensor_model->objects;
+ok($sensor_objects->{success}, "testSensor objects retrieved");
+my @sensors = @{$sensor_objects->{objects}};
+my %sensor_names;
+for my $inv (@sensors) {
+	my $d = $inv->data;
+	ok($d->{testSensorName}, "Sensor has testSensorName: $d->{testSensorName}");
+	$sensor_names{$d->{testSensorName}} = 1;
+	ok(!$inv->historic, "Sensor is not historic");
+	ok($inv->enabled, "Sensor is enabled");
+}
+ok($sensor_names{$snmp_walk{OID_sensorName1()}}, "Sensor index 1 name found: " . $snmp_walk{OID_sensorName1()});
+ok($sensor_names{$snmp_walk{OID_sensorName2()}}, "Sensor index 2 name found: " . $snmp_walk{OID_sensorName2()});
+
+# update_concepts
+$snmp_node->update_concepts(sys => $S);
+# Re-check sensors are still active
+$sensor_model = $snmp_node->get_inventory_model(concept => "testSensor", filter => { historic => 0 });
+is($sensor_model->count, 2, "testSensor still active after update_concepts");
+
+# Save catchall
+$snmp_catchall_inv->save(node => $snmp_node);
+$S->close();
+
+# ============================================================
+# Phase 2b: Test Inventory Lifecycle (Index Appear/Disappear)
+# ============================================================
+diag("=== Phase 2b: Inventory Lifecycle (Index Appear/Disappear) ===");
+
+# Save original values so we can restore after lifecycle tests
+my %saved_index2_oids = (
+	OID_sensorName2() => $snmp_walk{OID_sensorName2()},
+	OID_sensorStat2() => $snmp_walk{OID_sensorStat2()},
+	OID_sensorVal2()  => $snmp_walk{OID_sensorVal2()},
+);
+
+# --- Test A: Index disappears → marked historic ---
+diag("--- Test A: Index disappears ---");
+delete $snmp_walk{OID_sensorName2()};
+delete $snmp_walk{OID_sensorStat2()};
+delete $snmp_walk{OID_sensorVal2()};
+
+my $S_lc = setup_snmp_sys(node => $snmp_node, update => 1, catchall_inventory => $snmp_catchall_inv);
+$S_lc->open();
+$snmp_node->collect_systemhealth_info(sys => $S_lc, catchall_inventory => $snmp_catchall_inv);
+$S_lc->close();
+
+my $active_sensors = $snmp_node->get_inventory_model(concept => "testSensor", filter => { historic => 0 });
+is($active_sensors->count, 1, "After removing index 2: 1 active sensor");
+
+my $historic_sensors = $snmp_node->get_inventory_model(concept => "testSensor", filter => { historic => 1 });
+is($historic_sensors->count, 1, "After removing index 2: 1 historic sensor");
+
+# Validate the historic sensor is TempSensor2
+my $hist_objs = $historic_sensors->objects;
+my $hist_inv = $hist_objs->{objects}[0];
+is($hist_inv->data->{testSensorName}, $saved_index2_oids{OID_sensorName2()},
+	"Historic sensor is TempSensor2");
+
+# Validate the active sensor
+my $act_objs = $active_sensors->objects;
+my $act_inv = $act_objs->{objects}[0];
+ok(!$act_inv->historic, "Active sensor historic=0");
+ok($act_inv->enabled, "Active sensor enabled=1");
+
+# --- Test B: Index reappears → unmarked historic ---
+diag("--- Test B: Index reappears ---");
+$snmp_walk{OID_sensorName2()} = $saved_index2_oids{OID_sensorName2()};
+$snmp_walk{OID_sensorStat2()} = $saved_index2_oids{OID_sensorStat2()};
+$snmp_walk{OID_sensorVal2()}  = $saved_index2_oids{OID_sensorVal2()};
+
+$S_lc = setup_snmp_sys(node => $snmp_node, update => 1, catchall_inventory => $snmp_catchall_inv);
+$S_lc->open();
+$snmp_node->collect_systemhealth_info(sys => $S_lc, catchall_inventory => $snmp_catchall_inv);
+$S_lc->close();
+
+$active_sensors = $snmp_node->get_inventory_model(concept => "testSensor", filter => { historic => 0 });
+is($active_sensors->count, 2, "After restoring index 2: 2 active sensors");
+
+$historic_sensors = $snmp_node->get_inventory_model(concept => "testSensor", filter => { historic => 1 });
+is($historic_sensors->count, 0, "After restoring index 2: 0 historic sensors");
+
+# Validate both are active
+$act_objs = $active_sensors->objects;
+for my $inv (@{$act_objs->{objects}}) {
+	ok(!$inv->historic, "Sensor " . $inv->data->{testSensorName} . " is not historic");
+}
+
+# --- Test C: New index appears → new inventory created ---
+diag("--- Test C: New index appears ---");
+$snmp_walk{OID_sensorName3()} = "TempSensor3";
+$snmp_walk{OID_sensorStat3()} = "ok";
+$snmp_walk{OID_sensorVal3()}  = "60";
+
+$S_lc = setup_snmp_sys(node => $snmp_node, update => 1, catchall_inventory => $snmp_catchall_inv);
+$S_lc->open();
+$snmp_node->collect_systemhealth_info(sys => $S_lc, catchall_inventory => $snmp_catchall_inv);
+$S_lc->close();
+
+$active_sensors = $snmp_node->get_inventory_model(concept => "testSensor", filter => { historic => 0 });
+is($active_sensors->count, 3, "After adding index 3: 3 active sensors");
+
+# Find the new sensor
+$act_objs = $active_sensors->objects;
+my $found_sensor3 = 0;
+for my $inv (@{$act_objs->{objects}}) {
+	if ($inv->data->{testSensorName} eq "TempSensor3") {
+		$found_sensor3 = 1;
+		ok(!$inv->historic, "TempSensor3 is not historic");
+		ok($inv->enabled, "TempSensor3 is enabled");
+	}
+}
+ok($found_sensor3, "TempSensor3 inventory was created");
+
+# --- Test D: Collect skips historic inventory ---
+diag("--- Test D: Collect skips historic inventory ---");
+
+# Remove TempSensor3 so it becomes historic
+delete $snmp_walk{OID_sensorName3()};
+delete $snmp_walk{OID_sensorStat3()};
+delete $snmp_walk{OID_sensorVal3()};
+
+$S_lc = setup_snmp_sys(node => $snmp_node, update => 1, catchall_inventory => $snmp_catchall_inv);
+$S_lc->open();
+$snmp_node->collect_systemhealth_info(sys => $S_lc, catchall_inventory => $snmp_catchall_inv);
+$S_lc->close();
+
+$historic_sensors = $snmp_node->get_inventory_model(concept => "testSensor", filter => { historic => 1 });
+is($historic_sensors->count, 1, "TempSensor3 is now historic");
+
+# Run collect phase
+my $S_lc_collect = setup_snmp_sys(node => $snmp_node, update => 0, catchall_inventory => $snmp_catchall_inv);
+$S_lc_collect->open();
+$cd = $snmp_catchall_inv->data_live();
+$cd->{last_poll} = time - 300;
+$snmp_catchall_inv->save(node => $snmp_node);
+
+$snmp_node->collect_systemhealth_data(sys => $S_lc_collect, catchall_inventory => $snmp_catchall_inv);
+$S_lc_collect->close();
+
+# Active sensors should have timed data from this collect
+$active_sensors = $snmp_node->get_inventory_model(concept => "testSensor", filter => { historic => 0 });
+my $active_have_data = 1;
+$act_objs = $active_sensors->objects;
+for my $inv (@{$act_objs->{objects}}) {
+	my $td = $inv->get_newest_timed_data();
+	if (!$td || !$td->{success}) {
+		$active_have_data = 0;
+	}
+}
+ok($active_have_data, "Active sensors have timed data after collect");
+
+# Historic sensor should NOT have timed data from this collect cycle
+$historic_sensors = $snmp_node->get_inventory_model(concept => "testSensor", filter => { historic => 1 });
+$hist_objs = $historic_sensors->objects;
+$hist_inv = $hist_objs->{objects}[0];
+my $hist_td = $hist_inv->get_newest_timed_data();
+my $hist_has_no_recent_data = (!$hist_td || !$hist_td->{success} || !$hist_td->{data});
+ok($hist_has_no_recent_data, "Historic sensor has no timed data from collect");
+
+# --- Cleanup: restore original walk data ---
+# TempSensor3 OIDs already deleted above; index 2 already restored in Test B.
+# Verify we're back to 2 active sensors for subsequent phases.
+$active_sensors = $snmp_node->get_inventory_model(concept => "testSensor", filter => { historic => 0 });
+is($active_sensors->count, 2, "Restored to 2 active sensors for subsequent phases");
+
+# ============================================================
+# Phase 3: Test SNMP Collect Pipeline
+# ============================================================
+diag("=== Phase 3: SNMP Collect Pipeline ===");
+
+my $S2 = setup_snmp_sys(node => $snmp_node, update => 0, catchall_inventory => $snmp_catchall_inv);
+ok($S2, "Collect Sys object created");
+ok($S2->open(), "Mock SNMP session opened for collect");
+
+# Set last_poll for collect delta
+$cd = $snmp_catchall_inv->data_live();
+$cd->{last_poll} = time - 300;
+$cd->{last_update} = time - 3600;
+
+# collect_node_info
+my $cni_ok = $snmp_node->collect_node_info(sys => $S2, catchall_inventory => $snmp_catchall_inv, time_marker => time);
+ok($cni_ok, "collect_node_info succeeded");
+
+$cd = $snmp_catchall_inv->data_live();
+ok($cd->{last_poll_snmp}, "last_poll_snmp set");
+is($S2->reach->{snmpresult}, 100, "snmpresult is 100");
+
+# collect_node_data
+$snmp_node->collect_node_data(sys => $S2, catchall_inventory => $snmp_catchall_inv);
+
+# Verify mib2ip timed data was stored in catchall inventory
+# Flush any delayed timed data inserts
+$snmp_catchall_inv->save(node => $snmp_node);
+
+# Verify mib2ip in latest_data
+my $newest = $snmp_catchall_inv->get_newest_timed_data();
+ok($newest->{success}, "catchall latest_data retrieved");
+ok($newest->{time}, "catchall latest_data has timestamp");
+if ($newest->{success} && ref($newest->{data}) eq "HASH") {
+	my $mib2ip = $newest->{data}{mib2ip};
+	ok(ref($mib2ip) eq "HASH", "mib2ip subconcept present in latest_data");
+	# Counter values start at rate 0 on first collect (no previous data point)
+	ok(defined($mib2ip->{ipInReceives}), "ipInReceives in latest_data (counter rate)");
+	ok(defined($mib2ip->{ipInDelivers}), "ipInDelivers in latest_data (counter rate)");
+	ok(defined($mib2ip->{ipOutRequests}), "ipOutRequests in latest_data (counter rate)");
+}
+else {
+	ok(0, "mib2ip subconcept present in latest_data");
+	ok(0, "ipInReceives in latest_data");
+	ok(0, "ipInDelivers in latest_data");
+	ok(0, "ipOutRequests in latest_data");
+}
+
+# Verify timed collection also has the data
+my $newest_timed = $snmp_catchall_inv->get_newest_timed_data(from_timed => 1);
+ok($newest_timed->{success}, "catchall timed collection record exists");
+if ($newest_timed->{success} && $newest_timed->{time}) {
+	is($newest_timed->{time}, $newest->{time}, "timed collection timestamp matches latest_data for catchall");
+}
+else {
+	ok(0, "timed collection timestamp matches latest_data for catchall");
+}
+
+# Verify mib2ip storage path was recorded
+my $storage = $snmp_catchall_inv->storage();
+ok($storage->{mib2ip}, "mib2ip RRD storage path recorded in catchall inventory");
+
+# Check that inline alert on ipOutRequests was evaluated
+my $alerts = $S2->{alerts} || [];
+my @system_alerts = grep { $_->{event} && $_->{event} eq 'High IP Traffic' } @$alerts;
+# ipOutRequests=450000, test is '$r > 1000000', so should NOT fire
+is(scalar(@system_alerts), 1, "System-level alert evaluated");
+ok(!$system_alerts[0]->{test_result}, "ipOutRequests alert did not fire (450000 < 1000000)");
+
+# Set mock stats HIGH before systemhealth collect so timed_data stores it for thresholds
+$mock_stats{testSensor} = { testSensorUtil => 92 };
+
+# collect_systemhealth_data
+$snmp_node->collect_systemhealth_data(sys => $S2, catchall_inventory => $snmp_catchall_inv);
+
+# Validate testSensor data was collected - both inventory data and timed data
+$sensor_model = $snmp_node->get_inventory_model(concept => "testSensor", filter => { historic => 0 });
+$sensor_objects = $sensor_model->objects;
+for my $inv (@{$sensor_objects->{objects}}) {
+	my $d = $inv->data;
+	my $sname = $d->{testSensorName};
+
+	# Inventory data: sys fields from update + rrd fields from collect
+	ok(defined($d->{testSensorName}), "testSensorName in inventory data: $sname");
+	ok(defined($d->{testSensorStatus}), "testSensorStatus in inventory data for $sname: " . ($d->{testSensorStatus} // 'undef'));
+	ok(defined($d->{testSensorValue}), "testSensorValue in inventory data for $sname: " . ($d->{testSensorValue} // 'undef'));
+
+	# latest_data: the most recent point-in-time record (read from latest_data collection)
+	my $td = $inv->get_newest_timed_data();
+	ok($td->{success}, "testSensor latest_data retrieved for $sname");
+	ok($td->{time}, "testSensor latest_data has timestamp for $sname");
+	if ($td->{success} && ref($td->{data}) eq "HASH") {
+		my $pit = $td->{data}{testSensor} // $td->{data};
+		ok(defined($pit->{testSensorValue}), "testSensorValue in latest_data for $sname: " . ($pit->{testSensorValue} // 'undef'));
+	}
+	else {
+		ok(0, "testSensorValue in latest_data for $sname");
+	}
+
+	# Derived data in latest_data
+	if ($td->{success} && ref($td->{derived_data}) eq "HASH") {
+		my $dd = $td->{derived_data}{testSensor} // $td->{derived_data};
+		ok(defined($dd->{testSensorUtil}), "testSensorUtil in latest_data derived_data for $sname: " . ($dd->{testSensorUtil} // 'undef'));
+	}
+	else {
+		ok(0, "testSensorUtil in latest_data derived_data for $sname");
+	}
+
+	# timed collection: verify the per-concept timed collection also has the data
+	my $td_timed = $inv->get_newest_timed_data(from_timed => 1);
+	ok($td_timed->{success}, "testSensor timed collection record exists for $sname");
+	if ($td_timed->{success} && $td_timed->{time}) {
+		is($td_timed->{time}, $td->{time}, "timed collection timestamp matches latest_data for $sname");
+	}
+	else {
+		ok(0, "timed collection timestamp matches latest_data for $sname");
+	}
+
+	# Storage path recorded
+	my $inv_storage = $inv->storage();
+	ok($inv_storage->{testSensor}, "testSensor RRD storage path recorded for $sname");
+}
+
+# Check inline alerts for testSensorValue
+my @sensor_alerts = grep { $_->{event} && $_->{event} eq 'High Sensor Value' } @{$S2->{alerts}};
+ok(scalar(@sensor_alerts) >= 2, "Got testSensorValue alerts for both indices") or diag("Alert count: " . scalar(@sensor_alerts));
+
+# Index 1 (value=95) should fire, index 2 (value=42) should not
+my @fired = grep { $_->{test_result} } @sensor_alerts;
+my @normal = grep { !$_->{test_result} } @sensor_alerts;
+is(scalar(@fired), 1, "One sensor alert fired (value 95 > 90)");
+is(scalar(@normal), 1, "One sensor alert normal (value 42 <= 90)");
+
+# process_alerts creates status records
+$snmp_node->process_alerts(sys => $S2);
+
+my $status_md = $snmp_node->get_status_model();
+if ($status_md && !$status_md->error) {
+	my $status_objs = $status_md->objects;
+	my @alert_statuses = grep { $_->method eq "Alert" } @{$status_objs->{objects} || []};
+	ok(scalar(@alert_statuses) > 0, "Status records created with method=Alert") or diag("Alert status count: " . scalar(@alert_statuses));
+}
+
+# ============================================================
+# Phase 3b: Test error handling and handle_down
+# ============================================================
+diag("=== Phase 3b: Error handling and handle_down ===");
+
+my $mock_for_errors = $S2->{snmp};
+
+# Helper: reset catchall snmpdown state and save
+sub reset_snmpdown {
+	my ($inv, $node) = @_;
+	my $d = $inv->data;
+	$d->{snmpdown} = 'false';
+	$d->{nodestatus} = 'reachable';
+	$inv->data($d);
+	$inv->save(node => $node, update => 1);
+}
+
+# --- Direct handle_down tests ---
+diag("  -- Direct handle_down tests --");
+
+# Test handle_down going DOWN
+reset_snmpdown($snmp_catchall_inv, $snmp_node);
+$snmp_node->handle_down(sys => $S2, type => "snmp", details => "test snmp down", catchall_inventory => $snmp_catchall_inv);
+
+my $hd_data = $snmp_catchall_inv->data();
+is($hd_data->{snmpdown}, 'true', "handle_down(snmp): snmpdown flag set to 'true'");
+ok($hd_data->{nodestatus} && $hd_data->{nodestatus} ne 'reachable',
+	"handle_down(snmp): nodestatus changed from reachable to '$hd_data->{nodestatus}'");
+ok($snmp_node->eventExist("SNMP Down"), "handle_down(snmp): 'SNMP Down' event created");
+
+# Test handle_down going UP (recovery)
+$snmp_node->handle_down(sys => $S2, type => "snmp", up => 1, details => "snmp ok", catchall_inventory => $snmp_catchall_inv);
+
+$hd_data = $snmp_catchall_inv->data();
+is($hd_data->{snmpdown}, 'false', "handle_down(snmp, up): snmpdown flag set to 'false'");
+is($hd_data->{nodestatus}, 'reachable', "handle_down(snmp, up): nodestatus back to 'reachable'");
+
+# Test handle_down for WMI
+reset_snmpdown($snmp_catchall_inv, $snmp_node);  # ensure clean state
+$snmp_node->handle_down(sys => $S2, type => "wmi", details => "test wmi down", catchall_inventory => $snmp_catchall_inv);
+$hd_data = $snmp_catchall_inv->data();
+is($hd_data->{wmidown}, 'true', "handle_down(wmi): wmidown flag set to 'true'");
+# Clean up WMI down state
+$snmp_node->handle_down(sys => $S2, type => "wmi", up => 1, details => "wmi ok", catchall_inventory => $snmp_catchall_inv);
+
+# --- handle_sys_get_data_error tests ---
+diag("  -- handle_sys_get_data_error tests --");
+
+# For no_session and transport_error to trigger handle_down, Sys status must have snmp_error set.
+# handle_sys_get_data_error checks $S->status->{snmp_error} to decide whether to call handle_down.
+
+# Test "not present" — return 1, NO handle_down
+reset_snmpdown($snmp_catchall_inv, $snmp_node);
+$mock_for_errors->force_error("Requested table is empty or does not exist");
+my $err_result = $snmp_node->handle_sys_get_data_error(
+	sys => $S2, caller => "test_not_present", section => "testSensor",
+	index => "1", catchall_data => $snmp_catchall_inv->data_live(),
+	catchall_inventory => $snmp_catchall_inv
+);
+is($err_result, 1, "error_not_present: returns 1");
+$hd_data = $snmp_catchall_inv->data();
+is($hd_data->{snmpdown}, 'false', "error_not_present: snmpdown still 'false' (no handle_down)");
+ok(!$snmp_node->eventExist("SNMP Down"), "error_not_present: no 'SNMP Down' event");
+
+# Test "model error" — return 2, NO handle_down
+reset_snmpdown($snmp_catchall_inv, $snmp_node);
+$mock_for_errors->force_error("incorrect syntax near OID");
+$err_result = $snmp_node->handle_sys_get_data_error(
+	sys => $S2, caller => "test_model_error", section => "testSensor",
+	index => "1", catchall_data => $snmp_catchall_inv->data_live(),
+	catchall_inventory => $snmp_catchall_inv
+);
+is($err_result, 2, "error_model: returns 2");
+$hd_data = $snmp_catchall_inv->data();
+is($hd_data->{snmpdown}, 'false', "error_model: snmpdown still 'false' (no handle_down)");
+ok(!$snmp_node->eventExist("SNMP Down"), "error_model: no 'SNMP Down' event");
+
+# Test "no session" — return 10, YES handle_down
+# Need to set snmp_error in Sys status so handle_down gets triggered
+reset_snmpdown($snmp_catchall_inv, $snmp_node);
+$mock_for_errors->force_error("No session open");
+$S2->{snmp_error} = "No session open";  # set status-level error
+$err_result = $snmp_node->handle_sys_get_data_error(
+	sys => $S2, caller => "test_no_session", section => "testSensor",
+	index => "1", catchall_data => $snmp_catchall_inv->data_live(),
+	catchall_inventory => $snmp_catchall_inv
+);
+is($err_result, 10, "error_no_session: returns 10");
+$hd_data = $snmp_catchall_inv->data();
+is($hd_data->{snmpdown}, 'true', "error_no_session: snmpdown set to 'true' (handle_down called)");
+ok($snmp_node->eventExist("SNMP Down"), "error_no_session: 'SNMP Down' event created");
+ok($hd_data->{nodestatus} && $hd_data->{nodestatus} ne 'reachable',
+	"error_no_session: nodestatus changed to '$hd_data->{nodestatus}'");
+
+# Clean up: recover from snmp down
+$snmp_node->handle_down(sys => $S2, type => "snmp", up => 1, details => "snmp ok", catchall_inventory => $snmp_catchall_inv);
+$S2->{snmp_error} = undef;
+
+# Test "transport error" — return 4, YES handle_down
+reset_snmpdown($snmp_catchall_inv, $snmp_node);
+$mock_for_errors->force_error("Connection timed out");
+$S2->{snmp_error} = "Connection timed out";
+$err_result = $snmp_node->handle_sys_get_data_error(
+	sys => $S2, caller => "test_transport_error", section => "testSensor",
+	index => "1", catchall_data => $snmp_catchall_inv->data_live(),
+	catchall_inventory => $snmp_catchall_inv
+);
+is($err_result, 4, "error_transport: returns 4");
+$hd_data = $snmp_catchall_inv->data();
+is($hd_data->{snmpdown}, 'true', "error_transport: snmpdown set to 'true' (handle_down called)");
+ok($snmp_node->eventExist("SNMP Down"), "error_transport: 'SNMP Down' event created");
+ok($hd_data->{nodestatus} && $hd_data->{nodestatus} ne 'reachable',
+	"error_transport: nodestatus changed to '$hd_data->{nodestatus}'");
+
+# Clean up for subsequent tests
+$snmp_node->handle_down(sys => $S2, type => "snmp", up => 1, details => "snmp ok", catchall_inventory => $snmp_catchall_inv);
+$S2->{snmp_error} = undef;
+$mock_for_errors->force_error(undef);
+
+# ============================================================
+# Phase 4: Test Custom Alerts (model-level alerts class)
+# ============================================================
+diag("=== Phase 4: Custom Alerts ===");
+
+my $alerts_before = scalar(@{$S2->{alerts} || []});
+$snmp_node->handle_custom_alerts(sys => $S2, catchall_inventory => $snmp_catchall_inv);
+my $alerts_after = scalar(@{$S2->{alerts} || []});
+ok($alerts_after > $alerts_before, "handle_custom_alerts added alerts (before=$alerts_before, after=$alerts_after)");
+
+# Check for custom test alert (CVAR1=testSensorValue;$CVAR1 > 80)
+my @custom_test = grep { $_->{event} && $_->{event} eq 'Custom Sensor Alert' } @{$S2->{alerts}};
+ok(scalar(@custom_test) >= 2, "Custom test alerts found for both indices");
+my @custom_fired = grep { $_->{test_result} } @custom_test;
+is(scalar(@custom_fired), 1, "One custom test alert fired (value 95 > 80)");
+
+# Check for custom threshold-rising alert
+my @custom_thr = grep { $_->{event} && $_->{event} eq 'Custom Sensor Threshold' } @{$S2->{alerts}};
+ok(scalar(@custom_thr) >= 2, "Custom threshold alerts found for both indices");
+# value=95 should be Critical (>= 95), value=42 should be Normal (< 70)
+my @crit = grep { $_->{level} && $_->{level} eq 'Critical' } @custom_thr;
+my @norm = grep { !$_->{test_result} } @custom_thr;
+ok(scalar(@crit) >= 1, "Custom threshold alert at Critical for value=95");
+ok(scalar(@norm) >= 1, "Custom threshold alert Normal for value=42");
+
+# ============================================================
+# Phase 5: Test Compute Reachability
+# ============================================================
+diag("=== Phase 5: Compute Reachability ===");
+
+my $RI = $S2->reach;
+$RI->{pingresult} = 100;
+$RI->{pingloss}   = 0;
+$RI->{pingavg}    = 2.5;
+$RI->{snmpresult} = 100;
+$RI->{cpu}        = 25;
+$RI->{memused}    = 500000;
+$RI->{memfree}    = 500000;
+
+# Ensure catchall data has required fields for compute_reachability
+$cd = $snmp_catchall_inv->data_live();
+$cd->{collect}     = "true";
+$cd->{nodeModel}   = "TestSnmp";
+$cd->{nodeType}    = "generic";
+$cd->{intfTotal}   = 0;
+$cd->{intfCollect} = 0;
+$snmp_catchall_inv->save(node => $snmp_node);
+
+my $reachdata = $snmp_node->compute_reachability(
+	sys => $S2, delayupdate => 1, catchall_inventory => $snmp_catchall_inv
+);
+ok(ref($reachdata) eq "HASH", "compute_reachability returned hash");
+ok(exists $reachdata->{reachability}, "reachability key exists");
+ok(exists $reachdata->{availability}, "availability key exists");
+ok(exists $reachdata->{health}, "health key exists");
+ok($reachdata->{reachability}{value} > 0, "reachability value > 0: $reachdata->{reachability}{value}");
+ok($reachdata->{health}{value} > 0, "health value > 0: $reachdata->{health}{value}");
+
+# --- Test compute_reachability when SNMP poll failed (degraded node) ---
+diag("--- Compute Reachability: SNMP poll failed (degraded) ---");
+$RI->{snmpresult} = 0;      # SNMP was tried and failed
+$RI->{pingresult} = 100;    # but ping still works
+
+my $degraded = $snmp_node->compute_reachability(
+	sys => $S2, delayupdate => 1, catchall_inventory => $snmp_catchall_inv
+);
+is($degraded->{reachability}{value}, 80, "degraded: reachability is 80 (up but degraded)");
+is($degraded->{health}{value}, "U", "degraded: health is U when SNMP down");
+
+# --- Test compute_reachability when source was never enabled (undef result) ---
+diag("--- Compute Reachability: WMI never enabled (undef result) ---");
+$RI->{snmpresult} = 100;
+$RI->{wmiresult}  = undef;  # WMI was never enabled, should not affect result
+
+my $snmponly = $snmp_node->compute_reachability(
+	sys => $S2, delayupdate => 1, catchall_inventory => $snmp_catchall_inv
+);
+is($snmponly->{reachability}{value}, 100, "snmp-only: reachability is 100");
+ok($snmponly->{health}{value} > 0, "snmp-only: health is numeric > 0: $snmponly->{health}{value}");
+
+# --- Test compute_reachability when both results exist and one failed ---
+diag("--- Compute Reachability: dual-protocol, WMI failed ---");
+$RI->{snmpresult} = 100;
+$RI->{wmiresult}  = 0;      # WMI enabled but failed: min(100,0) = 0
+
+my $dual_degraded = $snmp_node->compute_reachability(
+	sys => $S2, delayupdate => 1, catchall_inventory => $snmp_catchall_inv
+);
+is($dual_degraded->{reachability}{value}, 80, "dual-degraded: reachability is 80 (poll failed)");
+is($dual_degraded->{health}{value}, "U", "dual-degraded: health is U when a poll source failed");
+
+# Restore for subsequent tests
+$RI->{snmpresult} = 100;
+$RI->{wmiresult}  = undef;
+
+# ============================================================
+# Phase 6: Test Compute Summary Stats
+# ============================================================
+diag("=== Phase 6: Compute Summary Stats ===");
+
+my $summary_stats = $snmp_node->compute_summary_stats(sys => $S2, inventory => $snmp_catchall_inv);
+ok(ref($summary_stats) eq "HASH", "compute_summary_stats returned hash");
+ok(exists $summary_stats->{reachability} || exists $summary_stats->{availability},
+	"Standard stats keys present") or diag("Stats: " . Dumper($summary_stats));
+
+# ============================================================
+# Phase 7: Test Thresholds (compute_thresholds)
+# ============================================================
+diag("=== Phase 7: Thresholds ===");
+
+# Save the catchall so thresholds can find it
+$snmp_catchall_inv->save(node => $snmp_node);
+
+# Stats were set to 92 before collect_systemhealth_data, so timed_data has testSensorUtil=92
+$nmisng->compute_thresholds(sys => $S2, running_independently => 0);
+
+# Check for threshold status records
+$status_md = $snmp_node->get_status_model();
+if ($status_md && !$status_md->error) {
+	my $objs_ret = $status_md->objects;
+	my @thr_statuses = grep { $_->method eq "Threshold" } @{$objs_ret->{objects} || []};
+	ok(scalar(@thr_statuses) > 0, "Threshold status records created") or diag("Threshold status count: " . scalar(@thr_statuses));
+	if (@thr_statuses) {
+		my @major = grep { $_->level eq "Major" } @thr_statuses;
+		ok(scalar(@major) > 0, "Found Major threshold status for testSensorUtil=92");
+	}
+}
+
+# Now test Normal case - need to re-collect with lower stats so timed_data is updated
+$mock_stats{testSensor} = { testSensorUtil => 50 };
+# Re-run systemhealth collect to store new derived_data with testSensorUtil=50
+$snmp_node->collect_systemhealth_data(sys => $S2, catchall_inventory => $snmp_catchall_inv);
+$nmisng->compute_thresholds(sys => $S2, running_independently => 0);
+
+$status_md = $snmp_node->get_status_model();
+if ($status_md && !$status_md->error) {
+	my $objs_ret = $status_md->objects;
+	my @thr_statuses = grep { $_->method eq "Threshold" && $_->property eq "testSensorUtil" } @{$objs_ret->{objects} || []};
+	my @normal = grep { $_->level eq "Normal" } @thr_statuses;
+	ok(scalar(@normal) > 0, "Threshold status Normal for testSensorUtil=50") or diag("Normal count: " . scalar(@normal) . ", total threshold: " . scalar(@thr_statuses));
+}
+
+$S2->close();
+
+# ============================================================
+# Phase 8: Test WMI Update Pipeline
+# ============================================================
+diag("=== Phase 8: WMI Update Pipeline ===");
+
+my ($wmi_catchall_inv, $wcinv_err) = $wmi_node->inventory(concept => "catchall", model_class => "system");
+ok(!$wcinv_err, "WMI catchall inventory created") or diag("Error: $wcinv_err");
+
+my $SW = setup_wmi_sys(node => $wmi_node, update => 1, catchall_inventory => $wmi_catchall_inv);
+ok($SW, "WMI Sys object created");
+
+# update_node_info for WMI
+my $wmi_result = $wmi_node->update_node_info(sys => $SW, catchall_inventory => $wmi_catchall_inv);
+ok($wmi_result->{success}, "WMI update_node_info succeeded") or diag("Result: " . Dumper($wmi_result));
+
+my $wcd = $wmi_catchall_inv->data_live();
+is($wcd->{nodeModel}, "TestWmi", "WMI nodeModel set to TestWmi");
+ok($wcd->{winosname} || $wcd->{sysDescr}, "WMI OS info populated");
+
+# collect_systemhealth_info for WMI
+$wmi_node->collect_systemhealth_info(sys => $SW, catchall_inventory => $wmi_catchall_inv);
+
+my $disk_model = $wmi_node->get_inventory_model(concept => "wmiDisk", filter => { historic => 0 });
+ok(!$disk_model->error, "wmiDisk inventory query ok") or diag("Error: " . $disk_model->error);
+is($disk_model->count, 2, "Found 2 wmiDisk indices (C: and D:)");
+
+$wmi_catchall_inv->save(node => $wmi_node);
+
+# ============================================================
+# Phase 9: Test WMI Collect Pipeline
+# ============================================================
+diag("=== Phase 9: WMI Collect Pipeline ===");
+
+my $SW2 = setup_wmi_sys(node => $wmi_node, update => 0, catchall_inventory => $wmi_catchall_inv);
+ok($SW2, "WMI collect Sys object created");
+
+$wcd = $wmi_catchall_inv->data_live();
+$wcd->{last_poll} = time - 300;
+$wcd->{last_update} = time - 3600;
+
+# collect_node_info for WMI
+my $wcni_ok = $wmi_node->collect_node_info(sys => $SW2, catchall_inventory => $wmi_catchall_inv, time_marker => time);
+ok($wcni_ok, "WMI collect_node_info succeeded");
+
+# collect_node_data for WMI
+$wmi_node->collect_node_data(sys => $SW2, catchall_inventory => $wmi_catchall_inv);
+
+# Check for WMI CPU alert (value=25, test is '$r > 90', should NOT fire)
+my @wmi_cpu_alerts = grep { $_->{event} && $_->{event} eq 'High WMI CPU' } @{$SW2->{alerts} || []};
+if (@wmi_cpu_alerts) {
+	ok(!$wmi_cpu_alerts[0]->{test_result}, "WMI CPU alert did not fire (25 < 90)");
+}
+
+# Set mock stats for WMI disk thresholds
+$mock_stats{wmiDisk} = { wmiDiskUtil => 92 };
+
+# collect_systemhealth_data for WMI
+$wmi_node->collect_systemhealth_data(sys => $SW2, catchall_inventory => $wmi_catchall_inv);
+
+# Validate WMI disk data - inventory data, timed data, and derived data
+$disk_model = $wmi_node->get_inventory_model(concept => "wmiDisk", filter => { historic => 0 });
+my $disk_objects = $disk_model->objects;
+for my $inv (@{$disk_objects->{objects} || []}) {
+	my $d = $inv->data;
+	my $dname = $d->{Name} // $d->{index} // 'unknown';
+
+	# Inventory data: sys fields from update + rrd fields from collect
+	ok(defined($d->{Name}), "Name in inventory data for disk: $dname");
+	ok(defined($d->{wmiDiskSize}), "wmiDiskSize in inventory data for $dname: " . ($d->{wmiDiskSize} // 'undef'));
+	ok(defined($d->{wmiDiskFreeSpace}), "wmiDiskFreeSpace in inventory data for $dname: " . ($d->{wmiDiskFreeSpace} // 'undef'));
+
+	# latest_data
+	my $td = $inv->get_newest_timed_data();
+	ok($td->{success}, "wmiDisk latest_data retrieved for $dname");
+	ok($td->{time}, "wmiDisk latest_data has timestamp for $dname");
+	if ($td->{success} && ref($td->{data}) eq "HASH") {
+		my $pit = $td->{data}{wmiDisk} // $td->{data};
+		ok(defined($pit->{wmiDiskFreeSpace}), "wmiDiskFreeSpace in latest_data for $dname: " . ($pit->{wmiDiskFreeSpace} // 'undef'));
+	}
+	else {
+		ok(0, "wmiDiskFreeSpace in latest_data for $dname");
+	}
+
+	# Derived data in latest_data
+	if ($td->{success} && ref($td->{derived_data}) eq "HASH") {
+		my $dd = $td->{derived_data}{wmiDisk} // $td->{derived_data};
+		ok(defined($dd->{wmiDiskUtil}), "wmiDiskUtil in latest_data derived_data for $dname: " . ($dd->{wmiDiskUtil} // 'undef'));
+	}
+	else {
+		ok(0, "wmiDiskUtil in latest_data derived_data for $dname");
+	}
+
+	# timed collection
+	my $td_timed = $inv->get_newest_timed_data(from_timed => 1);
+	ok($td_timed->{success}, "wmiDisk timed collection record exists for $dname");
+	if ($td_timed->{success} && $td_timed->{time}) {
+		is($td_timed->{time}, $td->{time}, "timed collection timestamp matches latest_data for $dname");
+	}
+	else {
+		ok(0, "timed collection timestamp matches latest_data for $dname");
+	}
+
+	# Storage path
+	my $inv_storage = $inv->storage();
+	ok($inv_storage->{wmiDisk}, "wmiDisk RRD storage path recorded for $dname");
+}
+
+# ============================================================
+# Phase 10: Test WMI Custom Alerts and Thresholds
+# ============================================================
+diag("=== Phase 10: WMI Custom Alerts and Thresholds ===");
+
+my $wmi_alerts_before = scalar(@{$SW2->{alerts} || []});
+$wmi_node->handle_custom_alerts(sys => $SW2, catchall_inventory => $wmi_catchall_inv);
+my $wmi_alerts_after = scalar(@{$SW2->{alerts} || []});
+ok($wmi_alerts_after > $wmi_alerts_before, "WMI handle_custom_alerts added alerts");
+
+# Save catchall for thresholds
+$wmi_catchall_inv->save(node => $wmi_node);
+
+# Test thresholds with high value
+$mock_stats{wmiDisk} = { wmiDiskUtil => 92 };
+$nmisng->compute_thresholds(sys => $SW2, running_independently => 0);
+
+my $wmi_status_md = $wmi_node->get_status_model();
+if ($wmi_status_md && !$wmi_status_md->error) {
+	my $objs_ret = $wmi_status_md->objects;
+	my @thr = grep { $_->method eq "Threshold" } @{$objs_ret->{objects} || []};
+	ok(scalar(@thr) > 0, "WMI threshold status records created");
+}
+
+$SW2->close();
+
+# ============================================================
+# Phase 11: Test full update() and collect() orchestration
+# ============================================================
+diag("=== Phase 11: Full update/collect orchestration ===");
+
+# Create a fresh node for this test
+my $orch_node = NMISNG::Node->new(uuid => NMISNG::Util::getUUID($C->{host_uuid_prefix}), nmisng => $nmisng);
+$orch_node->cluster_id($C->{cluster_id});
+$orch_node->name("test_orch_node");
+$orch_node->configuration({
+	host      => "127.0.0.1",
+	group     => "TestGroup",
+	netType   => "default",
+	roleType  => "default",
+	threshold => 1,
+	model     => "TestSnmp",
+	collect   => "true",
+	ping      => "false",
+	community => "public",
+	version   => "snmpv2c",
+});
+($op, $err) = $orch_node->save();
+ok(!$err, "Orchestration test node saved") or diag("Error: $err");
+
+# Monkey-patch NMISNG::Snmp::new to return our mock.
+# This ensures that when update()/collect() internally creates a Sys and calls init(),
+# the SNMP object created is our mock with walk data.
+my $orig_snmp_new = \&NMISNG::Snmp::new;
+{
+	no warnings 'redefine';
+	*NMISNG::Snmp::new = sub {
+		my ($class, %args) = @_;
+		return NMISNG::Snmp::Mock->new(
+			nmisng    => $args{nmisng},
+			name      => $args{name},
+			walk_data => \%snmp_walk,
+		);
+	};
+}
+
+# Test update() — full orchestration
+my $update_result = $orch_node->update(force => 1);
+ok($update_result->{success}, "Full update() succeeded") or diag("update error: " . ($update_result->{error} // 'none'));
+
+# Verify update populated catchall correctly
+my ($orch_catchall, $orch_err) = $orch_node->inventory(concept => "catchall");
+if (!$orch_err && $orch_catchall) {
+	my $ocd = $orch_catchall->data_live();
+	is($ocd->{sysDescr}, $snmp_walk{OID_sysDescr()}, "update() populated sysDescr");
+	is($ocd->{nodeModel}, "TestSnmp", "update() set nodeModel");
+	ok($ocd->{last_update}, "update() set last_update timestamp");
+}
+
+# Test collect() — full orchestration (needs last_update set by update above)
+my $collect_result = $orch_node->collect(wantsnmp => 1);
+ok($collect_result->{success}, "Full collect() succeeded") or diag("collect error: " . ($collect_result->{error} // 'none'));
+
+# Re-fetch catchall after collect (collect creates its own Sys/catchall internally)
+my ($orch_catchall2, $orch_err2) = $orch_node->inventory(concept => "catchall");
+if (!$orch_err2 && $orch_catchall2) {
+	my $ocd2 = $orch_catchall2->data();
+	ok($ocd2->{last_poll}, "collect() set last_poll timestamp");
+}
+else {
+	ok(0, "collect() set last_poll timestamp");
+}
+
+# Restore original NMISNG::Snmp::new
+{
+	no warnings 'redefine';
+	*NMISNG::Snmp::new = $orig_snmp_new;
+}
+
+# ============================================================
+# Phase 12: Cleanup
+# ============================================================
+diag("=== Phase 12: Cleanup ===");
+cleanup();
+ok(1, "Cleanup complete");
+
+done_testing();

--- a/test/t_polling.pl
+++ b/test/t_polling.pl
@@ -760,6 +760,14 @@ $cd->{intfTotal}   = 0;
 $cd->{intfCollect} = 0;
 $snmp_catchall_inv->save(node => $snmp_node);
 
+# Stock nmis9_dev's update_node_info sets wmiresult=0 unconditionally
+# (lib/NMISNG/Node.pm:2216), so compute_reachability's min() logic treats
+# the disabled WMI source as a failed poll and reports health = "U".
+# The follow-up refactor (commit e44eec11 on test-and-refactor-snmp-wmi)
+# replaces that init with a loop that only zeros enabled sources.
+# Normalize here so this test exercises only the healthy-path semantics.
+$RI->{wmiresult} = undef;
+
 my $reachdata = $snmp_node->compute_reachability(
 	sys => $S2, delayupdate => 1, catchall_inventory => $snmp_catchall_inv
 );

--- a/test/t_sys.pl
+++ b/test/t_sys.pl
@@ -1,0 +1,501 @@
+#!/usr/bin/perl
+#
+# t_sys.pl - Unit test for NMISNG::Sys functions (loadInfo, getData, getValues).
+# Tests all model item properties: calculate, format, replace, control,
+# skip_collect, calculate_index, nosave, HTML escaping, alerts, and more.
+# Uses the same mock SNMP/WMI infrastructure as t_polling.pl.
+#
+
+use strict;
+use warnings;
+our $VERSION = "1.0.0";
+
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use lib "$FindBin::Bin/lib";
+
+use Test::More;
+use Test::Deep;
+use Data::Dumper;
+use JSON::XS;
+use File::Slurp;
+
+use NMISNG;
+use NMISNG::Node;
+use NMISNG::Sys;
+use NMISNG::Log;
+use NMISNG::Util;
+use Compat::NMIS;
+
+use NMISNG::Snmp::Mock;
+use NMISNG::WMI::Mock;
+
+# ============================================================
+# Setup
+# ============================================================
+
+my $C = NMISNG::Util::loadConfTable();
+die "Cannot load config" if (!$C);
+
+$C->{db_name} = "t_sys-" . time;
+
+my $logger = NMISNG::Log->new(level => 'info');
+my $nmisng = NMISNG->new(config => $C, log => $logger);
+die "NMISNG object required" if (!$nmisng);
+
+sub cleanup { $nmisng->get_db()->drop(); }
+
+# Load walk data
+my $snmp_walk_raw = decode_json(read_file("$FindBin::Bin/testdata/snmpwalk_test.json"));
+my %snmp_walk;
+for my $k (keys %$snmp_walk_raw) {
+	$snmp_walk{$k} = $snmp_walk_raw->{$k} unless $k =~ /^_/;
+}
+
+my $wmi_data_raw = decode_json(read_file("$FindBin::Bin/testdata/wmi_test.json"));
+my %wmi_data;
+for my $k (keys %$wmi_data_raw) {
+	$wmi_data{$k} = $wmi_data_raw->{$k} unless $k =~ /^_/;
+}
+
+# OID constants for referencing walk data
+use constant {
+	OID_sysDescr     => '1.3.6.1.2.1.1.1.0',
+	OID_sysObjectID  => '1.3.6.1.2.1.1.2.0',
+	OID_sysUpTime    => '1.3.6.1.2.1.1.3.0',
+	OID_sysContact   => '1.3.6.1.2.1.1.4.0',
+	OID_sysName      => '1.3.6.1.2.1.1.5.0',
+	OID_sysLocation  => '1.3.6.1.2.1.1.6.0',
+	OID_ifNumber     => '1.3.6.1.2.1.2.1.0',
+	OID_ipInReceives => '1.3.6.1.2.1.4.3.0',
+	OID_ipInDelivers => '1.3.6.1.2.1.4.9.0',
+	OID_ipOutRequests => '1.3.6.1.2.1.4.10.0',
+	OID_sensorVal1   => '1.3.6.1.4.1.99999.1.1.1.3.1',
+	OID_sensorVal2   => '1.3.6.1.4.1.99999.1.1.1.3.2',
+	OID_rawCounter    => '1.3.6.1.4.1.99999.2.1.0',
+	OID_calcValue     => '1.3.6.1.4.1.99999.2.2.0',
+	OID_fmtValue      => '1.3.6.1.4.1.99999.2.3.0',
+	OID_replValue     => '1.3.6.1.4.1.99999.2.4.0',
+	OID_replNoFallback => '1.3.6.1.4.1.99999.2.5.0',
+	OID_nosaveValue   => '1.3.6.1.4.1.99999.2.6.0',
+	OID_htmlValue     => '1.3.6.1.4.1.99999.2.7.0',
+	OID_calcUndef     => '1.3.6.1.4.1.99999.2.8.0',
+	OID_calcOidVal1   => '1.3.6.1.4.1.99999.3.1.1.0',
+	OID_calcOidVal2   => '1.3.6.1.4.1.99999.3.1.2.0',
+};
+
+# Monkey-patch create_update_rrd to skip RRD I/O
+{
+	no warnings 'redefine';
+	*NMISNG::Sys::create_update_rrd = sub {
+		my ($self, %args) = @_;
+		if (ref($args{inventory})) {
+			my $type = $args{type} || 'unknown';
+			$args{inventory}->set_subconcept_type_storage(
+				subconcept => $type, type => 'rrd',
+				data => "/nodes/$self->{name}/mock-$type.rrd"
+			);
+		}
+		return 1;
+	};
+}
+
+# Create SNMP test node
+my $snmp_node = NMISNG::Node->new(uuid => NMISNG::Util::getUUID($C->{host_uuid_prefix}), nmisng => $nmisng);
+$snmp_node->cluster_id($C->{cluster_id});
+$snmp_node->name("test_sys_snmp");
+$snmp_node->configuration({
+	host      => "127.0.0.1",
+	group     => "TestGroup",
+	netType   => "default",
+	roleType  => "default",
+	threshold => 1,
+	model     => "TestSnmp",
+	collect   => "true",
+	ping      => "false",
+	community => "public",
+	version   => "snmpv2c",
+});
+my ($op, $err) = $snmp_node->save();
+ok(!$err, "SNMP test node saved") or diag("Error: $err");
+
+# Create WMI test node
+my $wmi_node = NMISNG::Node->new(uuid => NMISNG::Util::getUUID($C->{host_uuid_prefix}), nmisng => $nmisng);
+$wmi_node->cluster_id($C->{cluster_id});
+$wmi_node->name("test_sys_wmi");
+$wmi_node->configuration({
+	host        => "127.0.0.2",
+	group       => "TestGroup",
+	netType     => "default",
+	roleType    => "default",
+	threshold   => 1,
+	model       => "TestWmi",
+	collect     => "true",
+	ping        => "false",
+	wmiusername => "testuser",
+	wmipassword => "testpass",
+});
+($op, $err) = $wmi_node->save();
+ok(!$err, "WMI test node saved") or diag("Error: $err");
+
+# Init SNMP Sys and run update_node_info to get model loaded
+my ($snmp_catchall, $cerr) = $snmp_node->inventory(concept => "catchall", model_class => "system");
+ok(!$cerr, "SNMP catchall created");
+
+my $S = NMISNG::Sys->new(nmisng => $nmisng);
+$S->init(node => $snmp_node, snmp => 1, wmi => 0, update => 'true', force => 1, catchall_inventory => $snmp_catchall);
+$S->{snmp} = NMISNG::Snmp::Mock->new(nmisng => $nmisng, name => "test_sys_snmp", walk_data => \%snmp_walk);
+$S->open();
+$snmp_node->update_node_info(sys => $S, catchall_inventory => $snmp_catchall);
+# Also discover systemHealth indices for indexed tests
+$snmp_node->collect_systemhealth_info(sys => $S, catchall_inventory => $snmp_catchall);
+$snmp_catchall->save(node => $snmp_node);
+
+# ============================================================
+# Test 1: open / testsession / close
+# ============================================================
+diag("=== Test 1: Session lifecycle ===");
+
+my $mock_snmp = $S->{snmp};
+ok($mock_snmp->isopen, "isopen returns 1 after open");
+is($mock_snmp->version, 'snmpv2c', "version returns snmpv2c");
+is($mock_snmp->max_msg_size, 1472, "max_msg_size returns 1472");
+ok($mock_snmp->testsession, "testsession returns 1 (sysObjectID.0 in walk data)");
+ok(!$mock_snmp->error, "no error after successful operations");
+
+$mock_snmp->close();
+ok(!$mock_snmp->isopen, "isopen returns 0 after close");
+is($mock_snmp->version, undef, "version returns undef when closed");
+
+# Reopen for remaining tests
+$mock_snmp->open(config => { oidpkt => 10 });
+ok($mock_snmp->isopen, "session reopened");
+
+# ============================================================
+# Test 2: copyModelCfgInfo
+# ============================================================
+diag("=== Test 2: copyModelCfgInfo ===");
+
+$S->copyModelCfgInfo(type => 'all');
+my $cd = $snmp_catchall->data_live();
+is($cd->{nodeModel}, "TestSnmp", "copyModelCfgInfo preserved nodeModel");
+# Verify node config fields were copied to catchall
+is($cd->{host}, "127.0.0.1", "copyModelCfgInfo copied host from node config");
+is($cd->{group}, "TestGroup", "copyModelCfgInfo copied group from node config");
+
+# ============================================================
+# Test 3: loadInfo (sys section, non-indexed)
+# ============================================================
+diag("=== Test 3: loadInfo ===");
+
+my %sys_target;
+my $li_ok = $S->loadInfo(class => 'system', target => \%sys_target, inventory => $snmp_catchall);
+ok($li_ok, "loadInfo returned success");
+is($sys_target{sysDescr}, $snmp_walk{OID_sysDescr()}, "loadInfo: sysDescr matches walk data");
+is($sys_target{sysObjectID}, $snmp_walk{OID_sysObjectID()}, "loadInfo: sysObjectID matches walk data");
+is($sys_target{sysName}, $snmp_walk{OID_sysName()}, "loadInfo: sysName matches walk data");
+is($sys_target{sysLocation}, $snmp_walk{OID_sysLocation()}, "loadInfo: sysLocation matches walk data");
+is($sys_target{sysContact}, $snmp_walk{OID_sysContact()}, "loadInfo: sysContact matches walk data");
+is($sys_target{ifNumber}, $snmp_walk{OID_ifNumber()}, "loadInfo: ifNumber matches walk data");
+ok($sys_target{sysUpTime}, "loadInfo: sysUpTime populated");
+
+# ============================================================
+# Test 4: getData (rrd section, non-indexed)
+# ============================================================
+diag("=== Test 4: getData ===");
+
+$S->{alerts} = [];  # clear alerts from previous ops
+my $rrd_data = $S->getData(class => 'system', inventory => $snmp_catchall);
+ok(ref($rrd_data) eq "HASH", "getData returned hash");
+ok(exists $rrd_data->{mib2ip}, "getData has mib2ip section");
+
+my $ip = $rrd_data->{mib2ip};
+ok(exists $ip->{ipInReceives}, "mib2ip has ipInReceives");
+ok(exists $ip->{ipInDelivers}, "mib2ip has ipInDelivers");
+ok(exists $ip->{ipOutRequests}, "mib2ip has ipOutRequests");
+is($ip->{ipInReceives}{option}, 'counter,0:U', "ipInReceives option is counter,0:U");
+is($ip->{ipInReceives}{title}, 'IP In Receives', "ipInReceives title correct");
+is($ip->{ipInReceives}{value}, $snmp_walk{OID_ipInReceives()}, "ipInReceives value matches walk data");
+is($ip->{ipInDelivers}{value}, $snmp_walk{OID_ipInDelivers()}, "ipInDelivers value matches walk data");
+is($ip->{ipOutRequests}{value}, $snmp_walk{OID_ipOutRequests()}, "ipOutRequests value matches walk data");
+
+# ============================================================
+# Test 5: loadInfo vs getData — different model branches
+# ============================================================
+diag("=== Test 5: loadInfo vs getData ===");
+
+# loadInfo returns sys items, NOT rrd items
+ok(!exists $sys_target{ipInReceives}, "loadInfo did NOT return rrd item ipInReceives");
+ok(!exists $sys_target{rawCounter}, "loadInfo did NOT return rrd item rawCounter");
+
+# getData returns rrd items, NOT sys items
+ok(!exists $rrd_data->{standard}, "getData did NOT return sys section 'standard'");
+
+# ============================================================
+# Test 6: calculate with $r and CVAR
+# ============================================================
+diag("=== Test 6: calculate ===");
+
+ok(exists $rrd_data->{testProcessing}, "getData has testProcessing section");
+my $tp = $rrd_data->{testProcessing};
+
+# rawCounter: plain value
+is($tp->{rawCounter}{value}, $snmp_walk{OID_rawCounter()}, "rawCounter value matches walk data");
+
+# calcValue: calculate='CVAR1=rawCounter;return int($r / 10) + $CVAR1;'
+# raw=555, rawCounter=1000, expected: int(555/10) + 1000 = 55 + 1000 = 1055
+my $expected_calc = int($snmp_walk{OID_calcValue()} / 10) + $snmp_walk{OID_rawCounter()};
+is($tp->{calcValue}{value}, $expected_calc, "calcValue: calculate with \$r and CVAR produced $expected_calc");
+
+# ============================================================
+# Test 7: format (sprintf)
+# ============================================================
+diag("=== Test 7: format ===");
+
+my $expected_fmt = sprintf("%.2f", $snmp_walk{OID_fmtValue()});
+is($tp->{fmtValue}{value}, $expected_fmt, "fmtValue: format %.2f produced $expected_fmt");
+
+# ============================================================
+# Test 8: replace — match found
+# ============================================================
+diag("=== Test 8: replace (match) ===");
+
+my %repl_table = ('1' => 'Up', '2' => 'Down', 'unknown' => 'Other');
+my $raw_repl = $snmp_walk{OID_replValue()};
+my $expected_repl = $repl_table{$raw_repl} // $repl_table{unknown} // $raw_repl;
+is($tp->{replValue}{value}, $expected_repl, "replValue: replace lookup for '$raw_repl' => '$expected_repl'");
+
+# ============================================================
+# Test 9: replace — no match, no fallback (value unchanged)
+# ============================================================
+diag("=== Test 9: replace (no fallback) ===");
+
+my $raw_nofb = $snmp_walk{OID_replNoFallback()};
+# 99 is not in replace table {1=>Up, 2=>Down}, no 'unknown' key → value unchanged
+is($tp->{replNoFallback}{value}, $raw_nofb, "replNoFallback: value '$raw_nofb' unchanged (not in replace table)");
+
+# ============================================================
+# Test 10: nosave — alert suppressed
+# ============================================================
+diag("=== Test 10: nosave ===");
+
+ok(exists $tp->{nosaveValue}, "nosaveValue present in data");
+is($tp->{nosaveValue}{option}, 'nosave', "nosaveValue option is nosave");
+# The alert '$r > 0' would fire since 42 > 0, but nosave should suppress it
+my @nosave_alerts = grep { $_->{event} && $_->{event} eq 'Nosave Alert Should Not Fire' } @{$S->{alerts}};
+is(scalar(@nosave_alerts), 0, "nosave suppressed alert (none in \$S->{alerts})");
+
+# ============================================================
+# Test 11: HTML escaping
+# ============================================================
+diag("=== Test 11: HTML escaping ===");
+
+my $html_val = $tp->{htmlValue}{value};
+ok(defined($html_val), "htmlValue is defined");
+unlike($html_val, qr/<b>/, "htmlValue does NOT contain raw '<b>' tag");
+like($html_val, qr/&lt;b&gt;/, "htmlValue contains escaped '&lt;b&gt;'");
+like($html_val, qr/&amp;/, "htmlValue contains escaped '&amp;'");
+
+# ============================================================
+# Test 12: calculate returns undef — alert skipped
+# ============================================================
+diag("=== Test 12: calculate undef ===");
+
+# calcUndef: calculate='return undef;', raw=123 but result is undef
+ok(exists $tp->{calcUndef}, "calcUndef present in data");
+ok(!defined($tp->{calcUndef}{value}), "calcUndef value is undef (calculate returned undef)");
+my @undef_alerts = grep { $_->{event} && $_->{event} eq 'CalcUndef Alert Should Not Fire' } @{$S->{alerts}};
+is(scalar(@undef_alerts), 0, "calculate-undef suppressed alert (none in \$S->{alerts})");
+
+# ============================================================
+# Test 13: control expression — section skipped
+# ============================================================
+diag("=== Test 13: control ===");
+
+# testSkipped has control='$nodeModel eq "NeverMatch"' — nodeModel is TestSnmp
+ok(!exists $rrd_data->{testSkipped}, "testSkipped section not in getData (control expression false)");
+
+# ============================================================
+# Test 14: skip_collect — section skipped
+# ============================================================
+diag("=== Test 14: skip_collect ===");
+
+ok(!exists $rrd_data->{testSkipCollect}, "testSkipCollect section not in getData (skip_collect=true)");
+
+# ============================================================
+# Test 15: indexed getData (systemHealth testSensor)
+# ============================================================
+diag("=== Test 15: indexed getData ===");
+
+$S->{alerts} = [];
+# Get all testSensor inventories
+my $ts_all = $snmp_node->get_inventory_model(concept => 'testSensor', filter => { historic => 0 });
+my %ts_by_index;
+my $ts_objs = $ts_all->objects;
+for my $inv (@{$ts_objs->{objects} || []}) {
+	$ts_by_index{$inv->data->{index}} = $inv;
+}
+
+my $sh_data1 = $S->getData(class => 'systemHealth', section => 'testSensor', index => '1',
+	inventory => $ts_by_index{1});
+ok(ref($sh_data1) eq "HASH", "indexed getData returned hash for index 1");
+ok(exists $sh_data1->{testSensor}, "testSensor section in indexed getData");
+is($sh_data1->{testSensor}{'1'}{testSensorValue}{value}, $snmp_walk{OID_sensorVal1()},
+	"testSensorValue index 1 matches walk data");
+
+my $sh_data2 = $S->getData(class => 'systemHealth', section => 'testSensor', index => '2',
+	inventory => $ts_by_index{2});
+is($sh_data2->{testSensor}{'2'}{testSensorValue}{value}, $snmp_walk{OID_sensorVal2()},
+	"testSensorValue index 2 matches walk data");
+
+# ============================================================
+# Test 16: calculate_index
+# ============================================================
+diag("=== Test 16: calculate_index ===");
+
+# testCalcOid: calculate_index='CVAR1=index;return "$CVAR1.0";'
+# For index=1: suffix becomes ".1.0", full OID = 1.3.6.1.4.1.99999.3.1.1.0
+# Get all testCalcOid inventories, match by index value
+my $co_all = $snmp_node->get_inventory_model(concept => 'testCalcOid', filter => { historic => 0 });
+is($co_all->count, 2, "testCalcOid has 2 inventory items");
+
+my %co_by_index;
+my $co_objs = $co_all->objects;
+for my $inv (@{$co_objs->{objects} || []}) {
+	$co_by_index{$inv->data->{index}} = $inv;
+}
+
+for my $idx (1, 2) {
+	my $inv = $co_by_index{$idx};
+	if ($inv) {
+		my $co_data = $S->getData(class => 'systemHealth', section => 'testCalcOid', index => "$idx", inventory => $inv);
+		my $expected_oid = $idx == 1 ? OID_calcOidVal1() : OID_calcOidVal2();
+		if ($co_data->{testCalcOid} && $co_data->{testCalcOid}{$idx}) {
+			is($co_data->{testCalcOid}{$idx}{calcOidValue}{value}, $snmp_walk{$expected_oid},
+				"calculate_index: index $idx value matches walk data (OID suffix .$idx.0)");
+		} else {
+			ok(0, "calculate_index: index $idx value matches walk data");
+		}
+	} else {
+		ok(0, "calculate_index: index $idx value matches walk data");
+	}
+}
+
+# ============================================================
+# Test 17: inline alert evaluation
+# ============================================================
+diag("=== Test 17: inline alert ===");
+
+# Alerts from the indexed getData calls above (testSensorValue alert: '$r > 90')
+my @sensor_alerts = grep { $_->{event} && $_->{event} eq 'High Sensor Value' } @{$S->{alerts}};
+ok(scalar(@sensor_alerts) >= 2, "Two sensor alert records generated");
+
+my @fired = grep { $_->{test_result} } @sensor_alerts;
+my @normal = grep { !$_->{test_result} } @sensor_alerts;
+is(scalar(@fired), 1, "One alert fired (index 1, value > 90)");
+is(scalar(@normal), 1, "One alert normal (index 2, value <= 90)");
+
+if (@fired) {
+	is($fired[0]->{event}, 'High Sensor Value', "Alert event correct");
+	is($fired[0]->{level}, 'Warning', "Alert level correct");
+	ok(defined($fired[0]->{value}), "Alert has value");
+	is($fired[0]->{section}, 'testSensor', "Alert section correct");
+	# inventory_id may be set if inventory was passed and saved (has a DB id)
+	ok(1, "Alert record has expected fields (inventory_id=" . ($fired[0]->{inventory_id} // 'undef') . ")");
+}
+
+# ============================================================
+# Test 18: WMI loadInfo (non-indexed)
+# ============================================================
+diag("=== Test 18: WMI loadInfo ===");
+
+my ($wmi_catchall, $wcerr) = $wmi_node->inventory(concept => "catchall", model_class => "system");
+ok(!$wcerr, "WMI catchall created");
+
+my $SW = NMISNG::Sys->new(nmisng => $nmisng);
+$SW->init(node => $wmi_node, snmp => 0, wmi => 1, update => 'true', force => 1, catchall_inventory => $wmi_catchall);
+$SW->{wmi} = NMISNG::WMI::Mock->new(wmi_data => \%wmi_data, host => '127.0.0.2', username => 'testuser');
+
+my %wmi_target;
+my $wli_ok = $SW->loadInfo(class => 'system', target => \%wmi_target, inventory => $wmi_catchall);
+ok($wli_ok, "WMI loadInfo returned success");
+
+# Values come from WMI mock data
+my $expected_caption = $wmi_data{"select Caption from Win32_OperatingSystem"}[0]{Caption};
+my $expected_version = $wmi_data{"select Version from Win32_OperatingSystem"}[0]{Version};
+my $expected_build = $wmi_data{"select BuildNumber from Win32_OperatingSystem"}[0]{BuildNumber};
+my $expected_csname = $wmi_data{"select CSName from Win32_OperatingSystem"}[0]{CSName};
+
+is($wmi_target{winosname}, $expected_caption, "WMI loadInfo: winosname matches mock data");
+is($wmi_target{winversion}, $expected_version, "WMI loadInfo: winversion matches mock data");
+is($wmi_target{winbuild}, $expected_build, "WMI loadInfo: winbuild matches mock data");
+is($wmi_target{winsysname}, $expected_csname, "WMI loadInfo: winsysname matches mock data");
+
+# ============================================================
+# Test 19: WMI getData (non-indexed rrd)
+# ============================================================
+diag("=== Test 19: WMI getData ===");
+
+my $wmi_rrd = $SW->getData(class => 'system', inventory => $wmi_catchall);
+ok(ref($wmi_rrd) eq "HASH", "WMI getData returned hash");
+ok(exists $wmi_rrd->{wmiCpu}, "WMI getData has wmiCpu section");
+
+my $expected_cpu = $wmi_data{"select PercentProcessorTime from Win32_PerfFormattedData_PerfOS_Processor where Name='_Total'"}[0]{PercentProcessorTime};
+is($wmi_rrd->{wmiCpu}{percentProcessor}{value}, $expected_cpu, "WMI percentProcessor matches mock data");
+
+# ============================================================
+# Test 20: WMI indexed getData
+# ============================================================
+diag("=== Test 20: WMI indexed getData ===");
+
+# First discover disk indices
+$wmi_node->update_node_info(sys => $SW, catchall_inventory => $wmi_catchall);
+$wmi_node->collect_systemhealth_info(sys => $SW, catchall_inventory => $wmi_catchall);
+$wmi_catchall->save(node => $wmi_node);
+
+my $disk_inv_c = $wmi_node->get_inventory_model(concept => 'wmiDisk', filter => { 'data.index' => 'C:', historic => 0 })->objects->{objects}[0];
+if ($disk_inv_c) {
+	my $wmi_disk_data = $SW->getData(class => 'systemHealth', section => 'wmiDisk', index => 'C:', inventory => $disk_inv_c);
+	ok(ref($wmi_disk_data) eq "HASH", "WMI indexed getData returned hash");
+	my $expected_free = $wmi_data{"select Name,Size,FreeSpace from Win32_LogicalDisk where DriveType=3"}[0]{FreeSpace};
+	if ($wmi_disk_data->{wmiDisk} && $wmi_disk_data->{wmiDisk}{'C:'}) {
+		is($wmi_disk_data->{wmiDisk}{'C:'}{wmiDiskFreeSpace}{value}, $expected_free,
+			"WMI wmiDiskFreeSpace for C: matches mock data");
+	} else {
+		ok(0, "WMI wmiDiskFreeSpace for C: matches mock data");
+	}
+} else {
+	ok(0, "wmiDisk inventory for C: exists");
+	ok(0, "WMI wmiDiskFreeSpace for C: matches mock data");
+}
+
+# ============================================================
+# Test 21: WMI execute_queries handles missing index gracefully
+# ============================================================
+diag("=== Test 21: WMI execute_queries missing index ===");
+
+# Create a WMI Sys with mock data, then call getData with a non-existent index.
+# Before the fix, this would crash with "Can't use an undefined value as a HASH reference".
+my $SW_bad = NMISNG::Sys->new(nmisng => $nmisng);
+$SW_bad->init(node => $wmi_node, snmp => 0, wmi => 1, update => 0, catchall_inventory => $wmi_catchall);
+$SW_bad->{wmi} = NMISNG::WMI::Mock->new(wmi_data => \%wmi_data, host => '127.0.0.2', username => 'testuser');
+
+# Request data for an index that doesn't exist in the WMI result set
+my $bad_result = $SW_bad->getData(class => 'systemHealth', section => 'wmiDisk', index => 'Z:');
+my $bad_status = $SW_bad->status;
+# Should not crash — getData returns empty/error, not a die
+ok(1, "WMI getData with missing index did not crash");
+# The status should have an error or the result should be empty for that index
+ok(!$bad_result->{wmiDisk}{'Z:'} || !defined($bad_result->{wmiDisk}{'Z:'}{wmiDiskFreeSpace}{value}),
+	"WMI getData with missing index returned no data for Z:");
+
+# ============================================================
+# Cleanup
+# ============================================================
+diag("=== Cleanup ===");
+$S->close();
+$SW->close() if $SW;
+cleanup();
+ok(1, "Cleanup complete");
+
+done_testing();

--- a/test/testdata/snmpwalk_test.json
+++ b/test/testdata/snmpwalk_test.json
@@ -1,0 +1,51 @@
+{
+	"_comment": "SNMP walk data for test node - used by t_polling.pl",
+
+	"_section": "system sys standard OIDs (.0 appended by getValues)",
+	"1.3.6.1.2.1.1.1.0": "Test SNMP Device - Linux Mock 5.4.0",
+	"1.3.6.1.2.1.1.2.0": "1.3.6.1.4.1.99999",
+	"1.3.6.1.2.1.1.3.0": "123456789",
+	"1.3.6.1.2.1.1.4.0": "test@example.com",
+	"1.3.6.1.2.1.1.5.0": "test-snmp-node",
+	"1.3.6.1.2.1.1.6.0": "Test Lab Rack 1",
+	"1.3.6.1.2.1.2.1.0": "2",
+
+	"_section2": "system rrd mib2ip counters (.0 appended)",
+	"1.3.6.1.2.1.4.3.0": "500000",
+	"1.3.6.1.2.1.4.9.0": "480000",
+	"1.3.6.1.2.1.4.10.0": "450000",
+
+	"_section3": "testSensor table - index discovery (gettable on 1.3.6.1.4.1.99999.1.1.1.2)",
+	"1.3.6.1.4.1.99999.1.1.1.2.1": "TempSensor1",
+	"1.3.6.1.4.1.99999.1.1.1.2.2": "TempSensor2",
+
+	"_section4": "testSensor sys data - testSensorStatus per index",
+	"1.3.6.1.4.1.99999.1.1.1.4.1": "ok",
+	"1.3.6.1.4.1.99999.1.1.1.4.2": "ok",
+
+	"_section5": "testSensor rrd data - testSensorValue per index (95 fires alert, 42 does not)",
+	"1.3.6.1.4.1.99999.1.1.1.3.1": "95",
+	"1.3.6.1.4.1.99999.1.1.1.3.2": "42",
+
+	"_section6": "testProcessing rrd data (.0 appended by getValues for non-indexed)",
+	"1.3.6.1.4.1.99999.2.1.0": "1000",
+	"1.3.6.1.4.1.99999.2.2.0": "555",
+	"1.3.6.1.4.1.99999.2.3.0": "3.14159",
+	"1.3.6.1.4.1.99999.2.4.0": "1",
+	"1.3.6.1.4.1.99999.2.5.0": "99",
+	"1.3.6.1.4.1.99999.2.6.0": "42",
+	"1.3.6.1.4.1.99999.2.7.0": "<b>test&value</b>",
+	"1.3.6.1.4.1.99999.2.8.0": "123",
+
+	"_section7": "testSkipped/testSkipCollect (should never be read but present for completeness)",
+	"1.3.6.1.4.1.99999.2.20.0": "999",
+	"1.3.6.1.4.1.99999.2.21.0": "888",
+
+	"_section8": "testCalcOid index discovery table (gettable on 1.3.6.1.4.1.99999.3.2)",
+	"1.3.6.1.4.1.99999.3.2.1": "CalcItem1",
+	"1.3.6.1.4.1.99999.3.2.2": "CalcItem2",
+
+	"_section9": "testCalcOid rrd values (calculate_index appends .0 to index, so OID.index.0)",
+	"1.3.6.1.4.1.99999.3.1.1.0": "777",
+	"1.3.6.1.4.1.99999.3.1.2.0": "888"
+}

--- a/test/testdata/wmi_test.json
+++ b/test/testdata/wmi_test.json
@@ -1,0 +1,31 @@
+{
+	"_comment": "WMI mock data for test node - used by t_polling.pl",
+
+	"select Caption from Win32_OperatingSystem": [
+		{"Caption": "Microsoft Windows Server 2019 Standard"}
+	],
+	"select Version from Win32_OperatingSystem": [
+		{"Version": "10.0.17763"}
+	],
+	"select BuildNumber from Win32_OperatingSystem": [
+		{"BuildNumber": "17763"}
+	],
+	"select CSName from Win32_OperatingSystem": [
+		{"CSName": "TEST-WMI-NODE"}
+	],
+	"select LocalDateTime from Win32_OperatingSystem": [
+		{"LocalDateTime": "20260328120000.000000+000"}
+	],
+	"select LastBootUpTime from Win32_OperatingSystem": [
+		{"LastBootUpTime": "20260327000000.000000+000"}
+	],
+
+	"select PercentProcessorTime from Win32_PerfFormattedData_PerfOS_Processor where Name='_Total'": [
+		{"PercentProcessorTime": "25"}
+	],
+
+	"select Name,Size,FreeSpace from Win32_LogicalDisk where DriveType=3": [
+		{"Name": "C:", "Size": "107374182400", "FreeSpace": "536870912"},
+		{"Name": "D:", "Size": "214748364800", "FreeSpace": "161061273600"}
+	]
+}


### PR DESCRIPTION
Add polling/validation test infrastructure (mock SNMP/WMI, test scripts, test models)

    Adds a mock-based test harness for the NMIS9 polling pipeline:

    - test/lib/NMISNG/Snmp/Mock.pm and test/lib/NMISNG/WMI/Mock.pm — standalone
      mocks that implement the respective engine interfaces from in-memory
      walk/query fixtures. Injected into $S->{snmp} / $S->{wmi} after Sys->init().

    - test/testdata/snmpwalk_test.json, wmi_test.json — fixture data.

    - models-default/Model-TestSnmp.nmis, Model-TestWmi.nmis — self-contained
      test models (system + systemHealth concepts) that drive the mocks.

    - test/t_polling.pl — end-to-end test of update_node_info /
      collect_node_info / collect_node_data / collect_systemhealth_info /
      collect_systemhealth_data / handle_custom_alerts / compute_reachability /
      compute_summary_stats, with monkey-patched create_update_rrd and
      getSubconceptStats for deterministic thresholds.

    - test/t_sys.pl — unit tests for Sys loadInfo / getData / getValues
      covering calculate, format, replace, control, skip_collect,
      calculate_index, nosave, HTML escape, alerts, and SNMP/WMI error
      paths. Uses mock injection via $S->{snmp} / $S->{wmi}.

    This branch deliberately contains no production-code changes — the goal is
    to verify the existing pre-refactor polling engine passes the new tests.
    A follow-up PR will land the corresponding polling refactor.