### PR TITLE
Fix nodes stranded after an nmisd restart: clear leftover workers, KillMode=mixed

### DIFF
--- a/bin/nmisd
+++ b/bin/nmisd
@@ -595,6 +595,36 @@ $nmisng->clear_active_queue();
 
 &NMISNG::rrdfunc::require_RRDs;
 
+# A previous run may have left workers alive (master killed -9, OOM, crash, or
+# systemd KillMode=process). Such orphans run stale in-memory code and config
+# and must never be adopted into this run, so kill any still-alive processes
+# recorded in the loaded state before starting a fresh pool. Start time is
+# verified so a recycled PID can't hit an unrelated process. We cannot waitpid
+# these (they are reparented to init), so poll for exit with a ~1s ceiling.
+if (ref($scheduler_state->{zoo}) eq "HASH" && keys %{$scheduler_state->{zoo}})
+{
+	my $pt = Proc::ProcessTable->new(enable_ttys => 0);
+	my %bypid = map { ($_->pid => $_) } @{$pt->table};
+	my @leftover = grep { exists $bypid{$_}
+												&& kill(0, $_)
+												&& $scheduler_state->{zoo}->{$_}->{starttime} == $bypid{$_}->start
+											} keys %{$scheduler_state->{zoo}};
+	if (@leftover)
+	{
+		$logger->warn("Killing ".scalar(@leftover)." leftover worker(s) from a previous run: @leftover");
+		kill("TERM", @leftover);
+		my @alive = @leftover;
+		for (1..20)							# 20 * 50ms = 1s ceiling, exits early when all gone
+		{
+			@alive = grep { kill(0, $_) } @alive;
+			last if (!@alive);
+			Time::HiRes::sleep(0.05);
+		}
+		kill("KILL", @alive) if (@alive);	# SIGKILL only the ones that ignored TERM
+	}
+}
+$scheduler_state->{zoo} = {};			# always start with a clean worker pool
+
 my $zoo = ($scheduler_state->{zoo} //= {}); # process state structure for manage_processes
 my $exit_marker;							# signal handler scribbles here
 

--- a/bin/nmisd
+++ b/bin/nmisd
@@ -453,6 +453,15 @@ if (!$foreground)
 				print("Scheduler process was not running.\n");
 			}
 			unlink($pidFile) if (-f $pidFile);
+			# Sweep any per-node lock files orphaned by workers that
+			# didn't reach Node::unlock() before we killed them.
+			# Class-method form: no NMISNG instance is built in the
+			# stop/abort path, and we don't want to open a DB connection
+			# just to do a filesystem sweep (especially mid-shutdown).
+			my $cleaned = NMISNG->clear_stale_node_locks(
+				config => $config, log => $logger);
+			print("Removed $cleaned stale node lock file(s).\n")
+				if ($cleaned && !$debug);
 			exit (0);
 		}
 	}
@@ -477,6 +486,13 @@ if (!$foreground)
 					print "No processes running, nothing to kill\n";
 				}
 				unlink($pidFile) if (-f $pidFile);
+				# Sweep stale per-node lock files (workers we just killed
+				# probably didn't reach Node::unlock()). Class-method form
+				# avoids opening a DB connection during emergency shutdown.
+				my $cleaned = NMISNG->clear_stale_node_locks(
+					config => $config, log => $logger);
+				print("Removed $cleaned stale node lock file(s).\n")
+					if ($cleaned && !$debug);
 				exit(0);
 			}
 			# We are starting up; 
@@ -565,6 +581,17 @@ $nmisng->existing_timed_collections($tc_list);
 # they end up sitting there until their timeout period when
 # and nmisd wasn't running before this so they cant be active
 $nmisng->clear_active_queue();
+
+# Sweep any per-node lock files left behind by a previous run whose
+# workers died without releasing (kill -9, OOM, panic). The Node::lock
+# function self-heals on each acquisition too, but cleaning up here
+# leaves a tidy initial state so the first job for any node doesn't
+# need to do the cleanup mid-run.
+{
+	my $cleaned = $nmisng->clear_stale_node_locks();
+	$logger->info("Removed $cleaned stale node lock file(s) at startup")
+		if ($cleaned);
+}
 
 &NMISNG::rrdfunc::require_RRDs;
 

--- a/ci/scripts/perl_tests.sh
+++ b/ci/scripts/perl_tests.sh
@@ -20,6 +20,7 @@ working_tests=(
     nmisng_log.t
     t_sys.pl
     t_polling.pl
+    t_node_lock_stale.pl
 )
 
 for i in "${working_tests[@]}"; do

--- a/conf-default/init/nmis9d.service
+++ b/conf-default/init/nmis9d.service
@@ -17,6 +17,11 @@ Restart=no
 EnvironmentFile=-/etc/environment
 PIDFile=/usr/local/nmis9/var/nmis_system/nmisd.pid
 TimeoutSec=90s
-KillMode=process
+# mixed: SIGTERM to the master only (it shuts its workers down gracefully via
+# its own signal handler), then SIGKILL to the whole control group after the
+# timeout. This guarantees no worker survives a stop/restart/crash holding a
+# per-node lock. KillMode=process left orphaned workers alive, which stranded
+# nodes behind a live lock until the lock file was cleared manually.
+KillMode=mixed
 ExecStart=/usr/local/nmis9/bin/nmisd
 

--- a/lib/NMISNG.pm
+++ b/lib/NMISNG.pm
@@ -5072,8 +5072,12 @@ sub clear_stale_node_locks
 		chomp $line;
 		my ($pid, $op) = split /\s+/, $line;
 
-		# Only ESRCH counts as stale; non-numeric / undef / <=0 also stale
-		# (treated as "no live owner recorded"). Mirrors Node::_is_pid_stale.
+		# Only ESRCH counts as stale; non-numeric / undef / <=0 also stale.
+		# An unreadable or corrupt lock file is removed too, on purpose: the
+		# sweep runs at startup (and stop/abort) when no process holds a lock,
+		# and Node::lock() can't use a file it can't open either (it returns an
+		# error and never acquires), so leaving it would wedge the node forever.
+		# Removing it lets lock() recreate a clean file on the next acquire.
 		my $stale;
 		if (!defined $pid || $pid !~ /^\d+$/ || $pid <= 0)
 		{

--- a/lib/NMISNG.pm
+++ b/lib/NMISNG.pm
@@ -5012,6 +5012,99 @@ sub clear_active_queue
 	return $all_good;
 }
 
+# Sweep <nmis_var>/*.lock files; remove any whose recorded holder PID is no
+# longer alive. Idempotent and safe to call at any time. Used by nmisd at
+# startup, act=stop, and act=abort to leave a clean slate; the per-Node
+# lock() function also self-heals on each acquisition, so this sweep is
+# belt-and-suspenders rather than the only safety net.
+#
+# Liveness check matches Node::_is_pid_stale: only ESRCH counts as "dead";
+# EPERM (cross-user, signaling not allowed) means alive and is left alone.
+#
+# Can be invoked as either:
+#   $nmisng->clear_stale_node_locks();
+#   NMISNG->clear_stale_node_locks(config => \%config, log => $logger);
+#
+# The class-method form is used by nmisd's act=stop / act=abort paths where
+# no NMISNG instance has been built yet (avoiding an unnecessary DB
+# connection during what may be an emergency shutdown).
+#
+# returns: number of stale lock files removed.
+sub clear_stale_node_locks
+{
+	my ($self_or_class, %args) = @_;
+
+	my ($config, $log);
+	if (ref $self_or_class)
+	{
+		$config = $self_or_class->config;
+		$log    = $self_or_class->log;
+	}
+	else
+	{
+		$config = $args{config};
+		$log    = $args{log};
+	}
+
+	my $vardir = $config && $config->{'<nmis_var>'};
+	return 0 unless defined $vardir && -d $vardir;
+
+	my $cleaned = 0;
+	my $dh;
+	if (!opendir($dh, $vardir))
+	{
+		$log->warn("clear_stale_node_locks: cannot open $vardir: $!") if $log;
+		return 0;
+	}
+
+	while (my $name = readdir $dh)
+	{
+		next unless $name =~ /\.lock$/;
+		my $path = "$vardir/$name";
+		next unless -f $path;
+
+		my $line = '';
+		if (open my $fh, '<', $path)
+		{
+			$line = <$fh> // '';
+			close $fh;
+		}
+		chomp $line;
+		my ($pid, $op) = split /\s+/, $line;
+
+		# Only ESRCH counts as stale; non-numeric / undef / <=0 also stale
+		# (treated as "no live owner recorded"). Mirrors Node::_is_pid_stale.
+		my $stale;
+		if (!defined $pid || $pid !~ /^\d+$/ || $pid <= 0)
+		{
+			$stale = 1;
+		}
+		else
+		{
+			$! = 0;
+			$stale = (!kill(0, $pid) && $! == ESRCH) ? 1 : 0;
+		}
+
+		if ($stale)
+		{
+			if (unlink $path)
+			{
+				$log->info("clear_stale_node_locks: removed stale $path"
+					. " (holder PID " . (defined $pid ? $pid : 'undef')
+					. ", op=" . (defined $op ? $op : 'N/A') . ")") if $log;
+				$cleaned++;
+			}
+			else
+			{
+				$log->warn("clear_stale_node_locks: failed to remove $path: $!") if $log;
+			}
+		}
+	}
+	closedir $dh;
+
+	return $cleaned;
+}
+
 # records/updates the status of an operation
 # args: id (optional but required for updating an existing record)
 #  time (defaults to now),

--- a/lib/NMISNG.pm
+++ b/lib/NMISNG.pm
@@ -5014,12 +5014,12 @@ sub clear_active_queue
 
 # Sweep <nmis_var>/*.lock files; remove any whose recorded holder PID is no
 # longer alive. Idempotent and safe to call at any time. Used by nmisd at
-# startup, act=stop, and act=abort to leave a clean slate; the per-Node
-# lock() function also self-heals on each acquisition, so this sweep is
-# belt-and-suspenders rather than the only safety net.
+# startup, act=stop, and act=abort to leave a tidy initial state. This only
+# removes lock files left by a dead holder; a lock still held by a live
+# process is left alone (its recorded PID is alive).
 #
-# Liveness check matches Node::_is_pid_stale: only ESRCH counts as "dead";
-# EPERM (cross-user, signaling not allowed) means alive and is left alone.
+# Liveness check: only ESRCH counts as "dead"; EPERM (cross-user, signaling
+# not allowed) means the holder is alive and the lock file is left in place.
 #
 # Can be invoked as either:
 #   $nmisng->clear_stale_node_locks();

--- a/lib/NMISNG/Node.pm
+++ b/lib/NMISNG/Node.pm
@@ -47,6 +47,7 @@ use Statistics::Lite;
 use URI::Escape;
 use POSIX qw(:sys_wait_h :signal_h);
 use Fcntl qw(:DEFAULT :flock :mode); # for flock
+use Errno qw(ESRCH);                 # for stale-lock detection in lock()
 use Net::SNMP;									# for oid_lex_sort
 use File::Temp;
 
@@ -9285,10 +9286,17 @@ sub collect_services
 # type is set from conflict or arg, handle is the open fh, file
 #
 # note: mostly irrelevant, nmisd workers normally don't start jobs if clashing
+#
+# Stale-lock self-heal: if the recorded holder PID is no longer alive (worker
+# was killed -9, OOM-killed, or nmisd was abort'd before unlocking), the lock
+# file is removed and acquisition is retried once. ESRCH is the only verdict
+# that means "process gone"; EPERM means alive but cross-user and is left
+# alone. The _stale_retried flag prevents looping.
 sub lock
 {
 	my ($self, %args) = @_;
 	my $lock = $args{lock} // {};
+	my $retried = delete $args{_stale_retried};
 
 	my $config = $self->nmisng->config;
 	my $fn = $lock->{file} = $config->{'<nmis_var>'}."/".$self->name.".lock";
@@ -9323,6 +9331,19 @@ sub lock
 		{
 			my ($pid,$op) = split(/\s+/, <$fhandle>);
 			close($fhandle);
+
+			if (!$retried && _is_pid_stale($pid))
+			{
+				$self->nmisng->log->warn(
+					"Stale node lock for ".$self->name." held by dead PID "
+					. (defined $pid ? $pid : 'undef')
+					. " (op=" . (defined $op ? $op : 'N/A')
+					. "); removing and retrying");
+				unlink($fn);
+				delete $lock->{handle};
+				return $self->lock(%args, _stale_retried => 1);
+			}
+
 			return { conflict => ($pid || -1), type => ($op || "N/A") };
 		}
 	}
@@ -9334,6 +9355,20 @@ sub lock
 	$fhandle->autoflush;
 
 	return $lock;
+}
+
+# Private helper for lock(): is the recorded holder PID stale?
+# Returns true if undef, non-numeric, <=0, or kill(0,$pid) reports ESRCH.
+# Returns false for live PIDs, including cross-user PIDs that yield EPERM
+# (those are alive, just outside our signaling permission).
+sub _is_pid_stale
+{
+	my ($pid) = @_;
+	return 1 if !defined $pid;
+	return 1 if $pid !~ /^\d+$/;
+	return 1 if $pid <= 0;
+	$! = 0;
+	return (!kill(0, $pid) && $! == ESRCH) ? 1 : 0;
 }
 
 # unlock an existing lock and cleans up the lockfile afterwards

--- a/lib/NMISNG/Node.pm
+++ b/lib/NMISNG/Node.pm
@@ -47,7 +47,7 @@ use Statistics::Lite;
 use URI::Escape;
 use POSIX qw(:sys_wait_h :signal_h);
 use Fcntl qw(:DEFAULT :flock :mode); # for flock
-use Errno qw(ESRCH);                 # for stale-lock detection in lock()
+use Errno qw(ESRCH EPERM);           # for stale-lock detection + holder diagnostics in lock()
 use Net::SNMP;									# for oid_lex_sort
 use File::Temp;
 
@@ -9287,16 +9287,16 @@ sub collect_services
 #
 # note: mostly irrelevant, nmisd workers normally don't start jobs if clashing
 #
-# Stale-lock self-heal: if the recorded holder PID is no longer alive (worker
-# was killed -9, OOM-killed, or nmisd was abort'd before unlocking), the lock
-# file is removed and acquisition is retried once. ESRCH is the only verdict
-# that means "process gone"; EPERM means alive but cross-user and is left
-# alone. The _stale_retried flag prevents looping.
+# On a flock conflict this returns { conflict => holder_pid } and logs a
+# diagnostic describing the holder (liveness + command). It does NOT remove a
+# held lock: a held flock means a live process owns it, and stale lock files
+# left by a dead holder are cleaned up at the process layer instead (nmisd
+# kills leftover workers at startup and sweeps stale lock files; systemd
+# KillMode=mixed reaps the worker cgroup on stop/restart).
 sub lock
 {
 	my ($self, %args) = @_;
 	my $lock = $args{lock} // {};
-	my $retried = delete $args{_stale_retried};
 
 	my $config = $self->nmisng->config;
 	my $fn = $lock->{file} = $config->{'<nmis_var>'}."/".$self->name.".lock";
@@ -9332,17 +9332,16 @@ sub lock
 			my ($pid,$op) = split(/\s+/, <$fhandle>);
 			close($fhandle);
 
-			if (!$retried && _is_pid_stale($pid))
-			{
-				$self->nmisng->log->warn(
-					"Stale node lock for ".$self->name." held by dead PID "
-					. (defined $pid ? $pid : 'undef')
-					. " (op=" . (defined $op ? $op : 'N/A')
-					. "); removing and retrying");
-				unlink($fn);
-				delete $lock->{handle};
-				return $self->lock(%args, _stale_retried => 1);
-			}
+			# Diagnostic: log who holds the lock. Cleanup of orphaned locks is
+			# handled at the process layer (nmisd kills leftover workers at
+			# startup; systemd KillMode=mixed reaps the cgroup) plus the startup
+			# sweep, so lock() only reports the conflict here. The holder's
+			# liveness and command tell a genuinely-running worker apart from an
+			# orphan that survived a restart or a PID that is already gone.
+			$self->nmisng->log->info("Lock conflict for ".$self->name
+				.": "._lock_holder_diag($pid)
+				." (holder op=".(defined $op ? $op : 'N/A')
+				.", requested op=".(defined $args{type} ? $args{type} : '?').")");
 
 			return { conflict => ($pid || -1), type => ($op || "N/A") };
 		}
@@ -9357,18 +9356,43 @@ sub lock
 	return $lock;
 }
 
-# Private helper for lock(): is the recorded holder PID stale?
-# Returns true if undef, non-numeric, <=0, or kill(0,$pid) reports ESRCH.
-# Returns false for live PIDs, including cross-user PIDs that yield EPERM
-# (those are alive, just outside our signaling permission).
-sub _is_pid_stale
+# Diagnostic helper for lock(): describe the recorded holder PID on conflict.
+# Reports liveness (alive / dead / cross-user) and, on Linux, the holding
+# process's command, so an operator can tell a live nmisd worker apart from an
+# orphan or a PID that is already gone. Best-effort and side-effect free.
+# Note: this reports the PID recorded in the lock file; with fd inheritance the
+# process actually holding the flock may differ (use fuser/lsof to be certain).
+sub _lock_holder_diag
 {
 	my ($pid) = @_;
-	return 1 if !defined $pid;
-	return 1 if $pid !~ /^\d+$/;
-	return 1 if $pid <= 0;
+	return "no usable holder PID recorded"
+		if (!defined $pid || $pid !~ /^\d+$/ || $pid <= 0);
+
+	my $liveness;
 	$! = 0;
-	return (!kill(0, $pid) && $! == ESRCH) ? 1 : 0;
+	if    (kill(0, $pid)) { $liveness = "ALIVE"; }
+	elsif ($! == ESRCH)   { $liveness = "DEAD (no such process)"; }
+	elsif ($! == EPERM)   { $liveness = "alive, owned by another user"; }
+	else                  { $liveness = "indeterminate ($!)"; }
+
+	# best-effort process identity from /proc (Linux); never fatal
+	my $cmd;
+	if (open(my $fh, '<', "/proc/$pid/cmdline"))
+	{
+		local $/;
+		my $raw = <$fh>;
+		close $fh;
+		if (defined $raw && length $raw) { $raw =~ s/\0/ /g; $raw =~ s/\s+$//; $cmd = $raw; }
+	}
+	if (!defined $cmd && open(my $fh, '<', "/proc/$pid/comm"))
+	{
+		my $c = <$fh>;
+		close $fh;
+		chomp $c if defined $c;
+		$cmd = $c if (defined $c && length $c);
+	}
+
+	return "holder PID $pid is $liveness" . (defined $cmd ? " (cmd: $cmd)" : "");
 }
 
 # unlock an existing lock and cleans up the lockfile afterwards

--- a/test/t_node_lock_stale.pl
+++ b/test/t_node_lock_stale.pl
@@ -1,0 +1,200 @@
+#!/usr/bin/perl
+#
+# t_node_lock_stale.pl — tests the self-healing stale-lock fix.
+#
+# Part 1: Node::lock() detects a dead holder PID and recovers automatically.
+# Part 2: NMISNG::clear_stale_node_locks() sweeps stale .lock files.
+#
+
+use strict;
+use warnings;
+our $VERSION = "1.0.0";
+
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+
+use Test::More;
+use File::Temp qw(tempdir);
+
+use NMISNG;
+use NMISNG::Node;
+use NMISNG::Util;
+use NMISNG::Log;
+
+# ============================================================
+# Setup
+# ============================================================
+my $C = NMISNG::Util::loadConfTable();
+die "Cannot load config" if (!$C);
+
+# Override <nmis_var> to a private temp dir so this test is fully isolated
+# and never collides with real lock files in /usr/local/nmis9/var.
+my $vardir = tempdir(CLEANUP => 1);
+$C->{'<nmis_var>'} = $vardir;
+$C->{db_name}      = "t_node_lock_stale-" . time;
+
+my $logger = NMISNG::Log->new(level => 'info');
+my $nmisng = NMISNG->new(config => $C, log => $logger);
+die "NMISNG object required" if (!$nmisng);
+
+sub cleanup { $nmisng->get_db()->drop(); }
+
+sub make_node
+{
+	my ($name) = @_;
+	my $node = NMISNG::Node->new(uuid => NMISNG::Util::getUUID(), nmisng => $nmisng);
+	$node->cluster_id($C->{cluster_id});
+	$node->name($name);
+	$node->configuration({
+		host      => "127.0.0.1",
+		group     => "TestGroup",
+		netType   => "default",
+		roleType  => "default",
+		threshold => 1,
+		model     => "Default",
+		collect   => "true",
+		ping      => "false",
+		community => "public",
+	});
+	my ($op, $err) = $node->save();
+	die "saving $name failed: $err" if $err;
+	return $node;
+}
+
+# Helper: write a hand-crafted lock file with a given PID + op string.
+sub plant_lock
+{
+	my ($name, $pid, $op) = @_;
+	my $path = "$vardir/$name.lock";
+	open my $fh, '>', $path or die "cannot create $path: $!";
+	print $fh "$pid $op\n";
+	close $fh;
+	return $path;
+}
+
+sub read_lock
+{
+	my ($name) = @_;
+	my $path = "$vardir/$name.lock";
+	return undef unless -f $path;
+	open my $fh, '<', $path or return undef;
+	my $line = <$fh>;
+	close $fh;
+	chomp $line if defined $line;
+	return $line;
+}
+
+# Pick a PID that is almost certainly dead. We use 999999 — even if it
+# happens to exist, it's outside any normal range and a probe failure
+# would be noise, not a real test failure.
+my $DEAD_PID = 999999;
+
+# ============================================================
+# Part 1a: dead PID -> stale, lock acquired
+# ============================================================
+diag("=== Part 1a: dead holder PID -> self-heal ===");
+{
+	my $node = make_node("test_lock_dead");
+	plant_lock("test_lock_dead", $DEAD_PID, "update");
+
+	my $r = $node->lock(type => "update");
+	ok(!$r->{error},    "no error on stale-lock acquisition") or diag("err: $r->{error}");
+	ok(!$r->{conflict}, "no conflict reported (was treated as stale)");
+	ok($r->{handle},    "got a live file handle");
+
+	# After acquisition, the file should record our PID.
+	my $line = read_lock("test_lock_dead");
+	like($line, qr/^$$ update/, "lock file now records our own PID + op");
+
+	$node->unlock(lock => $r);
+	ok(!-f "$vardir/test_lock_dead.lock", "lock file removed by unlock");
+}
+
+# ============================================================
+# Part 1b: _is_pid_stale helper directly
+# (Testing live conflict end-to-end through lock() requires a second
+# process holding flock; the helper is the core liveness logic and is
+# what lock() actually consults. Direct testing covers all the edge
+# cases without needing fork.)
+# ============================================================
+diag("=== Part 1b: Node::_is_pid_stale liveness check ===");
+{
+	# Live PID — this very test process — must NOT be flagged stale.
+	ok(!NMISNG::Node::_is_pid_stale($$),  "self PID (live) -> not stale");
+
+	# Dead PID — almost certainly nothing at PID 999999.
+	ok(NMISNG::Node::_is_pid_stale($DEAD_PID), "dead PID -> stale");
+
+	# Malformed / sentinel values must all be stale.
+	ok(NMISNG::Node::_is_pid_stale(undef),     "undef -> stale");
+	ok(NMISNG::Node::_is_pid_stale(""),        "empty string -> stale");
+	ok(NMISNG::Node::_is_pid_stale(0),         "zero -> stale");
+	ok(NMISNG::Node::_is_pid_stale(-1),        "negative -> stale");
+	ok(NMISNG::Node::_is_pid_stale("garbage"), "non-numeric -> stale");
+
+	# Init PID 1 is essentially always alive on a Linux host.
+	# (If somehow not, that's a system-level oddity, not a fix issue.)
+	ok(!NMISNG::Node::_is_pid_stale(1), "PID 1 (init) -> not stale");
+}
+
+# ============================================================
+# Part 1c: non-numeric / -1 / 0 holder -> stale
+# ============================================================
+diag("=== Part 1c: malformed holder -> treated as stale ===");
+{
+	for my $bad ("-1", "0", "garbage") {
+		my $name = "test_lock_bad_$bad";
+		$name =~ s/[^a-zA-Z0-9_]/_/g;     # filename-safe
+		my $node = make_node($name);
+		plant_lock($name, $bad, "update");
+
+		my $r = $node->lock(type => "update");
+		ok(!$r->{conflict}, "[$bad holder] no conflict, treated as stale")
+			or diag("got conflict=$r->{conflict}");
+		ok($r->{handle}, "[$bad holder] acquired live handle");
+		$node->unlock(lock => $r) if $r->{handle};
+	}
+}
+
+# ============================================================
+# Part 2: clear_stale_node_locks() sweep
+# ============================================================
+diag("=== Part 2: NMISNG->clear_stale_node_locks() sweep ===");
+{
+	# Plant a mix: two dead, one live, plus a non-.lock file that should be ignored.
+	plant_lock("sweep_dead_a", $DEAD_PID,     "update");
+	plant_lock("sweep_dead_b", $DEAD_PID + 1, "collect");
+	plant_lock("sweep_live",   $$,            "update");
+	open my $fh, '>', "$vardir/not_a_lock.txt" or die;
+	print $fh "irrelevant";
+	close $fh;
+
+	# Instance form
+	my $cleaned = $nmisng->clear_stale_node_locks();
+	is($cleaned, 2, "instance form: removed exactly 2 stale locks");
+	ok(!-f "$vardir/sweep_dead_a.lock", "sweep_dead_a.lock removed");
+	ok(!-f "$vardir/sweep_dead_b.lock", "sweep_dead_b.lock removed");
+	ok(-f  "$vardir/sweep_live.lock",  "sweep_live.lock preserved");
+	ok(-f  "$vardir/not_a_lock.txt",   "non-.lock file preserved");
+
+	# Idempotent: a second sweep finds nothing more to do.
+	is($nmisng->clear_stale_node_locks(), 0, "second sweep is a no-op");
+
+	# Class-method form (used by nmisd act=stop/abort before NMISNG instance exists).
+	plant_lock("sweep_class_form_dead", $DEAD_PID, "update");
+	my $cleaned2 = NMISNG->clear_stale_node_locks(config => $C, log => $logger);
+	is($cleaned2, 1, "class-method form: removed 1 stale lock");
+	ok(!-f "$vardir/sweep_class_form_dead.lock", "class-method removed dead lock");
+
+	# Cleanup the live one we left behind.
+	unlink("$vardir/sweep_live.lock");
+}
+
+# ============================================================
+# Cleanup
+# ============================================================
+diag("=== Cleanup ===");
+cleanup();
+ok(1, "Cleanup complete");
+
+done_testing();

--- a/test/t_node_lock_stale.pl
+++ b/test/t_node_lock_stale.pl
@@ -1,14 +1,19 @@
 #!/usr/bin/perl
 #
-# t_node_lock_stale.pl — tests the self-healing stale-lock fix.
+# t_node_lock_stale.pl — tests per-node lock cleanup.
 #
-# Part 1: Node::lock() detects a dead holder PID and recovers automatically.
-# Part 2: NMISNG::clear_stale_node_locks() sweeps stale .lock files.
+# Part 2: NMISNG::clear_stale_node_locks() sweeps stale .lock files (removes
+#         those whose recorded holder PID is dead, leaves live ones).
+# Part 3: the production scenario — a worker killed mid-collect while a child
+#         holds the inherited lock fd, and how the sweep recovers it. lock()
+#         itself does NOT self-heal; orphaned workers are cleared at the process
+#         layer (nmisd kills leftover workers at startup, systemd KillMode), and
+#         the sweep tidies the lock files they leave behind.
 #
 
 use strict;
 use warnings;
-our $VERSION = "1.0.0";
+our $VERSION = "1.1.0";
 
 use FindBin;
 use lib "$FindBin::Bin/../lib";
@@ -74,18 +79,6 @@ sub plant_lock
 	return $path;
 }
 
-sub read_lock
-{
-	my ($name) = @_;
-	my $path = "$vardir/$name.lock";
-	return undef unless -f $path;
-	open my $fh, '<', $path or return undef;
-	my $line = <$fh>;
-	close $fh;
-	chomp $line if defined $line;
-	return $line;
-}
-
 # Read just the holder PID out of an arbitrary file written by a forked helper.
 sub _slurp_pid
 {
@@ -102,7 +95,7 @@ sub _slurp_pid
 my @orphan_children;
 END { kill 9, $_ for grep { $_ } @orphan_children; }
 
-# Build the real production stuck-lock: a worker acquires the node lock, forks a
+# Build the production stuck-lock: a worker acquires the node lock, forks a
 # child that inherits the lock fd (an external poller / wmic / plugin), then the
 # worker dies WITHOUT unlocking (nmisd killed -9). The child stays alive holding
 # the fd, so flock remains held while the recorded holder PID is dead — the only
@@ -155,73 +148,6 @@ sub lock_blocked
 my $DEAD_PID = 999999;
 
 # ============================================================
-# Part 1a: dead PID -> stale, lock acquired
-# ============================================================
-diag("=== Part 1a: dead holder PID -> self-heal ===");
-{
-	my $node = make_node("test_lock_dead");
-	plant_lock("test_lock_dead", $DEAD_PID, "update");
-
-	my $r = $node->lock(type => "update");
-	ok(!$r->{error},    "no error on stale-lock acquisition") or diag("err: $r->{error}");
-	ok(!$r->{conflict}, "no conflict reported (was treated as stale)");
-	ok($r->{handle},    "got a live file handle");
-
-	# After acquisition, the file should record our PID.
-	my $line = read_lock("test_lock_dead");
-	like($line, qr/^$$ update/, "lock file now records our own PID + op");
-
-	$node->unlock(lock => $r);
-	ok(!-f "$vardir/test_lock_dead.lock", "lock file removed by unlock");
-}
-
-# ============================================================
-# Part 1b: _is_pid_stale helper directly
-# (Testing live conflict end-to-end through lock() requires a second
-# process holding flock; the helper is the core liveness logic and is
-# what lock() actually consults. Direct testing covers all the edge
-# cases without needing fork.)
-# ============================================================
-diag("=== Part 1b: Node::_is_pid_stale liveness check ===");
-{
-	# Live PID — this very test process — must NOT be flagged stale.
-	ok(!NMISNG::Node::_is_pid_stale($$),  "self PID (live) -> not stale");
-
-	# Dead PID — almost certainly nothing at PID 999999.
-	ok(NMISNG::Node::_is_pid_stale($DEAD_PID), "dead PID -> stale");
-
-	# Malformed / sentinel values must all be stale.
-	ok(NMISNG::Node::_is_pid_stale(undef),     "undef -> stale");
-	ok(NMISNG::Node::_is_pid_stale(""),        "empty string -> stale");
-	ok(NMISNG::Node::_is_pid_stale(0),         "zero -> stale");
-	ok(NMISNG::Node::_is_pid_stale(-1),        "negative -> stale");
-	ok(NMISNG::Node::_is_pid_stale("garbage"), "non-numeric -> stale");
-
-	# Init PID 1 is essentially always alive on a Linux host.
-	# (If somehow not, that's a system-level oddity, not a fix issue.)
-	ok(!NMISNG::Node::_is_pid_stale(1), "PID 1 (init) -> not stale");
-}
-
-# ============================================================
-# Part 1c: non-numeric / -1 / 0 holder -> stale
-# ============================================================
-diag("=== Part 1c: malformed holder -> treated as stale ===");
-{
-	for my $bad ("-1", "0", "garbage") {
-		my $name = "test_lock_bad_$bad";
-		$name =~ s/[^a-zA-Z0-9_]/_/g;     # filename-safe
-		my $node = make_node($name);
-		plant_lock($name, $bad, "update");
-
-		my $r = $node->lock(type => "update");
-		ok(!$r->{conflict}, "[$bad holder] no conflict, treated as stale")
-			or diag("got conflict=$r->{conflict}");
-		ok($r->{handle}, "[$bad holder] acquired live handle");
-		$node->unlock(lock => $r) if $r->{handle};
-	}
-}
-
-# ============================================================
 # Part 2: clear_stale_node_locks() sweep
 # ============================================================
 diag("=== Part 2: NMISNG->clear_stale_node_locks() sweep ===");
@@ -266,7 +192,7 @@ diag("=== Part 3: orphaned-fd stuck lock (nmisd killed mid-collect) ===");
 	# 3a: a child holds the inherited fd; recorded worker PID is dead.
 	my ($node, $wpid, $cpid) = make_orphan_stuck_lock("orphan_stuck");
 	ok(lock_blocked("orphan_stuck"), "3a: orphaned-fd lock blocks acquisition (collect would be skipped)");
-	ok(NMISNG::Node::_is_pid_stale($wpid),
+	ok(!kill(0, $wpid),
 		"3a: recorded holder PID ($wpid) is dead while child ($cpid) holds the fd");
 
 	# 3b: the sweep clears it by dead recorded PID, even though flock is still held.
@@ -280,12 +206,13 @@ diag("=== Part 3: orphaned-fd stuck lock (nmisd killed mid-collect) ===");
 	kill 9, $cpid if $cpid;
 }
 {
-	# 3c: Node::lock()'s in-acquire self-heal clears the same state with no sweep.
-	my ($node, $wpid, $cpid) = make_orphan_stuck_lock("orphan_heal");
-	ok(lock_blocked("orphan_heal"), "3c: stuck lock present before acquire");
+	# 3c: lock() does NOT steal a live-held lock — it reports the conflict.
+	# With the self-heal removed, a held flock always yields a conflict rather
+	# than an unlink+retry, so the live holder is left untouched.
+	my ($node, $wpid, $cpid) = make_orphan_stuck_lock("orphan_conflict");
 	my $r = $node->lock(type => "update");
-	ok($r->{handle} && !$r->{conflict}, "3c: lock() self-healed and acquired");
-	$node->unlock(lock => $r) if $r->{handle};
+	ok(!$r->{handle},  "3c: lock() did not acquire a live-held lock");
+	ok($r->{conflict}, "3c: lock() reported the conflict instead of stealing it");
 	kill 9, $cpid if $cpid;
 }
 {

--- a/test/t_node_lock_stale.pl
+++ b/test/t_node_lock_stale.pl
@@ -142,10 +142,18 @@ sub lock_blocked
 	return $got ? 0 : 1;
 }
 
-# Pick a PID that is almost certainly dead. We use 999999 — even if it
-# happens to exist, it's outside any normal range and a probe failure
-# would be noise, not a real test failure.
-my $DEAD_PID = 999999;
+# A guaranteed-dead, already-reaped PID: fork a child that exits immediately
+# and waitpid it, then reuse its PID. Deterministic, unlike a hard-coded number
+# that could in theory belong to a live process.
+sub dead_pid
+{
+	my $pid = fork();
+	die "fork failed: $!" if !defined $pid;
+	POSIX::_exit(0) if $pid == 0;
+	waitpid($pid, 0);
+	return $pid;
+}
+my $DEAD_PID = dead_pid();
 
 # ============================================================
 # Part 2: clear_stale_node_locks() sweep
@@ -153,8 +161,8 @@ my $DEAD_PID = 999999;
 diag("=== Part 2: NMISNG->clear_stale_node_locks() sweep ===");
 {
 	# Plant a mix: two dead, one live, plus a non-.lock file that should be ignored.
-	plant_lock("sweep_dead_a", $DEAD_PID,     "update");
-	plant_lock("sweep_dead_b", $DEAD_PID + 1, "collect");
+	plant_lock("sweep_dead_a", $DEAD_PID,   "update");
+	plant_lock("sweep_dead_b", dead_pid(),  "collect");
 	plant_lock("sweep_live",   $$,            "update");
 	open my $fh, '>', "$vardir/not_a_lock.txt" or die;
 	print $fh "irrelevant";

--- a/test/t_node_lock_stale.pl
+++ b/test/t_node_lock_stale.pl
@@ -15,6 +15,8 @@ use lib "$FindBin::Bin/../lib";
 
 use Test::More;
 use File::Temp qw(tempdir);
+use Fcntl qw(:flock);
+use POSIX ();
 
 use NMISNG;
 use NMISNG::Node;
@@ -82,6 +84,69 @@ sub read_lock
 	close $fh;
 	chomp $line if defined $line;
 	return $line;
+}
+
+# Read just the holder PID out of an arbitrary file written by a forked helper.
+sub _slurp_pid
+{
+	my ($f) = @_;
+	open my $h, '<', $f or return undef;
+	my $x = <$h>;
+	close $h;
+	chomp $x if defined $x;
+	return $x;
+}
+
+# Child PIDs that hold an inherited lock fd; killed in END as a backstop so a
+# failed assertion can't leave a 30s sleeper holding a lock.
+my @orphan_children;
+END { kill 9, $_ for grep { $_ } @orphan_children; }
+
+# Build the real production stuck-lock: a worker acquires the node lock, forks a
+# child that inherits the lock fd (an external poller / wmic / plugin), then the
+# worker dies WITHOUT unlocking (nmisd killed -9). The child stays alive holding
+# the fd, so flock remains held while the recorded holder PID is dead — the only
+# state in which a leftover .lock actually blocks the next collect.
+# Returns ($node, $worker_pid_now_dead, $child_pid_still_alive).
+sub make_orphan_stuck_lock
+{
+	my ($name) = @_;
+	my $node = make_node($name);
+	my $w = fork();
+	die "fork failed: $!" if !defined $w;
+	if ($w == 0)
+	{
+		my $r = $node->lock(type => "update");
+		POSIX::_exit(1) if !$r->{handle};
+		my $c = fork();
+		if (defined $c && $c == 0)
+		{
+			open my $f, '>', "$vardir/${name}_c"; print $f $$; close $f;
+			sleep 30;                 # keep the inherited fd open
+			POSIX::_exit(0);
+		}
+		open my $f, '>', "$vardir/${name}_w"; print $f $$; close $f;
+		POSIX::_exit(0);              # worker dies without unlock
+	}
+	waitpid($w, 0);
+	my $t = 0;
+	until (-e "$vardir/${name}_c") { select(undef,undef,undef,0.02); die "timeout setting up $name\n" if (($t += 0.02) > 15); }
+	select(undef, undef, undef, 0.2);
+	my $cpid = _slurp_pid("$vardir/${name}_c");
+	push @orphan_children, $cpid if $cpid;
+	return ($node, _slurp_pid("$vardir/${name}_w"), $cpid);
+}
+
+# Is the node's lock file currently blocking acquisition (someone holds flock)?
+sub lock_blocked
+{
+	my ($name) = @_;
+	my $fn = "$vardir/$name.lock";
+	return 0 if !-f $fn;
+	open my $fh, '+<', $fn or return 0;
+	my $got = flock($fh, LOCK_EX | LOCK_NB);
+	close $fh;                       # releases only our probe handle
+	return $got ? 0 : 1;
 }
 
 # Pick a PID that is almost certainly dead. We use 999999 — even if it
@@ -188,6 +253,61 @@ diag("=== Part 2: NMISNG->clear_stale_node_locks() sweep ===");
 
 	# Cleanup the live one we left behind.
 	unlink("$vardir/sweep_live.lock");
+}
+
+# ============================================================
+# Part 3: orphaned-fd stuck lock — the real production scenario
+# (nmisd/worker killed mid-collect while a child still holds the lock fd).
+# This is the only case where a leftover .lock actually blocks polling;
+# a plain death with no surviving fd releases flock and never sticks.
+# ============================================================
+diag("=== Part 3: orphaned-fd stuck lock (nmisd killed mid-collect) ===");
+{
+	# 3a: a child holds the inherited fd; recorded worker PID is dead.
+	my ($node, $wpid, $cpid) = make_orphan_stuck_lock("orphan_stuck");
+	ok(lock_blocked("orphan_stuck"), "3a: orphaned-fd lock blocks acquisition (collect would be skipped)");
+	ok(NMISNG::Node::_is_pid_stale($wpid),
+		"3a: recorded holder PID ($wpid) is dead while child ($cpid) holds the fd");
+
+	# 3b: the sweep clears it by dead recorded PID, even though flock is still held.
+	#     (A flock-before-unlink sweep could NOT, because $cpid holds the lock.)
+	my $cleaned = $nmisng->clear_stale_node_locks();
+	ok($cleaned >= 1, "3b: sweep removed the stale lock despite the held flock");
+	ok(!-f "$vardir/orphan_stuck.lock", "3b: lock file removed");
+	my $r = $node->lock(type => "update");
+	ok($r->{handle} && !$r->{conflict}, "3b: collect can acquire again after the sweep");
+	$node->unlock(lock => $r) if $r->{handle};
+	kill 9, $cpid if $cpid;
+}
+{
+	# 3c: Node::lock()'s in-acquire self-heal clears the same state with no sweep.
+	my ($node, $wpid, $cpid) = make_orphan_stuck_lock("orphan_heal");
+	ok(lock_blocked("orphan_heal"), "3c: stuck lock present before acquire");
+	my $r = $node->lock(type => "update");
+	ok($r->{handle} && !$r->{conflict}, "3c: lock() self-healed and acquired");
+	$node->unlock(lock => $r) if $r->{handle};
+	kill 9, $cpid if $cpid;
+}
+{
+	# 3d: boundary — if NO fd-holder survives the kill, the kernel releases flock
+	# on death, so the leftover file does not block. This is the all-processes-
+	# killed case: the startup sweep tidies the file, but it was never blocking.
+	my $node = make_node("orphan_clean");
+	my $w = fork();
+	die "fork failed: $!" if !defined $w;
+	if ($w == 0)
+	{
+		my $r = $node->lock(type => "update");
+		POSIX::_exit(1) if !$r->{handle};
+		open my $f, '>', "$vardir/orphan_clean_ready"; print $f $$; close $f;
+		sleep 30; POSIX::_exit(0);
+	}
+	my $t = 0;
+	until (-e "$vardir/orphan_clean_ready") { select(undef,undef,undef,0.02); last if (($t += 0.02) > 15); }
+	kill 9, $w; waitpid($w, 0);
+	select(undef, undef, undef, 0.2);
+	ok(!lock_blocked("orphan_clean"),
+		"3d: no surviving fd-holder -> leftover lock does NOT block (flock released on death)");
 }
 
 # ============================================================


### PR DESCRIPTION
After nmisd was killed and restarted, some nodes stopped being polled until their per-node .lock files were cleared by hand. The cause was orphaned workers, not the lock files themselves. A worker killed mid-collect (hard master kill, OOM, crash) survived holding its node lock with a live PID, and the new nmisd adopted it from the saved state instead of clearing it, so the node stayed blocked behind a live lock. KillMode=process in the systemd unit let those orphans survive a stop or restart.

  Changes
  - bin/nmisd: at startup, kill any still-alive workers left by a previous run, then start with a clean pool. nmisd never adopts old workers again.
  - nmis9d.service: KillMode=process to mixed, so systemd reaps the worker cgroup on stop, restart, or crash.
  - Node.pm: lock() reports the conflict and logs the holder (liveness plus command) for diagnosis. The unused in-lock() self-heal was removed; clear_stale_node_locks stays as dead-PID tidy-up.
  - Tests for the sweep and the orphaned-fd scenario, wired into CI.

  Notes

  - Validated end to end in a dev container, plus 17 passing assertions in t_node_lock_stale.pl.
  - The installer prompts to update the systemd unit; it takes effect on the next daemon restart.