### PR TITLE
OMK-12380 -  model overrides: scoped Override-Model-* / Override-Common-* with au…

### DIFF
--- a/docs/model-loading.md
+++ b/docs/model-loading.md
@@ -1,0 +1,409 @@
+# NMIS9 Model Loading
+
+A device model tells NMIS what to poll on a given kind of equipment, how to interpret the results, and how to render them. Models are composed of one main `Model-*.nmis` file plus zero or more shared `Common-*.nmis` files, optionally customized by `Override-*.nmis` files. This document describes how those files are discovered, merged, cached, and consumed at runtime.
+
+## Directory Layout
+
+Two directories hold model files. Both are configured as macros in `conf-default/Config.nmis`:
+
+| Macro | Default path | Purpose |
+|---|---|---|
+| `<nmis_default_models>` | `<nmis_base>/models-default` | Shipped with NMIS. Never modified by users -- overwritten on upgrade. |
+| `<nmis_models>` | `<nmis_base>/models-custom` | Site-specific customizations. Users own this. Searched first. |
+
+When a model file is requested by name, `models-custom/` wins on conflict; `models-default/` is the fallback. The override files described below are looked up only in `models-custom/`.
+
+## File Types
+
+| Filename pattern | Role | Lookup |
+|---|---|---|
+| `Model-<name>.nmis` | Top-level model for one device type. References Common files via the `-common-` section. | both dirs |
+| `Common-<feature>.nmis` | Reusable section (e.g. CPU, memory, interfaces). Referenced by one or more Model files. | both dirs |
+| `Override-Model-<name>.nmis` | Partial overlay of `Model-<name>.nmis`. Auto-discovered. | `models-custom/` only |
+| `Override-Common-<feature>.nmis` | Partial overlay of `Common-<feature>.nmis`. Auto-discovered. | `models-custom/` only |
+| `Override-<entry>.nmis` | Global overlay applied to every model. Registered in the `global_model_overrides` config setting. | both dirs |
+| `Graph-<type>.nmis` | RRD graph definitions. Loaded separately by the graphing code, not by `loadModel`. | both dirs |
+
+`.nmis` files are Perl source containing a single top-level `%hash = (...)` assignment. They are loaded with `eval` via `NMISNG::Util::readFiletoHash` / `loadTable`.
+
+## Merge Order
+
+When a model is loaded, files are merged in this order. Later wins on key conflicts:
+
+1. `Model-<name>.nmis`
+2. `Override-Model-<name>.nmis` (scoped, optional)
+3. For each Common in the model's `-common-` section, in alphabetical class order:
+   - a. `Common-<feature>.nmis`
+   - b. `Override-Common-<feature>.nmis` (scoped, optional)
+4. For each entry in `global_model_overrides`: `Override-<entry>.nmis` (global, optional)
+
+Step 4 always merges last and therefore has the highest precedence. Use scoped overrides (`Override-Model-*`, `Override-Common-*`) when you want to customize a single file; use global overrides (`global_model_overrides`) when you want a customization that applies across every model on the system.
+
+The merge itself is a recursive deep merge: nested hashes combine, and source values overwrite destination values for any non-hash leaf. Type conflicts (a key that is a hash on one side and a non-hash on the other) abort the load with an error.
+
+## The Override Mechanism
+
+The point of override files is to let users customize part of a model without taking ownership of the whole file. An override only needs to contain the keys it wants to change; everything else is inherited from the base file.
+
+### Scoped overrides (auto-discovered)
+
+`Override-Model-<name>.nmis` is auto-applied whenever `Model-<name>.nmis` is loaded. `Override-Common-<feature>.nmis` is auto-applied whenever `Common-<feature>.nmis` is included in the merged model. No config registration is required -- the existence of the file in `models-custom/` is the trigger. To stop applying an override, delete the file.
+
+These are the right tool when the customization is specific to one model or one Common.
+
+### Global overrides (`global_model_overrides`)
+
+An array config setting that names override files applied to every model load:
+
+```perl
+'global_model_overrides' => [ 'company-defaults', 'rrd-tuning' ],
+```
+
+This loads `Override-company-defaults.nmis` and `Override-rrd-tuning.nmis` and merges each on top of every model. Lookup uses the same precedence as ordinary model files (`models-custom/` first, then `models-default/`).
+
+These are the right tool when the customization is cross-cutting -- e.g. retuning RRD step sizes or replacing a default that should differ everywhere on the site.
+
+## Caching
+
+Loaded models are cached as JSON in `<nmis_var>/nmis_system/model_cache/`. Two files are written per model:
+
+| File | Contents |
+|---|---|
+| `<modelname>.json` | The fully-merged model hash. This is what `$self->{mdl}` becomes on a cache hit. |
+| `<modelname>.json.meta.json` | Sidecar metadata: `{ applied_overrides => [ { path, mtime }, ... ] }`. Used only by the cache freshness check. |
+
+The cached model hash is a pure model -- it contains exactly the merged Model + Common + override data, with no metadata sentinels. Code that walks `$self->{mdl}` can treat every top-level value as a section hashref.
+
+### Freshness check
+
+On a cache hit, the cached model is verified against the current state of disk. If any of the following is true, the cache is considered stale and the model is reloaded from source:
+
+- `Config.nmis` was modified more recently than the cache file.
+- `Model-<name>.nmis` or any referenced `Common-<feature>.nmis` was modified more recently than the cache file.
+- Any file listed in `global_model_overrides` was modified more recently than the cache file.
+- **The sidecar is missing, unreadable, or doesn't contain a valid `applied_overrides` arrayref.** This is the strong invariant: without trustworthy metadata about what was applied last time, the cache cannot be trusted.
+- A scoped override file (`Override-Model-<name>.nmis` or `Override-Common-<feature>.nmis`) appeared, was edited, or was deleted relative to what the sidecar recorded.
+
+Reloading from source rewrites both files atomically.
+
+The first run after deploying this code reloads every model once (no sidecars exist yet); steady-state polling reads from cache.
+
+## Pre-processing
+
+Before the merged model is written to cache, `loadModel` performs a small cleanup pass:
+
+- Any SNMP `oid` that starts with `.` has the leading dot stripped (some MIBs include it, but `Net::SNMP` rejects it).
+
+Other code that consumes the model (for example `Sys::loadInfo`) does its own normalization and does not modify the cached structure.
+
+## Model Policy
+
+After the model is loaded (whether from cache or from source), an optional **model policy** can amend the result for a specific node. The policy file is `conf/Model-Policy.nmis`. Each rule has an `IF` clause matching against `node.*` or `config.*` properties; the first matching rule applies.
+
+```perl
+%hash = (
+  10 => {
+    IF => { 'node.name' => ['edge-1','edge-2'] },
+    systemHealth => {
+      cdp  => 'true',          # add to systemHealth.sections if absent
+      lldp => 'false',         # remove from systemHealth.sections if present
+    },
+  },
+);
+```
+
+The supported amendment is currently a `systemHealth.sections` add/remove list -- the code is hardcoded to only act on `systemHealth` and notes "the only supported setting so far".
+
+The policy is applied **after** the cache write, so it does not pollute the cached model. The cache reflects the un-policied merged result, and policy is re-applied on every load.
+
+## Overrides vs. Model Policy
+
+Both mechanisms can change a loaded model, but they answer different questions:
+
+| | Override files | Model Policy |
+|---|---|---|
+| What it changes | Any key, anywhere in the merged model hash | Only `systemHealth.sections` (which subconcepts are active) |
+| Scope | All nodes that load this model | Per-node, gated by `IF` rules against `node.*` / `config.*` |
+| Trigger | File presence (scoped) or config list (global) | Rules in `conf/Model-Policy.nmis`, evaluated each load |
+| Cached? | Yes -- baked into the cached merged model | No -- re-applied on every load |
+| Answers | "What is the right way to model device type X?" | "For this specific node, which of those concepts should be active?" |
+
+**Use overrides when** you need to change the data definitions: tweak a threshold name, swap an OID, add a section the shipped Common file doesn't know about, fix a typo in vendor data. The change is true for every node of that type.
+
+**Use Model Policy when** the answer depends on the node: turn off `mplsVpnVrf` monitoring on edge nodes, enable `cdp` only in a specific location, etc. The model itself is unchanged; only the active section list shifts per-node.
+
+The mechanisms are complementary. You cannot do per-node selection with overrides (they apply at model-load time, before per-node context is available), and you cannot change OIDs, thresholds, or sub-section structure with policy (it only manipulates the section list).
+
+## Public API
+
+All functions are in `NMISNG::Sys` (`lib/NMISNG/Sys.pm`) and `NMISNG::Util` (`lib/NMISNG/Util.pm`).
+
+### `NMISNG::Sys::loadModel(model => $name)`
+
+Loads, merges, and caches the named model into `$self->{mdl}`. `$name` is the full filename without extension (e.g. `Model-CiscoRouter`). Returns 1 on success, 0 on failure (and sets `$self->{error}`).
+
+### `NMISNG::Util::getModelFile(model => $name, conf => $C, only_mtime => $bool)`
+
+Locates a model file by name, searching `<nmis_models>` first, then `<nmis_default_models>`. Returns a hashref:
+
+- `success` -- 1 if found and parsed, 0 otherwise
+- `data` -- parsed hash (omitted if `only_mtime`)
+- `mtime` -- file modification time
+- `is_custom` -- 1 if the file came from `<nmis_models>`
+- `error` -- error message on failure
+
+### `NMISNG::Util::getDir(dir => "models" | "default_models", conf => $C)`
+
+Resolves the symbolic directory name to a filesystem path.
+
+## File Format
+
+`.nmis` files contain Perl assigning to a top-level `%hash`:
+
+```perl
+%hash = (
+  'system' => {
+    'nodeVendor' => 'Cisco',
+    'nodeType'   => 'router',
+  },
+  '-common-' => {
+    'class' => {
+      'cpu'    => { 'common-model' => 'Cisco-cpu' },
+      'memory' => { 'common-model' => 'Cisco-memory' },
+    },
+  },
+  'systemHealth' => {
+    'sys' => { ... },
+    'rrd' => { ... },
+  },
+);
+```
+
+The `-common-` section names which Common files to merge in. Override files use the same format and only need to contain the keys they want to change.
+
+## Customization Recipe
+
+The general pattern is: figure out the dotted path from the top of the merged model down to the leaf you want to change, then mirror that path in an override file containing only the keys you want to change. Save it under `models-custom/` with the matching `Override-` prefix. Reload -- the override is auto-discovered, the cache invalidates, and the new value wins.
+
+To remove the customization, delete the file. The cache invalidates again on the next load.
+
+### Example 1: change an alert threshold in a Model file
+
+`models-default/Model-net-snmp.nmis` defines an alert that fires when system process count exceeds 375:
+
+```perl
+'system' => {
+  'sys' => {
+    'alerts' => {
+      'snmp' => {
+        'hrSystemProcesses' => {
+          'oid'   => 'hrSystemProcesses',
+          'title' => 'System Processes',
+          'alert' => {
+            'test'  => '$r > 375',
+            'event' => 'High Number of System Processes',
+            'unit'  => 'processes',
+            'level' => 'Warning',
+          },
+        },
+      },
+    },
+  },
+},
+```
+
+To raise the threshold to 1000 -- and only that one field -- create `models-custom/Override-Model-net-snmp.nmis`:
+
+```perl
+%hash = (
+  'system' => {
+    'sys' => {
+      'alerts' => {
+        'snmp' => {
+          'hrSystemProcesses' => {
+            'alert' => {
+              'test' => '$r > 1000',
+            },
+          },
+        },
+      },
+    },
+  },
+);
+```
+
+Everything else (`event`, `unit`, `level`, `oid`, `title`, every other alert, the rest of the model) is inherited from the base file because the override file doesn't mention it. The merge only overwrites keys present in the override.
+
+### Example 2: change multiple fields in the same alert
+
+To loosen the threshold AND escalate the severity, expand the same override file:
+
+```perl
+%hash = (
+  'system' => {
+    'sys' => {
+      'alerts' => {
+        'snmp' => {
+          'hrSystemProcesses' => {
+            'alert' => {
+              'test'  => '$r > 1000',
+              'level' => 'Critical',
+              'event' => 'Process Count Exceeded Critical Threshold',
+            },
+          },
+        },
+      },
+    },
+  },
+);
+```
+
+Sibling keys (`unit`) are still inherited. You can change as many keys as you like in a single override file -- the deep merge handles each leaf independently.
+
+### Example 3: override two unrelated alerts at once
+
+The same override file can touch any number of paths. To also raise the TCP connection alert:
+
+```perl
+%hash = (
+  'system' => {
+    'sys' => {
+      'alerts' => {
+        'snmp' => {
+          'hrSystemProcesses' => {
+            'alert' => { 'test' => '$r > 1000' },
+          },
+          'tcpCurrEstab' => {
+            'alert' => { 'test' => '$r > 500' },
+          },
+        },
+      },
+    },
+  },
+);
+```
+
+### Example 4: effectively disabling an alert
+
+The override merge **overwrites** keys but does not **delete** them -- there is no way to remove an alert via override. The closest equivalent is to give the test an expression that never matches:
+
+```perl
+%hash = (
+  'system' => {
+    'sys' => {
+      'alerts' => {
+        'snmp' => {
+          'hrSystemProcesses' => {
+            'alert' => { 'test' => '0' },   # always false
+          },
+        },
+      },
+    },
+  },
+);
+```
+
+If you need to genuinely add or remove monitored sub-concepts on a per-node basis, that is a job for **Model Policy** (see above), not for an override.
+
+### Knowing whether to use Model- or Common-
+
+When the path you want to change is defined directly inside a `Model-*.nmis` file, use `Override-Model-<name>.nmis`. When it is defined inside a `Common-*.nmis` file (often shared across many models), use `Override-Common-<feature>.nmis` so the change applies wherever that Common is included.
+
+Quick way to find out: `grep -l '<key-or-string>' models-default/Model-*.nmis models-default/Common-*.nmis`. Whichever file contains the leaf you want to change tells you the override flavour to use.
+
+## Debugging Overrides
+
+When an override doesn't behave the way you expected, the question is almost always "what does the merged model actually look like after my override was applied?" Several tools answer that.
+
+### 1. Inspect the compiled (cached) model JSON
+
+After a model loads from source, the fully-merged result is written to:
+
+```
+<nmis_var>/nmis_system/model_cache/<modelname>.json
+<nmis_var>/nmis_system/model_cache/<modelname>.json.meta.json
+```
+
+The first file is the merged model -- the same hash that becomes `$self->{mdl}` at runtime. The second is the sidecar listing which scoped overrides were applied (and at what mtime). Pretty-print and grep them:
+
+```bash
+jq . /usr/local/nmis9/var/nmis_system/model_cache/Model-net-snmp.json | less
+jq . /usr/local/nmis9/var/nmis_system/model_cache/Model-net-snmp.json.meta.json
+```
+
+Confirming the sidecar lists your override file proves it was discovered and merged. Confirming a value at the expected path in the model JSON proves the merge produced what you wanted.
+
+If you change an override and want to force a reload, simply `touch` the override file; the next model load will see the newer mtime and rebuild. To wipe caches across the board, `rm -rf <nmis_var>/nmis_system/model_cache/*` -- the next load rebuilds everything from source.
+
+### 2. `test/dev-tools.pl act=model`
+
+For the runtime view (cache or source, whichever is current, plus any per-node Model Policy applied), use the dev-tool:
+
+```bash
+perl /usr/local/nmis9/test/dev-tools.pl act=model node=<nodename>
+```
+
+It calls `NMISNG::Sys->init(name => ...)` and `Data::Dumper`s the result of `$S->mdl()`. This is the merged hash exactly as the polling code will see it for that specific node, so any per-node Model-Policy amendments are also reflected.
+
+Useful for distinguishing "the override merged correctly but policy is changing things" from "the override didn't merge at all".
+
+### 3. `admin/model_tool.pl`
+
+A model validator and discovery helper. Three modes that are useful here:
+
+```bash
+# Validate every shipped model and any custom overrides for syntax errors
+perl /usr/local/nmis9/admin/model_tool.pl check=true errors=true
+
+# Validate against the JSON schema (checks structure, not just syntax)
+perl /usr/local/nmis9/admin/model_tool.pl check=true schema=true errors=true
+
+# Walk every local node and try to load its model (catches merge failures
+# that only manifest for specific node configurations)
+perl /usr/local/nmis9/admin/model_tool.pl nodes=true
+```
+
+Schema validation will catch override files that introduce keys at illegal paths (e.g. typos in the merge structure), which can otherwise silently merge into a place no consumer reads from.
+
+### 4. `admin/compare_models.pl`
+
+Diff `models-custom/` against `models-default/`:
+
+```bash
+perl /usr/local/nmis9/admin/compare_models.pl /usr/local/nmis9/models-custom /usr/local/nmis9/models-default
+```
+
+Useful when migrating from the old "copy the whole file" style of customization: it shows exactly which files in `models-custom/` differ from shipped, which makes it easy to convert each one into a much smaller `Override-*.nmis`.
+
+### 5. Bypass the cache
+
+If you suspect the cache is masking a problem, two options:
+
+- Wipe the cache directory: `rm -rf <nmis_var>/nmis_system/model_cache/*`
+- Or set `cache_models => 0` in `conf/Config.nmis` to disable caching entirely. Models then re-merge on every load. Slower for production, fine for short debugging sessions.
+
+### 6. Run with debug logging
+
+`loadModel` emits debug messages that name each Common and Override file it merges, in order. Run any CLI command with a debug level high enough to surface them:
+
+```bash
+perl /usr/local/nmis9/bin/nmis-cli act=run-reports period=day type=health debug=2
+```
+
+Or invoke `dev-tools.pl act=model debug=3 node=<nodename>` to see the load decisions for a single node.
+
+Look for lines mentioning `Override-`, `(from cache)`, `(from source)`, `stale`, and `merged`. Combined with the cached JSON inspection above, this is usually enough to pinpoint a misbehaving override.
+
+### 7. Use the test harness as a sandbox
+
+`test/t_model_overrides.pl` builds a fresh model + Common + override under a temporary directory and confirms the merge. The same pattern is the cleanest way to validate a tricky override before deploying it: write a tiny driver that copies the relevant base files into a temp directory, drops your candidate override next to them, points `<nmis_models>` / `<nmis_default_models>` at the temp dirs, calls `NMISNG::Sys::loadModel`, and prints the result. Nothing on the live system changes.
+
+## Testing
+
+Override loading and cache freshness are tested in `test/t_model_overrides.pl`. The test runs entirely against temporary `models-default/`, `models-custom/`, and `var/` directories, so it does not perturb a running NMIS install on the same host. It does not need MongoDB. Run with:
+
+```bash
+perl test/t_model_overrides.pl
+```
+
+Broader regressions for `loadModel` are exercised by `test/t_sys.pl`, `test/t_polling.pl`, and `test/t_nmisng.pl`.

--- a/lib/NMISNG/Sys.pm
+++ b/lib/NMISNG/Sys.pm
@@ -1802,6 +1802,87 @@ sub loadModel
 					$self->nmisng->log->debug2(sub {"Cached model \"$model\" mtime $cfage compares ok to \"$other\" ($othermtime)."});
 				}
 			}
+
+			# also verify scoped override files (Override-Model-X.nmis and Override-Common-X.nmis)
+			# auto-discovered from models-custom only. Detects adds, edits, and deletes since cache was written.
+			# Cache-tracking metadata lives in a sidecar file alongside $thiscf so $self->{mdl} stays a pure model hash.
+			if (!$isstale)
+			{
+				my $sidecar_path = "$thiscf.meta.json";
+				my $cache_meta = -f $sidecar_path
+					? NMISNG::Util::readFiletoHash(file => $sidecar_path, json => 1, lock => 0, conf => $C)
+					: undef;
+
+				# Strong invariant: cache hit requires a valid sidecar with applied_overrides arrayref.
+				# Without it we cannot distinguish "no overrides ever applied" from "overrides existed but got deleted",
+				# so we cannot trust that the cached merged model still matches the current on-disk state.
+				if (ref($cache_meta) ne "HASH" or ref($cache_meta->{applied_overrides}) ne "ARRAY")
+				{
+					$self->nmisng->log->debug2(sub {"Cached model \"$model\" stale: missing or invalid sidecar at $sidecar_path."});
+					$isstale = 1;
+				}
+				else
+				{
+					my $custom_models_dir = NMISNG::Util::getDir(dir => "models", conf => $C);
+					my $shortname = $model;
+					$shortname =~ s/^Model-//;
+
+					my @expected_overrides = ("Override-Model-$shortname");
+					if (ref($self->{mdl}->{'-common-'}) eq "HASH"
+							&& ref($self->{mdl}->{'-common-'}->{class}) eq "HASH")
+					{
+						push @expected_overrides,
+							map { "Override-Common-".$self->{mdl}->{'-common-'}->{class}->{$_}->{'common-model'} }
+							(keys %{$self->{mdl}->{'-common-'}->{class}});
+					}
+
+					# what was applied last time, keyed by full path
+					my %was_applied = map { $_->{path} => $_->{mtime} } @{$cache_meta->{applied_overrides}};
+					my %expected_paths;
+
+					for my $name (@expected_overrides)
+					{
+						my $path = "$custom_models_dir/$name.nmis";
+						$expected_paths{$path} = 1;
+						my $exists_now = -e $path;
+						my $current_mtime = $exists_now ? (stat($path))[9] : undef;
+						my $prev_mtime = $was_applied{$path};
+
+						if ($exists_now && !defined $prev_mtime)
+						{
+							$self->nmisng->log->debug2(sub {"Cached model \"$model\" stale: scoped override $path appeared since cache."});
+							$isstale = 1;
+							last;
+						}
+						elsif (!$exists_now && defined $prev_mtime)
+						{
+							$self->nmisng->log->debug2(sub {"Cached model \"$model\" stale: scoped override $path was deleted since cache."});
+							$isstale = 1;
+							last;
+						}
+						elsif ($exists_now && defined $prev_mtime && $current_mtime != $prev_mtime)
+						{
+							$self->nmisng->log->debug2(sub {"Cached model \"$model\" stale: scoped override $path mtime changed."});
+							$isstale = 1;
+							last;
+						}
+					}
+
+					# defensive: catch a previously-applied override whose path no longer matches the current model structure
+					if (!$isstale)
+					{
+						for my $applied_path (keys %was_applied)
+						{
+							if (!$expected_paths{$applied_path})
+							{
+								$self->nmisng->log->debug2(sub {"Cached model \"$model\" stale: previously-applied override $applied_path no longer expected."});
+								$isstale = 1;
+								last;
+							}
+						}
+					}
+				}
+			}
 			if ($isstale)
 			{
 				$mustloadfromsource = 1;
@@ -1836,10 +1917,40 @@ sub loadModel
 			$shortname =~ s/^Model-//;
 			$self->{mdl}->{system}->{nodeModel} = $shortname;
 
+			# scoped overrides are auto-discovered from models-custom (no config setting required).
+			# Override-Model-<name>.nmis  applies to Model-<name>.nmis
+			# Override-Common-<feature>.nmis applies to Common-<feature>.nmis (merged right after the matching Common)
+			my $custom_models_dir = NMISNG::Util::getDir(dir => "models", conf => $C);
+			my @applied_overrides;
+			my $apply_scoped_override = sub {
+				my ($name) = @_;
+				my $path = "$custom_models_dir/$name.nmis";
+				return 1 if (!-e $path); # absent is normal/silent
+				my $mtime = (stat($path))[9];
+				my $data = NMISNG::Util::loadTable(dir => "models", name => "$name.nmis", conf => $C);
+				if (ref($data) ne "HASH" or !keys %$data)
+				{
+					$self->{error} = "ERROR ($self->{name}) failed to read scoped override $path: $data";
+					$exit = 0;
+					return 0;
+				}
+				if (!$self->_mergeHash($self->{mdl}, $data))
+				{
+					$self->{error} = "ERROR ($self->{name}) scoped override merge failed for $path!";
+					return 0;
+				}
+				push @applied_overrides, { path => $path, mtime => $mtime };
+				return 1;
+			};
+
+			# apply Override-Model-<shortname> right after the main model is in place
+			return 0 if (!$apply_scoped_override->("Override-Model-$shortname"));
+
 			# continue with loading common Models, sorted using characters because we didn't use numbers here...
 			foreach my $class (sort  {$a cmp $b} keys %{$self->{mdl}{'-common-'}{class}} )
 			{
-				my $name = "Common-" . $self->{mdl}{'-common-'}{class}{$class}{'common-model'};
+				my $feature = $self->{mdl}{'-common-'}{class}{$class}{'common-model'};
+				my $name = "Common-$feature";
 				my $commonres = NMISNG::Util::getModelFile(model => $name, conf => $C);
 				if (!$commonres->{success})
 				{
@@ -1855,6 +1966,8 @@ sub loadModel
 						$self->{error} = "ERROR ($self->{name}) model merging failed!";
 						return 0;
 					}
+					# apply Override-Common-<feature> immediately after its base Common file
+					return 0 if (!$apply_scoped_override->("Override-Common-$feature"));
 				}
 			}
 			# after all models are loaded add in override files
@@ -1915,6 +2028,12 @@ sub loadModel
 			if ( -d $modelcachedir && ( $self->{cache_models} || $self->{update} ) )
 			{
 				NMISNG::Util::writeHashtoFile( file => $thiscf, data => $self->{mdl}, json => 1, pretty => 0, conf => $C );
+				# sidecar with the list of scoped overrides actually merged in. Used by the freshness check
+				# on subsequent cache hits to detect added / edited / deleted scoped override files.
+				# Kept out of the model JSON so $self->{mdl} stays a pure model hash that all walkers can iterate.
+				NMISNG::Util::writeHashtoFile( file => "$thiscf.meta.json",
+											   data => { applied_overrides => \@applied_overrides },
+											   json => 1, pretty => 0, conf => $C );
 			}
 		}
 	}

--- a/test/t_model_overrides.pl
+++ b/test/t_model_overrides.pl
@@ -1,0 +1,581 @@
+#!/usr/bin/perl
+#
+# t_model_overrides.pl - tests the scoped + global model override system in
+# NMISNG::Sys::loadModel().
+#
+# Runs against isolated temporary models-default / models-custom / var directories
+# so a running NMIS install on the same host is not affected.
+#
+
+use strict;
+use warnings;
+our $VERSION = "1.0.0";
+
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+
+use Test::More;
+use Test::Deep;
+use File::Path qw(make_path remove_tree);
+use File::Temp qw(tempdir);
+use Clone;
+use Data::Dumper;
+use Time::HiRes qw(sleep);
+
+use NMISNG::Sys;
+use NMISNG::Log;
+use NMISNG::Util;
+
+use JSON::XS;
+use File::Slurp qw(read_file write_file);
+
+# -----------------------------------------------------------------------------
+# Minimal nmisng-like object: loadModel only needs ->log
+# -----------------------------------------------------------------------------
+{
+	package T::FakeNmisng;
+	sub new { my ($c, %a) = @_; bless { %a }, $c; }
+	sub log { $_[0]->{log} }
+	sub config { $_[0]->{config} }
+}
+
+# -----------------------------------------------------------------------------
+# Test harness
+# -----------------------------------------------------------------------------
+
+# Build a config rooted at temp dirs. Cloned from the real config so all the
+# other expansions and defaults are present, then path keys are replaced.
+my $tmpbase = tempdir("nmis-override-test-XXXXXX", TMPDIR => 1, CLEANUP => 1);
+my $defaults_dir = "$tmpbase/models-default";
+my $custom_dir   = "$tmpbase/models-custom";
+my $var_dir      = "$tmpbase/var";
+my $conf_dir     = "$tmpbase/conf";
+make_path($defaults_dir, $custom_dir, $var_dir, $conf_dir,
+		  "$var_dir/nmis_system/model_cache");
+
+my $real_C = NMISNG::Util::loadConfTable();
+die "cannot load real config\n" if (!$real_C || ref($real_C) ne "HASH");
+
+my $C = Clone::clone($real_C);
+$C->{'<nmis_default_models>'} = $defaults_dir;
+$C->{'<nmis_models>'}         = $custom_dir;
+$C->{'<nmis_var>'}            = $var_dir;
+$C->{'<nmis_conf>'}           = $conf_dir;
+$C->{'<nmis_conf_default>'}   = $conf_dir;
+delete $C->{global_model_overrides};
+$C->{use_json}        = 'false';
+$C->{use_json_pretty} = 'false';
+
+# Logger that drops everything quietly so the test output stays clean.
+my $logger = NMISNG::Log->new(level => 'fatal');
+my $fake_nmisng = T::FakeNmisng->new(config => $C, log => $logger);
+
+# Helpers ---------------------------------------------------------------------
+
+sub write_nmis_file {
+	my ($path, $data) = @_;
+	# writeHashtoFile returns undef on success, error string on failure
+	if (my $err = NMISNG::Util::writeHashtoFile(file => $path, data => $data,
+												json => 0, conf => $C))
+	{
+		die "failed to write $path: $err";
+	}
+	# bump mtime so successive writes within the same wallclock second
+	# are still detectable as changed
+	my $now = time();
+	utime($now, $now, $path) or die "utime $path: $!";
+	return $path;
+}
+
+sub bump_mtime {
+	my ($path) = @_;
+	my $now = time() + 2;
+	utime($now, $now, $path) or die "utime $path: $!";
+}
+
+sub make_sys {
+	my $sys = NMISNG::Sys->new();
+	$sys->{config}      = $C;
+	$sys->{_nmisng}     = $fake_nmisng;
+	$sys->{cache_models} = 1;
+	return $sys;
+}
+
+sub clear_model_cache {
+	# wipe model cache between scenarios so we always start clean
+	my $cache_dir = "$var_dir/nmis_system/model_cache";
+	if (opendir(my $dh, $cache_dir)) {
+		while (my $f = readdir($dh)) {
+			next if $f =~ /^\.\.?$/;
+			unlink "$cache_dir/$f";
+		}
+		closedir($dh);
+	}
+	# also clear loadTable's in-memory cache so stale data doesn't survive
+	# between scenarios that recreate the same path with different content
+	# (we work around per-test by using fresh paths per scenario)
+}
+
+# -----------------------------------------------------------------------------
+# Build test models. Each scenario uses a uniquely-named model so loadTable's
+# internal mtime cache cannot hand back stale data from a previous scenario.
+# -----------------------------------------------------------------------------
+
+# Base Model + Common written into the default dir, used for almost every scenario.
+sub install_base_model {
+	my ($name, $cpu_feature) = @_;
+	$cpu_feature //= "${name}Cpu";
+
+	write_nmis_file("$defaults_dir/Model-$name.nmis", {
+		system => {
+			nodeVendor => 'BaseVendor',
+			nodeType   => 'router',
+		},
+		'-common-' => {
+			class => {
+				cpu => { 'common-model' => $cpu_feature },
+			},
+		},
+	});
+	write_nmis_file("$defaults_dir/Common-$cpu_feature.nmis", {
+		systemHealth => {
+			rrd => {
+				cpu => {
+					graphtype => 'cpu',
+					indexed   => 'true',
+					threshold => 'cpu_load_base',
+				},
+			},
+		},
+	});
+	return ($name, $cpu_feature);
+}
+
+# -----------------------------------------------------------------------------
+# Scenario 1: scoped Model override changes a top-level value
+# -----------------------------------------------------------------------------
+{
+	clear_model_cache();
+	my ($name) = install_base_model("S1Router");
+
+	# add scoped Override-Model that changes nodeVendor
+	write_nmis_file("$custom_dir/Override-Model-$name.nmis", {
+		system => { nodeVendor => 'OverriddenVendor' },
+	});
+
+	my $sys = make_sys();
+	my $ok = $sys->loadModel(model => "Model-$name");
+	ok($ok, "S1: loadModel succeeded");
+	is($sys->{mdl}->{system}->{nodeVendor}, 'OverriddenVendor',
+	   "S1: scoped Model override replaced nodeVendor");
+	is($sys->{mdl}->{system}->{nodeType}, 'router',
+	   "S1: non-overridden Model values are preserved");
+}
+
+# -----------------------------------------------------------------------------
+# Scenario 2: scoped Common override changes a value contributed by Common-X
+# -----------------------------------------------------------------------------
+{
+	clear_model_cache();
+	my ($name, $feat) = install_base_model("S2Router");
+
+	write_nmis_file("$custom_dir/Override-Common-$feat.nmis", {
+		systemHealth => {
+			rrd => {
+				cpu => { threshold => 'cpu_load_overridden' },
+			},
+		},
+	});
+
+	my $sys = make_sys();
+	ok($sys->loadModel(model => "Model-$name"), "S2: loadModel succeeded");
+	is($sys->{mdl}->{systemHealth}->{rrd}->{cpu}->{threshold},
+	   'cpu_load_overridden',
+	   "S2: scoped Common override replaced threshold");
+	is($sys->{mdl}->{systemHealth}->{rrd}->{cpu}->{graphtype}, 'cpu',
+	   "S2: non-overridden Common values are preserved");
+}
+
+# -----------------------------------------------------------------------------
+# Scenario 3: auto-discovery — no global_model_overrides key, override is
+# picked up purely by file presence in models-custom.
+# -----------------------------------------------------------------------------
+{
+	clear_model_cache();
+	my ($name) = install_base_model("S3Router");
+
+	# explicit assertion: config doesn't list this override anywhere
+	ok(!exists $C->{global_model_overrides}
+	   || !@{$C->{global_model_overrides} // []},
+	   "S3: global_model_overrides config is empty");
+
+	write_nmis_file("$custom_dir/Override-Model-$name.nmis", {
+		system => { nodeVendor => 'AutoDiscovered' },
+	});
+
+	my $sys = make_sys();
+	ok($sys->loadModel(model => "Model-$name"), "S3: loadModel succeeded");
+	is($sys->{mdl}->{system}->{nodeVendor}, 'AutoDiscovered',
+	   "S3: override picked up purely from filesystem");
+}
+
+# -----------------------------------------------------------------------------
+# Scenario 4: cache invalidation when a scoped override is ADDED
+# -----------------------------------------------------------------------------
+{
+	clear_model_cache();
+	my ($name) = install_base_model("S4Router");
+
+	# first load — no overrides anywhere — populates cache
+	{
+		my $sys = make_sys();
+		ok($sys->loadModel(model => "Model-$name"), "S4: initial load ok");
+		is($sys->{mdl}->{system}->{nodeVendor}, 'BaseVendor',
+		   "S4: baseline value before override");
+	}
+
+	# wait so the override file's mtime is strictly newer than the cache file
+	sleep(1.2);
+
+	# now drop in an override
+	write_nmis_file("$custom_dir/Override-Model-$name.nmis", {
+		system => { nodeVendor => 'AddedAfterCache' },
+	});
+
+	# second load — should detect the new override and re-load from source
+	{
+		my $sys = make_sys();
+		ok($sys->loadModel(model => "Model-$name"), "S4: second load ok");
+		is($sys->{mdl}->{system}->{nodeVendor}, 'AddedAfterCache',
+		   "S4: cache invalidated, override applied");
+	}
+}
+
+# -----------------------------------------------------------------------------
+# Scenario 5: cache invalidation when a scoped override is DELETED
+# -----------------------------------------------------------------------------
+{
+	clear_model_cache();
+	my ($name) = install_base_model("S5Router");
+
+	# install override, load (caches with override applied)
+	my $override_path = "$custom_dir/Override-Model-$name.nmis";
+	write_nmis_file($override_path, {
+		system => { nodeVendor => 'WillBeDeleted' },
+	});
+
+	{
+		my $sys = make_sys();
+		ok($sys->loadModel(model => "Model-$name"), "S5: load with override ok");
+		is($sys->{mdl}->{system}->{nodeVendor}, 'WillBeDeleted',
+		   "S5: override applied initially");
+	}
+
+	# delete the override
+	unlink($override_path) or die "unlink $override_path: $!";
+
+	# next load must re-build from source (override gone) and revert
+	{
+		my $sys = make_sys();
+		ok($sys->loadModel(model => "Model-$name"), "S5: post-delete load ok");
+		is($sys->{mdl}->{system}->{nodeVendor}, 'BaseVendor',
+		   "S5: cache invalidated on delete, value reverted");
+	}
+}
+
+# -----------------------------------------------------------------------------
+# Scenario 6: cache invalidation when a scoped override is EDITED
+# -----------------------------------------------------------------------------
+{
+	clear_model_cache();
+	my ($name) = install_base_model("S6Router");
+
+	my $override_path = "$custom_dir/Override-Model-$name.nmis";
+	write_nmis_file($override_path, {
+		system => { nodeVendor => 'V1' },
+	});
+
+	{
+		my $sys = make_sys();
+		ok($sys->loadModel(model => "Model-$name"), "S6: initial load ok");
+		is($sys->{mdl}->{system}->{nodeVendor}, 'V1', "S6: V1 applied first");
+	}
+
+	sleep(1.2);
+
+	# rewrite the override with new content; mtime now > cache mtime
+	write_nmis_file($override_path, {
+		system => { nodeVendor => 'V2' },
+	});
+
+	{
+		my $sys = make_sys();
+		ok($sys->loadModel(model => "Model-$name"), "S6: post-edit load ok");
+		is($sys->{mdl}->{system}->{nodeVendor}, 'V2',
+		   "S6: cache invalidated on edit, V2 applied");
+	}
+}
+
+# -----------------------------------------------------------------------------
+# Helpers for sidecar inspection
+# -----------------------------------------------------------------------------
+sub model_cache_file {
+	my ($model) = @_;
+	return "$var_dir/nmis_system/model_cache/$model.json";
+}
+sub sidecar_file {
+	my ($model) = @_;
+	return model_cache_file($model) . ".meta.json";
+}
+sub read_sidecar {
+	my ($model) = @_;
+	my $path = sidecar_file($model);
+	return undef if (!-f $path);
+	my $raw = read_file($path);
+	my $data = eval { decode_json($raw) };
+	return $@ ? undef : $data;
+}
+
+# -----------------------------------------------------------------------------
+# Scenario 7: global + scoped together. Globals merge LAST so they win on
+# any keys both touch.
+# -----------------------------------------------------------------------------
+{
+	clear_model_cache();
+	my ($name) = install_base_model("S7Router");
+
+	write_nmis_file("$custom_dir/Override-Model-$name.nmis", {
+		system => { nodeVendor => 'ScopedWins' },
+	});
+	# global override file (lookup uses Override-<entry>.nmis under either
+	# models dir; we put it in models-custom)
+	write_nmis_file("$custom_dir/Override-globaltest.nmis", {
+		system => { nodeVendor => 'GlobalWins' },
+	});
+
+	local $C->{global_model_overrides} = ['globaltest'];
+
+	my $sys = make_sys();
+	ok($sys->loadModel(model => "Model-$name"), "S7: load ok");
+	is($sys->{mdl}->{system}->{nodeVendor}, 'GlobalWins',
+	   "S7: global override applied last, beats scoped");
+
+	# scoped Model override is recorded in the sidecar (not in $sys->{mdl})
+	ok(!exists $sys->{mdl}->{'-applied-overrides-'},
+	   "S7: \$sys->{mdl} does NOT contain -applied-overrides- (metadata is in sidecar)");
+	my $meta = read_sidecar("Model-$name");
+	is(ref($meta), 'HASH', "S7: sidecar parses as hash");
+	is(ref($meta->{applied_overrides}), 'ARRAY',
+	   "S7: sidecar.applied_overrides is an arrayref");
+	my @paths = map { $_->{path} } @{$meta->{applied_overrides}};
+	ok((grep { /Override-Model-S7Router\.nmis$/ } @paths),
+	   "S7: scoped Model override recorded in sidecar");
+}
+
+# -----------------------------------------------------------------------------
+# Scenario 8: regression — with no overrides, $sys->{mdl} contains exactly
+# the merged Model + Common content with no metadata leak.
+# -----------------------------------------------------------------------------
+{
+	clear_model_cache();
+	my ($name) = install_base_model("S8Router");
+
+	my $sys = make_sys();
+	ok($sys->loadModel(model => "Model-$name"), "S8: load ok");
+	is($sys->{mdl}->{system}->{nodeVendor}, 'BaseVendor',
+	   "S8: model value untouched without override");
+	ok(!exists $sys->{mdl}->{'-applied-overrides-'},
+	   "S8: \$sys->{mdl} stays a pure model hash");
+	is($sys->{mdl}->{systemHealth}->{rrd}->{cpu}->{graphtype}, 'cpu',
+	   "S8: Common content still merged in");
+
+	# sidecar must still be written, even with no overrides — freshness check needs it
+	my $meta = read_sidecar("Model-$name");
+	is(ref($meta), 'HASH', "S8: sidecar exists even with no overrides");
+	is(ref($meta->{applied_overrides}), 'ARRAY',
+	   "S8: sidecar applied_overrides is an arrayref");
+	is(scalar(@{$meta->{applied_overrides}}), 0,
+	   "S8: applied_overrides is empty when none on disk");
+}
+
+# -----------------------------------------------------------------------------
+# Scenario 9: walker safety — top-level model walkers must not see any
+# non-hash junk after loadModel(). Exercises the same iteration patterns
+# init() and getTitle() use.
+# -----------------------------------------------------------------------------
+{
+	clear_model_cache();
+	my ($name) = install_base_model("S9Router");
+
+	# apply both a Model override and a Common override so multiple sidecar
+	# entries get recorded, maximising the chance of stray metadata leakage.
+	write_nmis_file("$custom_dir/Override-Model-$name.nmis", {
+		system => { nodeVendor => 'WalkSafe' },
+	});
+	write_nmis_file("$custom_dir/Override-Common-S9RouterCpu.nmis", {
+		systemHealth => {
+			rrd => { cpu => { threshold => 'cpu_walked' } },
+		},
+	});
+
+	my $sys = make_sys();
+	ok($sys->loadModel(model => "Model-$name"), "S9: load ok");
+
+	# 9a: every top-level value of $sys->{mdl} must be a hashref. This is
+	# the invariant that protects all walker patterns in Sys.pm and elsewhere.
+	my @nonhash_keys = grep { ref($sys->{mdl}->{$_}) ne "HASH" }
+						keys %{$sys->{mdl}};
+	is(scalar(@nonhash_keys), 0,
+	   "S9: every top-level key in \$sys->{mdl} is a hashref")
+		or diag("non-hash top-level keys: " . join(", ", @nonhash_keys));
+
+	# 9b: getTitle's iteration shape — must not throw
+	my $title;
+	eval { $title = $sys->getTitle(attr => "nodeVendor"); };
+	ok(!$@, "S9: getTitle does not crash on overridden model")
+		or diag("getTitle threw: $@");
+
+	# 9c: init()'s policy-section iteration shape — replicate it directly
+	# and confirm no exception (the bug it would trigger is "Not a HASH reference")
+	my $crashed;
+	eval {
+		for my $topsect (keys %{$sys->{mdl}}) {
+			# the original init() loop dereferences ->{rrd} unconditionally;
+			# we replicate that exact dereference to prove our model is safe
+			my $rrd = $sys->{mdl}->{$topsect}->{rrd};
+			# touch it so perl actually evaluates the deref
+			my $is_hash = ref($rrd) eq "HASH";
+		}
+	};
+	$crashed = $@;
+	ok(!$crashed, "S9: init()-style top-level walker does not throw")
+		or diag("walker threw: $crashed");
+
+	# 9d: data integrity — overrides actually applied
+	is($sys->{mdl}->{system}->{nodeVendor}, 'WalkSafe',
+	   "S9: Model override value present");
+	is($sys->{mdl}->{systemHealth}->{rrd}->{cpu}->{threshold}, 'cpu_walked',
+	   "S9: Common override value present");
+}
+
+# -----------------------------------------------------------------------------
+# Scenario 10: sidecar visibility — file present, parses, has expected
+# structure. (Most assertions already covered by S7/S8; this consolidates
+# a focused check.)
+# -----------------------------------------------------------------------------
+{
+	clear_model_cache();
+	my ($name) = install_base_model("S10Router");
+
+	write_nmis_file("$custom_dir/Override-Common-S10RouterCpu.nmis", {
+		systemHealth => { rrd => { cpu => { threshold => 'cpu_visible' } } },
+	});
+
+	my $sys = make_sys();
+	ok($sys->loadModel(model => "Model-$name"), "S10: load ok");
+
+	ok(-f sidecar_file("Model-$name"), "S10: sidecar file exists on disk");
+	my $meta = read_sidecar("Model-$name");
+	is(ref($meta), 'HASH', "S10: sidecar is a JSON hash");
+	is(ref($meta->{applied_overrides}), 'ARRAY',
+	   "S10: applied_overrides is an arrayref");
+	is(scalar(@{$meta->{applied_overrides}}), 1,
+	   "S10: exactly one override recorded");
+	my $entry = $meta->{applied_overrides}->[0];
+	like($entry->{path}, qr/Override-Common-S10RouterCpu\.nmis$/,
+		 "S10: recorded path matches the override file");
+	ok(defined $entry->{mtime} && $entry->{mtime} > 0,
+	   "S10: recorded mtime is set");
+}
+
+# -----------------------------------------------------------------------------
+# Scenario 11: missing sidecar forces reload. Closes the
+# silent-stale-data hole — without the sidecar we cannot trust the cache.
+# -----------------------------------------------------------------------------
+{
+	clear_model_cache();
+	my ($name) = install_base_model("S11Router");
+
+	# load once with an override → cache + sidecar populated
+	my $override_path = "$custom_dir/Override-Model-$name.nmis";
+	write_nmis_file($override_path, {
+		system => { nodeVendor => 'BeforeSidecarGone' },
+	});
+
+	{
+		my $sys = make_sys();
+		ok($sys->loadModel(model => "Model-$name"), "S11: initial load ok");
+		is($sys->{mdl}->{system}->{nodeVendor}, 'BeforeSidecarGone',
+		   "S11: override applied initially");
+	}
+
+	# pathological case: user deletes BOTH the override file AND the sidecar
+	# leaving only the (now stale) model JSON. Without the sidecar gate, the
+	# cached model would be silently used and contain wrong data.
+	unlink($override_path) or die "unlink override: $!";
+	my $sidecar = sidecar_file("Model-$name");
+	ok(-f $sidecar, "S11: sidecar exists before deletion");
+	unlink($sidecar) or die "unlink sidecar: $!";
+	ok(!-f $sidecar, "S11: sidecar deleted");
+
+	{
+		my $sys = make_sys();
+		ok($sys->loadModel(model => "Model-$name"), "S11: post-delete load ok");
+		is($sys->{mdl}->{system}->{nodeVendor}, 'BaseVendor',
+		   "S11: missing sidecar forced reload, value reverted");
+		ok(-f $sidecar, "S11: sidecar regenerated by reload");
+	}
+}
+
+# -----------------------------------------------------------------------------
+# Scenario 12: corrupt sidecar forces reload.
+# -----------------------------------------------------------------------------
+{
+	clear_model_cache();
+	my ($name) = install_base_model("S12Router");
+
+	my $override_path = "$custom_dir/Override-Model-$name.nmis";
+	write_nmis_file($override_path, {
+		system => { nodeVendor => 'V1WithSidecar' },
+	});
+
+	# initial load → populates cache and sidecar
+	{
+		my $sys = make_sys();
+		ok($sys->loadModel(model => "Model-$name"), "S12: initial load ok");
+	}
+
+	# corrupt sidecar three different ways across sub-cases. Each must
+	# trigger a reload; the load itself should always succeed.
+	my $sidecar = sidecar_file("Model-$name");
+
+	for my $case (
+		[ "garbage non-JSON",        "this is not json {{{}}" ],
+		[ "JSON array (not hash)",   '[1,2,3]' ],
+		[ "JSON hash w/o array key", '{"foo":"bar"}' ],
+	) {
+		my ($label, $content) = @$case;
+		write_file($sidecar, $content);
+
+		# write override with a different value to prove a reload happened
+		# (i.e. the new value would only appear on reload-from-source)
+		sleep(1.2);
+		write_nmis_file($override_path, {
+			system => { nodeVendor => "Reloaded-$label" },
+		});
+
+		my $sys = make_sys();
+		ok($sys->loadModel(model => "Model-$name"),
+		   "S12 [$label]: load ok despite corrupt sidecar");
+		is($sys->{mdl}->{system}->{nodeVendor}, "Reloaded-$label",
+		   "S12 [$label]: corrupt sidecar forced reload, latest override applied");
+		# sidecar must be regenerated cleanly
+		my $meta = read_sidecar("Model-$name");
+		is(ref($meta), 'HASH',
+		   "S12 [$label]: sidecar rewritten as valid hash");
+		is(ref($meta->{applied_overrides}), 'ARRAY',
+		   "S12 [$label]: applied_overrides arrayref restored");
+	}
+}
+
+done_testing();


### PR DESCRIPTION
…to-discovery

  Customizing a model previously required either copying the whole
  Model-*.nmis or Common-*.nmis into models-custom (forcing the user to
  own the whole file across upgrades), or registering global override
  files in the global_model_overrides config setting (with no way to
  target a specific Model file).

  This change adds two filename-scoped override flavours, auto-discovered
  from models-custom — no config registration required:

    - Override-Model-<name>.nmis    merges on top of Model-<name>.nmis
    - Override-Common-<feat>.nmis   merges on top of Common-<feat>.nmis

  Merge precedence (highest last): base file -> scoped override ->
  matching scoped Common overrides for each Common -> global_model_overrides
  entries (preserved unchanged for cross-cutting customizations).

  Cache freshness now tracks which scoped overrides were applied via a
  sidecar file (<model>.json.meta.json) so add / edit / delete of a
  scoped override invalidates the cache correctly. The sidecar lives
  outside $self->{mdl} so the merged model hash stays a pure model —
  top-level walkers in init() and getTitle() (and anywhere else that
  iterates keys %{$self->{mdl}}) continue to work without per-walker
  guards. Missing or invalid sidecar forces a reload, closing the
  silent-stale-data hole if a user removes the sidecar by hand.

  Adds test/t_model_overrides.pl (67 assertions, 12 scenarios) running
  against isolated temp model + var dirs so it does not perturb a
  running NMIS install on the same host.

  Adds docs/model-loading.md documenting the directory layout, file
  types, override mechanism, merge order, caching with sidecar, and
  how overrides relate to (and differ from) Model-Policy.nmis. Includes
  four worked examples customizing the hrSystemProcesses alert in
  Model-net-snmp.nmis.