### PR TITLE
polling tests: address PR #164 review comments

### DIFF
--- a/test/lib/NMISNG/Snmp/Mock.pm
+++ b/test/lib/NMISNG/Snmp/Mock.pm
@@ -186,8 +186,9 @@ sub get
 		}
 		else
 		{
-			# SNMP returns noSuchInstance for missing OIDs but doesn't fail the whole request
-			$result{$oid} = "NOSUCHINSTANCE";
+			# SNMP returns noSuchInstance for missing OIDs but doesn't fail the whole request.
+			# Case matters: NMISNG::Sys and rrdfunc compare against the literal "noSuchInstance".
+			$result{$oid} = "noSuchInstance";
 		}
 	}
 
@@ -238,7 +239,7 @@ sub getarray
 		}
 		else
 		{
-			push @retvals, "NOSUCHINSTANCE";
+			push @retvals, "noSuchInstance";
 		}
 	}
 

--- a/test/lib/NMISNG/WMI/Mock.pm
+++ b/test/lib/NMISNG/WMI/Mock.pm
@@ -11,7 +11,9 @@ sub new
 {
 	my ($class, %arg) = @_;
 
-	# Match real WMI.pm: return error string on missing required args
+	# wmi_data is mock-specific and must be present for the mock to function.
+	# host/username/password are accepted for interface parity with NMISNG::WMI->new
+	# but are not validated here (tests don't exercise the underlying WMI transport).
 	return "NMISNG::WMI::Mock requires wmi_data argument" if (!$arg{wmi_data});
 
 	my $self = bless({
@@ -108,25 +110,30 @@ sub gettable
 		return "No mock data found for query: $query";
 	}
 
-	my %result;
+	# Match real NMISNG::WMI->gettable semantics: before iterating, verify the
+	# requested index field exists AND is unique across all rows. If any row
+	# is missing the field or any value is duplicated, undef the indexfield
+	# entirely and key every row by its row number (with meta->{index} = undef).
 	my $used_index = $index_field;
-	my $row_num = 0;
-
-	for my $row (@$rows)
+	if ($used_index)
 	{
-		my $idx;
-		if ($index_field && exists $row->{$index_field})
+		my %seen;
+		for my $row (@$rows)
 		{
-			$idx = $row->{$index_field};
+			if (!defined($row->{$used_index}) || $seen{$row->{$used_index}}++)
+			{
+				$used_index = undef;
+				last;
+			}
 		}
-		else
-		{
-			# Fall back to row number
-			$idx = $row_num;
-			$used_index = undef;
-		}
+	}
 
-		# Filter fields if requested
+	my %result;
+	for my $i (0 .. $#{$rows})
+	{
+		my $row = $rows->[$i];
+		my $idx = $used_index ? $row->{$used_index} : $i;
+
 		my $data = $row;
 		if ($fields && @$fields)
 		{
@@ -139,7 +146,6 @@ sub gettable
 		}
 
 		$result{$idx} = $data;
-		$row_num++;
 	}
 
 	return (undef, \%result, { classname => "MockClass", index => $used_index });

--- a/test/t_polling.pl
+++ b/test/t_polling.pl
@@ -212,7 +212,7 @@ sub setup_wmi_sys
 # ============================================================
 # Create SNMP test node
 # ============================================================
-my $snmp_node = NMISNG::Node->new(uuid => NMISNG::Util::getUUID($C->{host_uuid_prefix}), nmisng => $nmisng);
+my $snmp_node = NMISNG::Node->new(uuid => NMISNG::Util::getUUID(), nmisng => $nmisng);
 $snmp_node->cluster_id($C->{cluster_id});
 $snmp_node->name("test_snmp_node");
 $snmp_node->configuration({
@@ -231,7 +231,7 @@ my ($op, $err) = $snmp_node->save();
 ok(!$err, "SNMP test node saved without error") or diag("Save error: $err");
 
 # Create WMI test node
-my $wmi_node = NMISNG::Node->new(uuid => NMISNG::Util::getUUID($C->{host_uuid_prefix}), nmisng => $nmisng);
+my $wmi_node = NMISNG::Node->new(uuid => NMISNG::Util::getUUID(), nmisng => $nmisng);
 $wmi_node->cluster_id($C->{cluster_id});
 $wmi_node->name("test_wmi_node");
 $wmi_node->configuration({
@@ -1003,7 +1003,7 @@ $SW2->close();
 diag("=== Phase 11: Full update/collect orchestration ===");
 
 # Create a fresh node for this test
-my $orch_node = NMISNG::Node->new(uuid => NMISNG::Util::getUUID($C->{host_uuid_prefix}), nmisng => $nmisng);
+my $orch_node = NMISNG::Node->new(uuid => NMISNG::Util::getUUID(), nmisng => $nmisng);
 $orch_node->cluster_id($C->{cluster_id});
 $orch_node->name("test_orch_node");
 $orch_node->configuration({

--- a/test/t_sys.pl
+++ b/test/t_sys.pl
@@ -101,7 +101,7 @@ use constant {
 }
 
 # Create SNMP test node
-my $snmp_node = NMISNG::Node->new(uuid => NMISNG::Util::getUUID($C->{host_uuid_prefix}), nmisng => $nmisng);
+my $snmp_node = NMISNG::Node->new(uuid => NMISNG::Util::getUUID(), nmisng => $nmisng);
 $snmp_node->cluster_id($C->{cluster_id});
 $snmp_node->name("test_sys_snmp");
 $snmp_node->configuration({
@@ -120,7 +120,7 @@ my ($op, $err) = $snmp_node->save();
 ok(!$err, "SNMP test node saved") or diag("Error: $err");
 
 # Create WMI test node
-my $wmi_node = NMISNG::Node->new(uuid => NMISNG::Util::getUUID($C->{host_uuid_prefix}), nmisng => $nmisng);
+my $wmi_node = NMISNG::Node->new(uuid => NMISNG::Util::getUUID(), nmisng => $nmisng);
 $wmi_node->cluster_id($C->{cluster_id});
 $wmi_node->name("test_sys_wmi");
 $wmi_node->configuration({


### PR DESCRIPTION
Copilot review on PR #164 flagged four issues with the mock harness. This commit addresses them without changing behavior for passing tests.

1. Snmp::Mock: return literal "noSuchInstance" (not "NOSUCHINSTANCE") for missing OIDs. NMISNG::Sys (Sys.pm:1138,1151), NMISNG::Node (Node.pm:2982, 2992,2993,5929) and NMISNG::rrdfunc (rrdfunc.pm:649) all compare against the mixed-case literal. The uppercase form silently bypassed that logic.

2. WMI::Mock::gettable: match real NMISNG::WMI->gettable semantics (WMI.pm:132-146). Pre-scan rows for index-field existence and uniqueness; if any row is missing the field or any value is duplicated, undef the indexfield entirely and key every row by row number (with meta->{index} = undef). Previously the mock decided per-row, producing mixed-key results and silently dropping duplicates.

3. Test node UUIDs: replace getUUID($C->{host_uuid_prefix}) with the standard getUUID() pattern used throughout the rest of the test suite (t_nmisng.pl, t_nmisng_node.pl, t_plugin_nodevalidation.pl, etc.). host_uuid_prefix is not in the default config; with UUID namespacing enabled a constant argument can produce colliding deterministic UUIDs.

4. WMI::Mock constructor: the comment claimed parity with NMISNG::WMI->new for missing-arg validation, but the mock only validates wmi_data. Update the comment to reflect actual behavior rather than adding validation the tests don't need.

Verified: t_polling.pl 165/165 and t_sys.pl 82/82 continue to pass.