### PR TITLE
Plugin nodeobj param

### DIFF
--- a/conf-default/plugins/APC_UPS.pm
+++ b/conf-default/plugins/APC_UPS.pm
@@ -59,12 +59,12 @@ use NMISNG::Snmp;
 sub collect_plugin
 {
 	my (%args) = @_;
-	my ($node, $S, $C, $NG) = @args{qw(node sys config nmisng)};
+	my ($node, $S, $C, $NG, $node_obj) = @args{qw(node sys config nmisng node_obj)};
 	my $catchall = $S->inventory( concept => 'catchall' )->data_live();
-	
+
 	return (0,undef) if ($S->{mdl}->{system}->{nodeModel} ne "APC-ups" or !NMISNG::Util::getbool($catchall->{collect}));
 	my $changesweremade = 0;
-	my $nodeobj        = $NG->node(name => $node);
+	my $nodeobj        = $node_obj;
 	my $NC             = $nodeobj->configuration;
 	my $upsAdvBatteryReplaceIndicator  = ".1.3.6.1.4.1.318.1.1.1.2.2.4.0";
 	my $upsBasicBatteryLastReplaceDate = ".1.3.6.1.4.1.318.1.1.1.2.1.3.0";

--- a/conf-default/plugins/APC_UPS.pm
+++ b/conf-default/plugins/APC_UPS.pm
@@ -64,7 +64,7 @@ sub collect_plugin
 
 	return (0,undef) if ($S->{mdl}->{system}->{nodeModel} ne "APC-ups" or !NMISNG::Util::getbool($catchall->{collect}));
 	my $changesweremade = 0;
-	my $nodeobj        = $node_obj;
+	my $nodeobj        = $node_obj // $S->nmisng_node;
 	my $NC             = $nodeobj->configuration;
 	my $upsAdvBatteryReplaceIndicator  = ".1.3.6.1.4.1.318.1.1.1.2.2.4.0";
 	my $upsBasicBatteryLastReplaceDate = ".1.3.6.1.4.1.318.1.1.1.2.1.3.0";

--- a/conf-default/plugins/AdtranInterface.pm
+++ b/conf-default/plugins/AdtranInterface.pm
@@ -507,7 +507,7 @@ sub update_plugin
 		}
 
 		# The above has added data to the inventory, that we now save.
-		my ( $op, $subError ) = $inventory->save( node => $node_obj, update => 1 );
+		my ( $op, $subError ) = $inventory->save( node => $nodeobj, update => 1 );
 		$NG->log->debug2(sub { "saved ".join(',', @$path)." op: $op"});
 		if ($subError)
 		{

--- a/conf-default/plugins/AdtranInterface.pm
+++ b/conf-default/plugins/AdtranInterface.pm
@@ -47,7 +47,7 @@ my $interestingInterfaces = qr/ten-gigabit-ethernet|^muxponder-highspeed/;
 sub update_plugin
 {
 	my (%args) = @_;
-	my ($node,$S,$C,$NG) = @args{qw(node sys config nmisng)};
+	my ($node,$S,$C,$NG,$node_obj) = @args{qw(node sys config nmisng node_obj)};
 
 	my $intfData = undef;
 	my $interface_max_number = $C->{interface_max_number} || 5000;
@@ -507,7 +507,7 @@ sub update_plugin
 		}
 
 		# The above has added data to the inventory, that we now save.
-		my ( $op, $subError ) = $inventory->save( node => $node, update => 1 );
+		my ( $op, $subError ) = $inventory->save( node => $node_obj, update => 1 );
 		$NG->log->debug2(sub { "saved ".join(',', @$path)." op: $op"});
 		if ($subError)
 		{

--- a/conf-default/plugins/AdtranInterface.pm
+++ b/conf-default/plugins/AdtranInterface.pm
@@ -55,7 +55,7 @@ sub update_plugin
 
 
 	my $NI = $S->nmisng_node;
-	my $nodeobj = $NG->node(name => $node);
+	my $nodeobj = $node_obj;
 	my $NC = $nodeobj->configuration;
 	my $catchall = $S->inventory( concept => 'catchall' )->data_live();
 

--- a/conf-default/plugins/AdtranInterface.pm
+++ b/conf-default/plugins/AdtranInterface.pm
@@ -55,7 +55,7 @@ sub update_plugin
 
 
 	my $NI = $S->nmisng_node;
-	my $nodeobj = $node_obj;
+	my $nodeobj = $node_obj // $S->nmisng_node;
 	my $NC = $nodeobj->configuration;
 	my $catchall = $S->inventory( concept => 'catchall' )->data_live();
 

--- a/conf-default/plugins/AlcatelASAM.pm
+++ b/conf-default/plugins/AlcatelASAM.pm
@@ -85,7 +85,7 @@ sub update_plugin
 
 	$NG->log->debug("Max Interfaces are: '$interface_max_number'");
 
-	my $nodeobj       = $node_obj;
+	my $nodeobj       = $node_obj // $S->nmisng_node;
 	my $NC            = $nodeobj->configuration;
 	my $catchall_data = $S->inventory( concept => 'catchall' )->data_live();
 	my $IF            = $nodeobj->ifinfo;

--- a/conf-default/plugins/AlcatelASAM.pm
+++ b/conf-default/plugins/AlcatelASAM.pm
@@ -85,7 +85,7 @@ sub update_plugin
 
 	$NG->log->debug("Max Interfaces are: '$interface_max_number'");
 
-	my $nodeobj       = $NG->node(name => $node);
+	my $nodeobj       = $node_obj;
 	my $NC            = $nodeobj->configuration;
 	my $catchall_data = $S->inventory( concept => 'catchall' )->data_live();
 	my $IF            = $nodeobj->ifinfo;

--- a/conf-default/plugins/AlcatelASAM.pm
+++ b/conf-default/plugins/AlcatelASAM.pm
@@ -347,7 +347,7 @@ sub update_plugin
 				}
 				# The above has added data to the inventory, that we now save.
 				$inventory->data( $customerData );
-				my ( $op, $subError ) = $inventory->save( node => $node_obj );
+				my ( $op, $subError ) = $inventory->save( node => $nodeobj );
 				$NG->log->debug2(sub { "Saved ".join(',', @$path)."; op: $op"});
 				if ($subError)
 				{
@@ -506,7 +506,7 @@ sub update_plugin
 			}
 			# The above has added data to the inventory, that we now save.
 			$inventory->data( $atmVclData );
-			my ( $op, $subError ) = $inventory->save( node => $node_obj, update => 1 );
+			my ( $op, $subError ) = $inventory->save( node => $nodeobj, update => 1 );
 			$NG->log->debug2(sub { "Saved ".join(',', @$path)."; op: $op"});
 			if ($subError)
 			{
@@ -723,7 +723,7 @@ sub update_plugin
 				}
 				# The above has added data to the inventory, that we now save.
 				$inventory->data( $ifDslamData );
-				my ( $op, $subError ) = $inventory->save( node => $node_obj );
+				my ( $op, $subError ) = $inventory->save( node => $nodeobj );
 				$NG->log->debug2(sub { "Saved ".join(',', @$path)."; op: $op"});
 				if ($subError)
 				{

--- a/conf-default/plugins/AlcatelASAM.pm
+++ b/conf-default/plugins/AlcatelASAM.pm
@@ -53,6 +53,7 @@ my $node;
 my $S;
 my $C;
 my $NG;
+my $node_obj;
 
 # *****************************************************************************
 # Set this to disable collection on Interfaces set to 'available'.
@@ -64,7 +65,7 @@ my $ignoreAvaibleInterfaces = 1;
 sub update_plugin
 {
 	my (%args) = @_;
-	($node,$S,$C,$NG) = @args{qw(node sys config nmisng)};
+	($node,$S,$C,$NG,$node_obj) = @args{qw(node sys config nmisng node_obj)};
 	my $NI            = $S->nmisng_node;
 
 	my $intfData             = undef;
@@ -346,7 +347,7 @@ sub update_plugin
 				}
 				# The above has added data to the inventory, that we now save.
 				$inventory->data( $customerData );
-				my ( $op, $subError ) = $inventory->save( node => $node );
+				my ( $op, $subError ) = $inventory->save( node => $node_obj );
 				$NG->log->debug2(sub { "Saved ".join(',', @$path)."; op: $op"});
 				if ($subError)
 				{
@@ -505,7 +506,7 @@ sub update_plugin
 			}
 			# The above has added data to the inventory, that we now save.
 			$inventory->data( $atmVclData );
-			my ( $op, $subError ) = $inventory->save( node => $node, update => 1 );
+			my ( $op, $subError ) = $inventory->save( node => $node_obj, update => 1 );
 			$NG->log->debug2(sub { "Saved ".join(',', @$path)."; op: $op"});
 			if ($subError)
 			{
@@ -722,7 +723,7 @@ sub update_plugin
 				}
 				# The above has added data to the inventory, that we now save.
 				$inventory->data( $ifDslamData );
-				my ( $op, $subError ) = $inventory->save( node => $node );
+				my ( $op, $subError ) = $inventory->save( node => $node_obj );
 				$NG->log->debug2(sub { "Saved ".join(',', @$path)."; op: $op"});
 				if ($subError)
 				{

--- a/conf-default/plugins/AsamInterface.pm
+++ b/conf-default/plugins/AsamInterface.pm
@@ -79,7 +79,7 @@ sub update_plugin
 
 	$NG->log->debug("Max Interfaces are: '$interface_max_number'");
 
-	my $nodeobj    = $NG->node(name => $node);
+	my $nodeobj    = $node_obj;
 	my $NC         = $nodeobj->configuration;
 	my $catchall   = $S->inventory( concept => 'catchall' )->data_live();
 	my %nodeconfig = %{$S->nmisng_node->configuration};

--- a/conf-default/plugins/AsamInterface.pm
+++ b/conf-default/plugins/AsamInterface.pm
@@ -79,7 +79,7 @@ sub update_plugin
 
 	$NG->log->debug("Max Interfaces are: '$interface_max_number'");
 
-	my $nodeobj    = $node_obj;
+	my $nodeobj    = $node_obj // $S->nmisng_node;
 	my $NC         = $nodeobj->configuration;
 	my $catchall   = $S->inventory( concept => 'catchall' )->data_live();
 	my %nodeconfig = %{$S->nmisng_node->configuration};

--- a/conf-default/plugins/AsamInterface.pm
+++ b/conf-default/plugins/AsamInterface.pm
@@ -610,7 +610,7 @@ sub update_plugin
 		}
 
 		# The above has added data to the inventory, that we now save.
-		my ( $op, $subError ) = $inventory->save( node => $node_obj, update => 1 );
+		my ( $op, $subError ) = $inventory->save( node => $nodeobj, update => 1 );
 		$NG->log->debug2(sub { "saved ".join(',', @$path)." op: $op"});
 		if ($subError)
 		{

--- a/conf-default/plugins/AsamInterface.pm
+++ b/conf-default/plugins/AsamInterface.pm
@@ -46,6 +46,7 @@ my $node;
 my $S;
 my $C;
 my $NG;
+my $node_obj;
 my $NI;
 my $interestingInterfaces = qr/atm Interface/;
 
@@ -59,7 +60,7 @@ my $ignoreAvaibleInterfaces = 1;
 sub update_plugin
 {
 	my (%args) = @_;
-	($node,$S,$C,$NG) = @args{qw(node sys config nmisng)};
+	($node,$S,$C,$NG,$node_obj) = @args{qw(node sys config nmisng node_obj)};
 	$NI               = $S->nmisng_node;
 
 	my $intfData             = undef;
@@ -609,7 +610,7 @@ sub update_plugin
 		}
 
 		# The above has added data to the inventory, that we now save.
-		my ( $op, $subError ) = $inventory->save( node => $node, update => 1 );
+		my ( $op, $subError ) = $inventory->save( node => $node_obj, update => 1 );
 		$NG->log->debug2(sub { "saved ".join(',', @$path)." op: $op"});
 		if ($subError)
 		{

--- a/conf-default/plugins/Aviat.pm
+++ b/conf-default/plugins/Aviat.pm
@@ -50,7 +50,7 @@ sub update_plugin
 	my $concept = 'ifTable';
 	my $inventory_data_key = 'index';
 
-    my $nodeobj = $NG->node(name => $node);
+    my $nodeobj = $node_obj;
     my $inv = $S->inventory( concept => 'catchall' );
 	my $catchall_data = $inv->data;
 

--- a/conf-default/plugins/Aviat.pm
+++ b/conf-default/plugins/Aviat.pm
@@ -43,7 +43,7 @@ use Data::Dumper;
 sub update_plugin
 {
 	my (%args) = @_;
-	my ($node, $S, $C, $NG) = @args{qw(node sys config nmisng)};
+	my ($node, $S, $C, $NG, $node_obj) = @args{qw(node sys config nmisng node_obj)};
 
 	my $sub = 'update';
 	my $plugin = 'Aviat.pm';
@@ -129,7 +129,7 @@ sub update_plugin
                     $inventory->enabled(1);
                     # disable for now
                     $inventory->data_info( subconcept => 'interface', enabled => 0 );
-                    my ($op,$error) = $inventory->save( node => $node, update => 1 );
+                    my ($op,$error) = $inventory->save( node => $node_obj, update => 1 );
                     $NG->log->debug2(sub { "saved ".join(',', @$path)." op: $op"});
                     $NG->log->info( "saved ".join(',', @$path)." op: $op");
                 } else {
@@ -141,7 +141,7 @@ sub update_plugin
         $catchall_data->{ifNumber} = $ids;
         $catchall_data->{active} = $active;
         $inv->data($catchall_data);
-        my ($op,$error) = $inv->save( node => $node );
+        my ($op,$error) = $inv->save( node => $node_obj );
         $NG->log->info( "saved catchall op: $op");
         
 	}
@@ -156,8 +156,8 @@ sub update_plugin
 sub collect_plugin
 {
 	my (%args) = @_;
-	my ($node, $S, $C, $NG) = @args{qw(node sys config nmisng)};
-	
+	my ($node, $S, $C, $NG, $node_obj) = @args{qw(node sys config nmisng node_obj)};
+
 	my @knownindices;
 	my $changesweremade = 0;
 	return (0,undef) if ($S->{mdl}->{system}->{nodeModel} ne "NL-Aviat");
@@ -179,7 +179,7 @@ sub collect_plugin
 			my $data = $ifTable->data();
 			$ifTable->historic(0);
 			$ifTable->data($data);
-			my ($op, $serror) = $ifTable->save( node => $node );
+			my ($op, $serror) = $ifTable->save( node => $node_obj );
 			$NG->log->debug2(sub {"Inventory update: $op "});
 			if ($serror)
 			{

--- a/conf-default/plugins/Aviat.pm
+++ b/conf-default/plugins/Aviat.pm
@@ -129,7 +129,7 @@ sub update_plugin
                     $inventory->enabled(1);
                     # disable for now
                     $inventory->data_info( subconcept => 'interface', enabled => 0 );
-                    my ($op,$error) = $inventory->save( node => $node_obj, update => 1 );
+                    my ($op,$error) = $inventory->save( node => $nodeobj, update => 1 );
                     $NG->log->debug2(sub { "saved ".join(',', @$path)." op: $op"});
                     $NG->log->info( "saved ".join(',', @$path)." op: $op");
                 } else {
@@ -141,7 +141,7 @@ sub update_plugin
         $catchall_data->{ifNumber} = $ids;
         $catchall_data->{active} = $active;
         $inv->data($catchall_data);
-        my ($op,$error) = $inv->save( node => $node_obj );
+        my ($op,$error) = $inv->save( node => $nodeobj );
         $NG->log->info( "saved catchall op: $op");
         
 	}
@@ -157,6 +157,7 @@ sub collect_plugin
 {
 	my (%args) = @_;
 	my ($node, $S, $C, $NG, $node_obj) = @args{qw(node sys config nmisng node_obj)};
+	my $nodeobj = $node_obj // $S->nmisng_node;
 
 	my @knownindices;
 	my $changesweremade = 0;
@@ -179,7 +180,7 @@ sub collect_plugin
 			my $data = $ifTable->data();
 			$ifTable->historic(0);
 			$ifTable->data($data);
-			my ($op, $serror) = $ifTable->save( node => $node_obj );
+			my ($op, $serror) = $ifTable->save( node => $nodeobj );
 			$NG->log->debug2(sub {"Inventory update: $op "});
 			if ($serror)
 			{

--- a/conf-default/plugins/Aviat.pm
+++ b/conf-default/plugins/Aviat.pm
@@ -50,7 +50,7 @@ sub update_plugin
 	my $concept = 'ifTable';
 	my $inventory_data_key = 'index';
 
-    my $nodeobj = $node_obj;
+    my $nodeobj = $node_obj // $S->nmisng_node;
     my $inv = $S->inventory( concept => 'catchall' );
 	my $catchall_data = $inv->data;
 

--- a/conf-default/plugins/EricssonPPX.pm
+++ b/conf-default/plugins/EricssonPPX.pm
@@ -51,7 +51,7 @@ my $changesweremade = 0;
 sub collect_plugin
 {
 	my (%args) = @_;
-	my ($node,$S,$C,$NG) = @args{qw(node sys config nmisng)};
+	my ($node,$S,$C,$NG,$node_obj) = @args{qw(node sys config nmisng node_obj)};
 
 	my $intfData = undef;
 	my $intfInfo = undef;
@@ -228,7 +228,7 @@ sub collect_plugin
 			}		
 
 			# The above has added data to the inventory, that we now save.
-			my ( $op, $saveError ) = $inventory->save( node => $node ); # update => 1 not required
+			my ( $op, $saveError ) = $inventory->save( node => $node_obj ); # update => 1 not required
 			$NG->log->debug2(sub { "saved op: $op"});
 			if ($saveError)
 			{

--- a/conf-default/plugins/EricssonPPX.pm
+++ b/conf-default/plugins/EricssonPPX.pm
@@ -228,7 +228,7 @@ sub collect_plugin
 			}		
 
 			# The above has added data to the inventory, that we now save.
-			my ( $op, $saveError ) = $inventory->save( node => $node_obj ); # update => 1 not required
+			my ( $op, $saveError ) = $inventory->save( node => $nodeobj ); # update => 1 not required
 			$NG->log->debug2(sub { "saved op: $op"});
 			if ($saveError)
 			{

--- a/conf-default/plugins/EricssonPPX.pm
+++ b/conf-default/plugins/EricssonPPX.pm
@@ -56,7 +56,7 @@ sub collect_plugin
 	my $intfData = undef;
 	my $intfInfo = undef;
 
-	my $nodeobj    = $node_obj;
+	my $nodeobj    = $node_obj // $S->nmisng_node;
 	my %nodeconfig = %{$S->nmisng_node->configuration};
 	my $NC         = $nodeobj->configuration;
 	my $catchall   = $S->inventory( concept => 'catchall' )->data_live();

--- a/conf-default/plugins/EricssonPPX.pm
+++ b/conf-default/plugins/EricssonPPX.pm
@@ -56,7 +56,7 @@ sub collect_plugin
 	my $intfData = undef;
 	my $intfInfo = undef;
 
-	my $nodeobj    = $NG->node(name => $node);
+	my $nodeobj    = $node_obj;
 	my %nodeconfig = %{$S->nmisng_node->configuration};
 	my $NC         = $nodeobj->configuration;
 	my $catchall   = $S->inventory( concept => 'catchall' )->data_live();

--- a/conf-default/plugins/F5BigIP.pm
+++ b/conf-default/plugins/F5BigIP.pm
@@ -60,7 +60,7 @@ sub collect_plugin
 	
 	my $changesweremade = 0;
 
-	my $nodeobj = $node_obj;
+	my $nodeobj = $node_obj // $S->nmisng_node;
 	my $catchall = $S->inventory( concept => 'catchall' )->data_live();
 
 	return (1,undef) if ( $catchall->{nodeModel} ne "F5-BigIP" or !NMISNG::Util::getbool($catchall->{collect}));

--- a/conf-default/plugins/F5BigIP.pm
+++ b/conf-default/plugins/F5BigIP.pm
@@ -45,7 +45,7 @@ use NMISNG::rrdfunc;
 sub collect_plugin
 {
 	my (%args) = @_;
-	my ($node, $S, $C, $NG) = @args{qw(node sys config nmisng)};
+	my ($node, $S, $C, $NG, $node_obj) = @args{qw(node sys config nmisng node_obj)};
 
 
 	# is the node down or is SNMP down?
@@ -60,9 +60,9 @@ sub collect_plugin
 	
 	my $changesweremade = 0;
 
-	my $nodeobj = $NG->node(name => $node);
+	my $nodeobj = $node_obj;
 	my $catchall = $S->inventory( concept => 'catchall' )->data_live();
-	
+
 	return (1,undef) if ( $catchall->{nodeModel} ne "F5-BigIP" or !NMISNG::Util::getbool($catchall->{collect}));
 	$NG->log->debug("Running F5BigIP plugin for node::$node");
 

--- a/conf-default/plugins/F5BigIPAPI.pm
+++ b/conf-default/plugins/F5BigIPAPI.pm
@@ -82,7 +82,7 @@ sub collect_plugin
 
 	my $changesweremade = 0;
 
-	my $nodeobj = $node_obj;
+	my $nodeobj = $node_obj // $S->nmisng_node;
 
 	$NG->log->info("Working on '$node' getting API data now");
 	my ($errmsg, $f5Data, $f5Info) = getF5Data(deviceName => $node, NG => $NG, C => $C, nodeObj => $nodeobj);
@@ -305,7 +305,7 @@ sub update_plugin
 	}
 
 	my $changesweremade = 0;
-	my $nodeobj         = $node_obj;
+	my $nodeobj         = $node_obj // $S->nmisng_node;
 
 	$NG->log->info("Working on '$node'");
 	my ($errmsg, $f5Data, $f5Info) = getF5Data(deviceName => $node, NG => $NG, C => $C, nodeObj => $nodeobj);

--- a/conf-default/plugins/F5BigIPAPI.pm
+++ b/conf-default/plugins/F5BigIPAPI.pm
@@ -61,7 +61,7 @@ our $poolConcept    = "F5_Pools";
 sub collect_plugin
 {
 	my (%args) = @_;
-	my ($node, $S, $C, $NG) = @args{qw(node sys config nmisng)};
+	my ($node, $S, $C, $NG, $node_obj) = @args{qw(node sys config nmisng node_obj)};
 
 	# is the node down or is SNMP down?
 	my ($inventory,$error) = $S->inventory(concept => 'catchall');
@@ -180,7 +180,7 @@ sub collect_plugin
 
             # Save the data so it appears in the GUI
             $serv_inventory->data($data); # set changed info
-			my ( $op, $subError ) = $serv_inventory->save( node => $node );
+			my ( $op, $subError ) = $serv_inventory->save( node => $node_obj );
 			if ($subError)
 			{
 				$NG->log->error("Failed to save inventory for Virtual Server '$name'; Error: $subError");
@@ -258,7 +258,7 @@ sub collect_plugin
 						$data->{pktsOut}                    = $f5SubData->{pktsOut};
 						$pool_inventory->data($data); # set changed info
 						# the above will put data into inventory, so save
-						my ( $op, $subError ) = $pool_inventory->save( node => $node );
+						my ( $op, $subError ) = $pool_inventory->save( node => $node_obj );
 						$NG->log->debug( "saved '$poolName' op: $op");
 						if ($subError)
 						{
@@ -285,7 +285,7 @@ sub collect_plugin
 sub update_plugin
 {
 	my (%args) = @_;
-	my ($node,$S,$C,$NG) = @args{qw(node sys config nmisng)};
+	my ($node,$S,$C,$NG,$node_obj) = @args{qw(node sys config nmisng node_obj)};
 
 	# is the node down or is SNMP down?
 	my ($inventory,$error) = $S->inventory(concept => 'catchall');
@@ -410,7 +410,7 @@ sub update_plugin
 													data => $dbname) if ($dbname);
 
 		# the above will put data into inventory, so save
-		my ( $op, $subError ) = $subInventory->save( node => $node, update => 1 );
+		my ( $op, $subError ) = $subInventory->save( node => $node_obj, update => 1 );
 		if ($subError)
 		{
 			$NG->log->error("Failed to save Concept '$virtSvrConcept' inventory for Virtual Server '$name': $subError");
@@ -497,7 +497,7 @@ sub update_plugin
 																	subconcept => $poolConcept,
 																	data => $dbname) if ($dbname);
 					# the above will put data into inventory, so save
-					my ( $op, $subError ) = $subMemberInventory->save( node => $node, update => 1 );
+					my ( $op, $subError ) = $subMemberInventory->save( node => $node_obj, update => 1 );
 					if ($subError)
 					{
 						$NG->log->error("Failed to save '$poolConcept' inventory for Virtual Server Pool '$poolName'; Member '$memberName'; Error: $subError");

--- a/conf-default/plugins/F5BigIPAPI.pm
+++ b/conf-default/plugins/F5BigIPAPI.pm
@@ -180,7 +180,7 @@ sub collect_plugin
 
             # Save the data so it appears in the GUI
             $serv_inventory->data($data); # set changed info
-			my ( $op, $subError ) = $serv_inventory->save( node => $node_obj );
+			my ( $op, $subError ) = $serv_inventory->save( node => $nodeobj );
 			if ($subError)
 			{
 				$NG->log->error("Failed to save inventory for Virtual Server '$name'; Error: $subError");
@@ -258,7 +258,7 @@ sub collect_plugin
 						$data->{pktsOut}                    = $f5SubData->{pktsOut};
 						$pool_inventory->data($data); # set changed info
 						# the above will put data into inventory, so save
-						my ( $op, $subError ) = $pool_inventory->save( node => $node_obj );
+						my ( $op, $subError ) = $pool_inventory->save( node => $nodeobj );
 						$NG->log->debug( "saved '$poolName' op: $op");
 						if ($subError)
 						{
@@ -410,7 +410,7 @@ sub update_plugin
 													data => $dbname) if ($dbname);
 
 		# the above will put data into inventory, so save
-		my ( $op, $subError ) = $subInventory->save( node => $node_obj, update => 1 );
+		my ( $op, $subError ) = $subInventory->save( node => $nodeobj, update => 1 );
 		if ($subError)
 		{
 			$NG->log->error("Failed to save Concept '$virtSvrConcept' inventory for Virtual Server '$name': $subError");
@@ -497,7 +497,7 @@ sub update_plugin
 																	subconcept => $poolConcept,
 																	data => $dbname) if ($dbname);
 					# the above will put data into inventory, so save
-					my ( $op, $subError ) = $subMemberInventory->save( node => $node_obj, update => 1 );
+					my ( $op, $subError ) = $subMemberInventory->save( node => $nodeobj, update => 1 );
 					if ($subError)
 					{
 						$NG->log->error("Failed to save '$poolConcept' inventory for Virtual Server Pool '$poolName'; Member '$memberName'; Error: $subError");

--- a/conf-default/plugins/F5BigIPAPI.pm
+++ b/conf-default/plugins/F5BigIPAPI.pm
@@ -82,7 +82,7 @@ sub collect_plugin
 
 	my $changesweremade = 0;
 
-	my $nodeobj = $NG->node(name => $node);
+	my $nodeobj = $node_obj;
 
 	$NG->log->info("Working on '$node' getting API data now");
 	my ($errmsg, $f5Data, $f5Info) = getF5Data(deviceName => $node, NG => $NG, C => $C, nodeObj => $nodeobj);
@@ -305,8 +305,8 @@ sub update_plugin
 	}
 
 	my $changesweremade = 0;
-	my $nodeobj         = $NG->node(name => $node);
-	
+	my $nodeobj         = $node_obj;
+
 	$NG->log->info("Working on '$node'");
 	my ($errmsg, $f5Data, $f5Info) = getF5Data(deviceName => $node, NG => $NG, C => $C, nodeObj => $nodeobj);
 	if (defined $errmsg) {

--- a/conf-default/plugins/Host_Resources.pm
+++ b/conf-default/plugins/Host_Resources.pm
@@ -42,7 +42,7 @@ use NMISNG::rrdfunc;
 sub collect_plugin
 {
 	my (%args) = @_;
-	my ($node, $S, $C, $NG) = @args{qw(node sys config nmisng)};
+	my ($node, $S, $C, $NG, $node_obj) = @args{qw(node sys config nmisng node_obj)};
 
 	# is the node down or is SNMP down?
 	my ($inventory,$error) = $S->inventory(concept => 'catchall');
@@ -260,7 +260,7 @@ sub collect_plugin
 				
 				# Save the data				
 	            $host_inventory->data($data); # set changed info
-	            (undef,$error) = $host_inventory->save( node => $node ); # and save to the db
+	            (undef,$error) = $host_inventory->save( node => $node_obj ); # and save to the db
 	            $NG->log->error("Failed to save inventory for ".$data->{hrStorageTypeName}. " : $error")
                 if ($error);
 		}
@@ -310,7 +310,7 @@ sub collect_plugin
 sub update_plugin
 {
 	my (%args) = @_;
-	my ($node, $S, $C, $NG) = @args{qw(node sys config nmisng)};
+	my ($node, $S, $C, $NG, $node_obj) = @args{qw(node sys config nmisng node_obj)};
 
 	# anything to do?
 	my $changesweremade = 0;
@@ -361,7 +361,7 @@ sub update_plugin
 				$changesweremade = 1;
                 # Save the data
                 $host_inventory->data($data); # set changed info
-                (undef,$error) = $host_inventory->save(node => $node); # and save to the db
+                (undef,$error) = $host_inventory->save(node => $node_obj); # and save to the db
                 $NG->log->error("Failed to save inventory for ".$data->{index}. " : $error")
                         if ($error);
 			}
@@ -429,11 +429,11 @@ sub update_plugin
             
             if ($changed) {
                 $host_inventory->data($data); # set changed info
-                (undef,$error) = $host_inventory->save(node => $node); # and save to the db, update not required
+                (undef,$error) = $host_inventory->save(node => $node_obj); # and save to the db, update not required
                 $NG->log->error("Failed to save inventory for ".$data->{index}. " : $error")
                         if ($error);
             }
-            
+
         }
     }
     
@@ -472,10 +472,10 @@ sub update_plugin
 				$changesweremade = 1;
 
                 $host_inventory->data($data); # set changed info
-                (undef,$error) = $host_inventory->save(node => $node); # and save to the db, update not required
+                (undef,$error) = $host_inventory->save(node => $node_obj); # and save to the db, update not required
                 $NG->log->error("Failed to save inventory for ".$data->{index}. " : $error")
                         if ($error);
-  
+
 				# lets push some data into Host_Storage now
                 my ($host_inventory_d,$error) = $S->nmisng_node->inventory(_id => $host_storage_id->{$hrFSStorageIndex});
                 if ($error)
@@ -486,7 +486,7 @@ sub update_plugin
                 my $data_hs = $host_inventory_d->data();
                 $data_hs->{hrPartitionLabel} = $data->{hrPartitionLabel};
                 $host_inventory_d->data($data_hs); # set changed info
-                (undef,$error) = $host_inventory_d->save(node => $node); # and save to the db, update not required
+                (undef,$error) = $host_inventory_d->save(node => $node_obj); # and save to the db, update not required
                 $NG->log->error("Failed to save inventory for ".$data_hs->{$hrFSStorageIndex}. " : $error")
                         if ($error);
 			}

--- a/conf-default/plugins/Host_Resources.pm
+++ b/conf-default/plugins/Host_Resources.pm
@@ -43,6 +43,7 @@ sub collect_plugin
 {
 	my (%args) = @_;
 	my ($node, $S, $C, $NG, $node_obj) = @args{qw(node sys config nmisng node_obj)};
+	my $nodeobj = $node_obj // $S->nmisng_node;
 
 	# is the node down or is SNMP down?
 	my ($inventory,$error) = $S->inventory(concept => 'catchall');
@@ -260,7 +261,7 @@ sub collect_plugin
 				
 				# Save the data				
 	            $host_inventory->data($data); # set changed info
-	            (undef,$error) = $host_inventory->save( node => $node_obj ); # and save to the db
+	            (undef,$error) = $host_inventory->save( node => $nodeobj ); # and save to the db
 	            $NG->log->error("Failed to save inventory for ".$data->{hrStorageTypeName}. " : $error")
                 if ($error);
 		}
@@ -311,6 +312,7 @@ sub update_plugin
 {
 	my (%args) = @_;
 	my ($node, $S, $C, $NG, $node_obj) = @args{qw(node sys config nmisng node_obj)};
+	my $nodeobj = $node_obj // $S->nmisng_node;
 
 	# anything to do?
 	my $changesweremade = 0;
@@ -361,7 +363,7 @@ sub update_plugin
 				$changesweremade = 1;
                 # Save the data
                 $host_inventory->data($data); # set changed info
-                (undef,$error) = $host_inventory->save(node => $node_obj); # and save to the db
+                (undef,$error) = $host_inventory->save(node => $nodeobj); # and save to the db
                 $NG->log->error("Failed to save inventory for ".$data->{index}. " : $error")
                         if ($error);
 			}
@@ -429,7 +431,7 @@ sub update_plugin
             
             if ($changed) {
                 $host_inventory->data($data); # set changed info
-                (undef,$error) = $host_inventory->save(node => $node_obj); # and save to the db, update not required
+                (undef,$error) = $host_inventory->save(node => $nodeobj); # and save to the db, update not required
                 $NG->log->error("Failed to save inventory for ".$data->{index}. " : $error")
                         if ($error);
             }
@@ -472,7 +474,7 @@ sub update_plugin
 				$changesweremade = 1;
 
                 $host_inventory->data($data); # set changed info
-                (undef,$error) = $host_inventory->save(node => $node_obj); # and save to the db, update not required
+                (undef,$error) = $host_inventory->save(node => $nodeobj); # and save to the db, update not required
                 $NG->log->error("Failed to save inventory for ".$data->{index}. " : $error")
                         if ($error);
 
@@ -486,7 +488,7 @@ sub update_plugin
                 my $data_hs = $host_inventory_d->data();
                 $data_hs->{hrPartitionLabel} = $data->{hrPartitionLabel};
                 $host_inventory_d->data($data_hs); # set changed info
-                (undef,$error) = $host_inventory_d->save(node => $node_obj); # and save to the db, update not required
+                (undef,$error) = $host_inventory_d->save(node => $nodeobj); # and save to the db, update not required
                 $NG->log->error("Failed to save inventory for ".$data_hs->{$hrFSStorageIndex}. " : $error")
                         if ($error);
 			}

--- a/conf-default/plugins/InterfaceTable.pm
+++ b/conf-default/plugins/InterfaceTable.pm
@@ -52,7 +52,7 @@ sub update_plugin
 
 	$NG->log->info("$plugin:$sub: Running for node $node");
 
-    my $nodeobj = $NG->node(name => $node);
+    my $nodeobj = $node_obj;
     my $inv = $S->inventory( concept => 'catchall' );
 	my $catchall_data = $inv->data;
 

--- a/conf-default/plugins/InterfaceTable.pm
+++ b/conf-default/plugins/InterfaceTable.pm
@@ -43,7 +43,7 @@ use Data::Dumper;
 sub update_plugin
 {
 	my (%args) = @_;
-	my ($node, $S, $C, $NG) = @args{qw(node sys config nmisng)};
+	my ($node, $S, $C, $NG, $node_obj) = @args{qw(node sys config nmisng node_obj)};
 
 	my $sub = 'update';
 	my $plugin = 'InterfaceTable.pm';
@@ -143,7 +143,7 @@ sub update_plugin
                     # disable for now
                     $inventory->data_info( subconcept => 'interface', enabled => 0 );
 
-                    my ($op,$error) = $inventory->save( node => $node );
+                    my ($op,$error) = $inventory->save( node => $node_obj );
                     $inventory->description( $data->{ifDescr} );
 
                     $NG->log->debug2(sub { "saved ".join(',', @$path)." op: $op"});
@@ -157,7 +157,7 @@ sub update_plugin
         $catchall_data->{ifNumber} = $ids;
         $catchall_data->{active} = $active;
         $inv->data($catchall_data);
-        my ($op,$error) = $inv->save( node => $node, update => 1 );
+        my ($op,$error) = $inv->save( node => $node_obj, update => 1 );
         $NG->log->info( "saved catchall op: $op");
         
 	}
@@ -172,8 +172,8 @@ sub update_plugin
 sub collect_plugin
 {
 	my (%args) = @_;
-	my ($node, $S, $C, $NG) = @args{qw(node sys config nmisng)};
-	
+	my ($node, $S, $C, $NG, $node_obj) = @args{qw(node sys config nmisng node_obj)};
+
 	my @knownindices;
 	my $changesweremade = 0;
 	return (0,undef) if ($S->{mdl}->{system}->{nodeModel} ne "NL-Aviat");
@@ -195,7 +195,7 @@ sub collect_plugin
 			my $data = $ifTable->data();
 			$ifTable->historic(0);
 			$ifTable->data($data);
-			my ($op, $serror) = $ifTable->save( node => $node );
+			my ($op, $serror) = $ifTable->save( node => $node_obj );
 			$NG->log->debug2(sub {"Inventory update: $op "});
 			if ($serror)
 			{

--- a/conf-default/plugins/InterfaceTable.pm
+++ b/conf-default/plugins/InterfaceTable.pm
@@ -143,7 +143,7 @@ sub update_plugin
                     # disable for now
                     $inventory->data_info( subconcept => 'interface', enabled => 0 );
 
-                    my ($op,$error) = $inventory->save( node => $node_obj );
+                    my ($op,$error) = $inventory->save( node => $nodeobj );
                     $inventory->description( $data->{ifDescr} );
 
                     $NG->log->debug2(sub { "saved ".join(',', @$path)." op: $op"});
@@ -157,7 +157,7 @@ sub update_plugin
         $catchall_data->{ifNumber} = $ids;
         $catchall_data->{active} = $active;
         $inv->data($catchall_data);
-        my ($op,$error) = $inv->save( node => $node_obj, update => 1 );
+        my ($op,$error) = $inv->save( node => $nodeobj, update => 1 );
         $NG->log->info( "saved catchall op: $op");
         
 	}
@@ -173,6 +173,7 @@ sub collect_plugin
 {
 	my (%args) = @_;
 	my ($node, $S, $C, $NG, $node_obj) = @args{qw(node sys config nmisng node_obj)};
+	my $nodeobj = $node_obj // $S->nmisng_node;
 
 	my @knownindices;
 	my $changesweremade = 0;
@@ -195,7 +196,7 @@ sub collect_plugin
 			my $data = $ifTable->data();
 			$ifTable->historic(0);
 			$ifTable->data($data);
-			my ($op, $serror) = $ifTable->save( node => $node_obj );
+			my ($op, $serror) = $ifTable->save( node => $nodeobj );
 			$NG->log->debug2(sub {"Inventory update: $op "});
 			if ($serror)
 			{

--- a/conf-default/plugins/InterfaceTable.pm
+++ b/conf-default/plugins/InterfaceTable.pm
@@ -52,7 +52,7 @@ sub update_plugin
 
 	$NG->log->info("$plugin:$sub: Running for node $node");
 
-    my $nodeobj = $node_obj;
+    my $nodeobj = $node_obj // $S->nmisng_node;
     my $inv = $S->inventory( concept => 'catchall' );
 	my $catchall_data = $inv->data;
 

--- a/conf-default/plugins/MA5600.pm
+++ b/conf-default/plugins/MA5600.pm
@@ -25,7 +25,7 @@ sub update_plugin
     $NG->log->info("Running update_plugin MA5600 for node $node");
     
 	#my $S = NMISNG::Sys->new(nmisng => $NG);
-	my $nodeobj = $node_obj;
+	my $nodeobj = $node_obj // $S->nmisng_node;
 	#$S->init(node => $nodeobj, snmp => 0); # load node info and Model if name exists
 	my $catchall_data = $S->inventory( concept => 'catchall' )->data_live();
 

--- a/conf-default/plugins/MA5600.pm
+++ b/conf-default/plugins/MA5600.pm
@@ -20,16 +20,16 @@ sub update_plugin
 {
 	my $changesweremade = 0;
 	my (%args) = @_;
-	my ($node,$S,$C,$NG) = @args{qw(node sys config nmisng)};
+	my ($node,$S,$C,$NG,$node_obj) = @args{qw(node sys config nmisng node_obj)};
 
     $NG->log->info("Running update_plugin MA5600 for node $node");
     
 	#my $S = NMISNG::Sys->new(nmisng => $NG);
-	my $nodeobj = $NG->node(name => $node);
+	my $nodeobj = $node_obj;
 	#$S->init(node => $nodeobj, snmp => 0); # load node info and Model if name exists
 	my $catchall_data = $S->inventory( concept => 'catchall' )->data_live();
 
-	my $IF = $nodeobj->ifinfo;	
+	my $IF = $nodeobj->ifinfo;
 	my $MDL = $S->mdl;
             
 	my $NC = $nodeobj->configuration;

--- a/conf-default/plugins/README
+++ b/conf-default/plugins/README
@@ -45,11 +45,22 @@ the calling interface is the same for both functions:
 
 sub update_plugin(node => nodename, sys => live sys object,
 		config => read-only configuration object/hash,
-		nmisng => live nmisng object)
+		nmisng => live nmisng object,
+		node_obj => the NMISNG::Node object for this node)
 
 sub collect_plugin(node => nodename, sys => live sys object,
 		config => configuration object/hash, treat as read-only,
-		nmisng => live nmisng object)
+		nmisng => live nmisng object,
+		node_obj => the NMISNG::Node object for this node)
+
+node_obj is the already-loaded NMISNG::Node object for the node being
+processed. prefer it over re-resolving the node yourself (e.g. via
+nmisng->node(name => node) or inventory->save(node => nodename)): passing
+the object avoids an extra MongoDB lookup per save. node (the name string)
+is retained for backward compatibility. if you support being called by
+older code that does not supply node_obj, fall back to the sys object's
+already-loaded node, which costs no lookup:
+		my $nodeobj = $node_obj // $sys->nmisng_node;
 
 the plugin can modify node attributes via sys and nmisng where required.
 it may call other nmis code (but care needs to be taken of

--- a/conf-default/plugins/RS420.pm
+++ b/conf-default/plugins/RS420.pm
@@ -18,10 +18,10 @@ use Net::SNMP qw(oid_lex_sort);
 sub getTeldatInventory {
 
 	my (%args) = @_;
-	my ($node,$S,$C,$NG,$section,$thissection) = @args{qw(node sys config nmisng section thissection)};
+	my ($node,$S,$C,$NG,$section,$thissection,$node_obj) = @args{qw(node sys config nmisng section thissection node_obj)};
 	$NG->log->info("Running getTeldatInventory RS420 for node $node");
 
-	my $nodeobj = $NG->node(name => $node);
+	my $nodeobj = $node_obj;
 	my $catchall_data = $S->inventory( concept => 'catchall' )->data_live();
 
 	my $IF = $nodeobj->ifinfo;	
@@ -125,12 +125,12 @@ sub update_plugin
 {	
 	my $changesweremade = 0;
 	my (%args) = @_;
-	my ($node,$S,$C,$NG) = @args{qw(node sys config nmisng)};
+	my ($node,$S,$C,$NG,$node_obj) = @args{qw(node sys config nmisng node_obj)};
 
     $NG->log->info("Running update_plugin RS420 for node $node");
-    
+
 	#my $S = NMISNG::Sys->new(nmisng => $NG);
-	my $nodeobj = $NG->node(name => $node);
+	my $nodeobj = $node_obj;
 	#$S->init(node => $nodeobj, snmp => 0); # load node info and Model if name exists
 	my $catchall_data = $S->inventory( concept => 'catchall' )->data_live();
 

--- a/conf-default/plugins/RS420.pm
+++ b/conf-default/plugins/RS420.pm
@@ -21,7 +21,7 @@ sub getTeldatInventory {
 	my ($node,$S,$C,$NG,$section,$thissection,$node_obj) = @args{qw(node sys config nmisng section thissection node_obj)};
 	$NG->log->info("Running getTeldatInventory RS420 for node $node");
 
-	my $nodeobj = $node_obj;
+	my $nodeobj = $node_obj // $S->nmisng_node;
 	my $catchall_data = $S->inventory( concept => 'catchall' )->data_live();
 
 	my $IF = $nodeobj->ifinfo;	
@@ -130,7 +130,7 @@ sub update_plugin
     $NG->log->info("Running update_plugin RS420 for node $node");
 
 	#my $S = NMISNG::Sys->new(nmisng => $NG);
-	my $nodeobj = $node_obj;
+	my $nodeobj = $node_obj // $S->nmisng_node;
 	#$S->init(node => $nodeobj, snmp => 0); # load node info and Model if name exists
 	my $catchall_data = $S->inventory( concept => 'catchall' )->data_live();
 

--- a/conf-default/plugins/ZXR10.pm
+++ b/conf-default/plugins/ZXR10.pm
@@ -85,7 +85,7 @@ sub update_plugin
 				$data->{zxAnSubIfIndex} =  ($sub_index >> 16) & 0x7FF;
 
 				$inventory->data($data);
-				$inventory->save(node => $node_obj);
+				$inventory->save(node => $nodeobj);
 			}
 		}
 		
@@ -108,7 +108,7 @@ sub update_plugin
 				$data->{'zxAnCardMemUsage'} =  $MemUsage->{$index};
 				$data->{'zxAnCardCpuLoad'} = $CPULoad->{$index};				
 				$inventory->data($data);
-				$inventory->save(node => $node_obj);
+				$inventory->save(node => $nodeobj);
 			}
 		}
 
@@ -132,7 +132,7 @@ sub update_plugin
 				$data->{zxAnSubIfIndex} =  (( 0 + $sub_index) >> 16) & 0x7FF;
 								
 				$inventory->data($data);
-				$inventory->save(node => $node_obj);
+				$inventory->save(node => $nodeobj);
 			}
 		}
 
@@ -168,7 +168,7 @@ sub update_plugin
 					$data->{zxAnGponSrvOnuLastOfflineTime} = snmp_hex_to_datetime($NG,$data->{zxAnGponSrvOnuLastOfflineTime});								
 				}
 					$inventory->data($data);
-					$inventory->save(node => $node_obj);
+					$inventory->save(node => $nodeobj);
 			}
 		}
 

--- a/conf-default/plugins/ZXR10.pm
+++ b/conf-default/plugins/ZXR10.pm
@@ -25,7 +25,7 @@ sub update_plugin
     $NG->log->info("Running update_plugin ZXR10 for node $node");
     
 	#my $S = NMISNG::Sys->new(nmisng => $NG);
-	my $nodeobj = $node_obj;
+	my $nodeobj = $node_obj // $S->nmisng_node;
 	#$S->init(node => $nodeobj, snmp => 0); # load node info and Model if name exists
 	my $catchall_data = $S->inventory( concept => 'catchall' )->data_live();
 

--- a/conf-default/plugins/ZXR10.pm
+++ b/conf-default/plugins/ZXR10.pm
@@ -25,11 +25,11 @@ sub update_plugin
     $NG->log->info("Running update_plugin ZXR10 for node $node");
     
 	#my $S = NMISNG::Sys->new(nmisng => $NG);
-	my $nodeobj = $NG->node(name => $node);
+	my $nodeobj = $node_obj;
 	#$S->init(node => $nodeobj, snmp => 0); # load node info and Model if name exists
 	my $catchall_data = $S->inventory( concept => 'catchall' )->data_live();
 
-	my $IF = $nodeobj->ifinfo;	
+	my $IF = $nodeobj->ifinfo;
 	my $MDL = $S->mdl;
             
 	my $NC = $nodeobj->configuration;

--- a/conf-default/plugins/ZXR10.pm
+++ b/conf-default/plugins/ZXR10.pm
@@ -20,7 +20,7 @@ sub update_plugin
 {	
 	my $changesweremade = 0;
 	my (%args) = @_;
-	my ($node,$S,$C,$NG) = @args{qw(node sys config nmisng)};
+	my ($node,$S,$C,$NG,$node_obj) = @args{qw(node sys config nmisng node_obj)};
 
     $NG->log->info("Running update_plugin ZXR10 for node $node");
     
@@ -85,7 +85,7 @@ sub update_plugin
 				$data->{zxAnSubIfIndex} =  ($sub_index >> 16) & 0x7FF;
 
 				$inventory->data($data);
-				$inventory->save(node => $node);				
+				$inventory->save(node => $node_obj);
 			}
 		}
 		
@@ -108,7 +108,7 @@ sub update_plugin
 				$data->{'zxAnCardMemUsage'} =  $MemUsage->{$index};
 				$data->{'zxAnCardCpuLoad'} = $CPULoad->{$index};				
 				$inventory->data($data);
-				$inventory->save(node => $node);				
+				$inventory->save(node => $node_obj);
 			}
 		}
 
@@ -132,7 +132,7 @@ sub update_plugin
 				$data->{zxAnSubIfIndex} =  (( 0 + $sub_index) >> 16) & 0x7FF;
 								
 				$inventory->data($data);
-				$inventory->save(node => $node);				
+				$inventory->save(node => $node_obj);
 			}
 		}
 
@@ -168,7 +168,7 @@ sub update_plugin
 					$data->{zxAnGponSrvOnuLastOfflineTime} = snmp_hex_to_datetime($NG,$data->{zxAnGponSrvOnuLastOfflineTime});								
 				}
 					$inventory->data($data);
-					$inventory->save(node => $node);
+					$inventory->save(node => $node_obj);
 			}
 		}
 

--- a/conf-default/plugins/ZyxelInterface.pm
+++ b/conf-default/plugins/ZyxelInterface.pm
@@ -525,7 +525,7 @@ sub update_plugin
 		}
 
 		# The above has added data to the inventory, that we now save.
-		my ( $op, $subError ) = $inventory->save( node => $node_obj, update => 1 );
+		my ( $op, $subError ) = $inventory->save( node => $nodeobj, update => 1 );
 		$NG->log->debug2(sub { "saved ".join(',', @$path)." op: $op"});
 		if ($subError)
 		{

--- a/conf-default/plugins/ZyxelInterface.pm
+++ b/conf-default/plugins/ZyxelInterface.pm
@@ -56,7 +56,7 @@ sub update_plugin
 
 
 	my $NI = $S->nmisng_node;
-	my $nodeobj = $NG->node(name => $node);
+	my $nodeobj = $node_obj;
 	my $NC = $nodeobj->configuration;
 	my $catchall = $S->inventory( concept => 'catchall' )->data_live();
 	my $IFT = NMISNG::Util::loadTable(dir => "conf", name => "ifTypes", conf => $C);

--- a/conf-default/plugins/ZyxelInterface.pm
+++ b/conf-default/plugins/ZyxelInterface.pm
@@ -47,7 +47,7 @@ my $changesweremade = 0;
 sub update_plugin
 {
 	my (%args) = @_;
-	my ($node,$S,$C,$NG) = @args{qw(node sys config nmisng)};
+	my ($node,$S,$C,$NG,$node_obj) = @args{qw(node sys config nmisng node_obj)};
 
 	my $intfData = undef;
 	my $intfInfo = undef;
@@ -525,7 +525,7 @@ sub update_plugin
 		}
 
 		# The above has added data to the inventory, that we now save.
-		my ( $op, $subError ) = $inventory->save( node => $node, update => 1 );
+		my ( $op, $subError ) = $inventory->save( node => $node_obj, update => 1 );
 		$NG->log->debug2(sub { "saved ".join(',', @$path)." op: $op"});
 		if ($subError)
 		{

--- a/conf-default/plugins/ZyxelInterface.pm
+++ b/conf-default/plugins/ZyxelInterface.pm
@@ -56,7 +56,7 @@ sub update_plugin
 
 
 	my $NI = $S->nmisng_node;
-	my $nodeobj = $node_obj;
+	my $nodeobj = $node_obj // $S->nmisng_node;
 	my $NC = $nodeobj->configuration;
 	my $catchall = $S->inventory( concept => 'catchall' )->data_live();
 	my $IFT = NMISNG::Util::loadTable(dir => "conf", name => "ifTypes", conf => $C);

--- a/conf-default/plugins/ciscoMemory.pm
+++ b/conf-default/plugins/ciscoMemory.pm
@@ -45,7 +45,7 @@ use NMISNG::Snmp;						# for snmp-related access
 sub update_plugin
 {
 	my (%args) = @_;
-	my ($node,$S,$C,$NG) = @args{qw(node sys config nmisng)};
+	my ($node,$S,$C,$NG,$node_obj) = @args{qw(node sys config nmisng node_obj)};
 	my $changesweremade  = 0;
 
 	# Node must have have data for both entityMib and cempMemPool to be relevant
@@ -100,7 +100,7 @@ sub update_plugin
 			# set the inventory description to a nice string.
 			$cempinventory->description( "$emibdata{$entityIndex}->{entPhysicalName} - $cempdata->{MemPoolName}");
 
-			my ( $op, $error ) = $cempinventory->save( node => $node );
+			my ( $op, $error ) = $cempinventory->save( node => $node_obj );
 			$NG->log->debug2(sub { "saved op: $op"});
 			if ($error)
 			{
@@ -128,7 +128,7 @@ sub update_plugin
 sub collect_plugin
 {
 	my (%args) = @_;
-	my ($node,$S,$C,$NG) = @args{qw(node sys config nmisng)};
+	my ($node,$S,$C,$NG,$node_obj) = @args{qw(node sys config nmisng node_obj)};
 
 	my $intfData = undef;
 	my $intfInfo = undef;
@@ -441,9 +441,9 @@ sub collect_plugin
 					data       => $rrdData,
 					item       => undef);
 	
-	my ( $op, $error ) = $inventory->save( node => $node );
+	my ( $op, $error ) = $inventory->save( node => $node_obj );
 	# The above has added data to the inventory, that we now save.
-	my ( $op, $error ) = $inventory->save( node => $node, update => 1 );
+	my ( $op, $error ) = $inventory->save( node => $node_obj, update => 1 );
 	$NG->log->debug2(sub {"saved inventory for Node '$node'; op: $op"});
 	if ($error)
 	{
@@ -459,7 +459,7 @@ sub collect_plugin
 					index      => undef,
 					data       => $rrdData,
 					item       => undef);
-	my ( $op, $error ) = $inventory->save( node => $node );
+	my ( $op, $error ) = $inventory->save( node => $node_obj );
 	$NG->log->debug( "saved op: $op");
 	if ($error)
 	{

--- a/conf-default/plugins/ciscoMemory.pm
+++ b/conf-default/plugins/ciscoMemory.pm
@@ -134,7 +134,7 @@ sub collect_plugin
 	my $intfInfo = undef;
 
 	my $NI       = $S->nmisng_node;
-	my $nodeobj  = $node_obj;
+	my $nodeobj  = $node_obj // $S->nmisng_node;
 	my $NC       = $nodeobj->configuration;
 	my $catchall_inventory = $S->inventory( concept => 'catchall' );
 	my $catchall = $catchall_inventory->data_live();

--- a/conf-default/plugins/ciscoMemory.pm
+++ b/conf-default/plugins/ciscoMemory.pm
@@ -46,6 +46,7 @@ sub update_plugin
 {
 	my (%args) = @_;
 	my ($node,$S,$C,$NG,$node_obj) = @args{qw(node sys config nmisng node_obj)};
+	my $nodeobj          = $node_obj // $S->nmisng_node;
 	my $changesweremade  = 0;
 
 	# Node must have have data for both entityMib and cempMemPool to be relevant
@@ -100,7 +101,7 @@ sub update_plugin
 			# set the inventory description to a nice string.
 			$cempinventory->description( "$emibdata{$entityIndex}->{entPhysicalName} - $cempdata->{MemPoolName}");
 
-			my ( $op, $error ) = $cempinventory->save( node => $node_obj );
+			my ( $op, $error ) = $cempinventory->save( node => $nodeobj );
 			$NG->log->debug2(sub { "saved op: $op"});
 			if ($error)
 			{
@@ -441,9 +442,9 @@ sub collect_plugin
 					data       => $rrdData,
 					item       => undef);
 	
-	my ( $op, $error ) = $inventory->save( node => $node_obj );
+	my ( $op, $error ) = $inventory->save( node => $nodeobj );
 	# The above has added data to the inventory, that we now save.
-	my ( $op, $error ) = $inventory->save( node => $node_obj, update => 1 );
+	my ( $op, $error ) = $inventory->save( node => $nodeobj, update => 1 );
 	$NG->log->debug2(sub {"saved inventory for Node '$node'; op: $op"});
 	if ($error)
 	{
@@ -459,7 +460,7 @@ sub collect_plugin
 					index      => undef,
 					data       => $rrdData,
 					item       => undef);
-	my ( $op, $error ) = $inventory->save( node => $node_obj );
+	my ( $op, $error ) = $inventory->save( node => $nodeobj );
 	$NG->log->debug( "saved op: $op");
 	if ($error)
 	{

--- a/conf-default/plugins/ciscoMemory.pm
+++ b/conf-default/plugins/ciscoMemory.pm
@@ -134,7 +134,7 @@ sub collect_plugin
 	my $intfInfo = undef;
 
 	my $NI       = $S->nmisng_node;
-	my $nodeobj  = $NG->node(name => $node);
+	my $nodeobj  = $node_obj;
 	my $NC       = $nodeobj->configuration;
 	my $catchall_inventory = $S->inventory( concept => 'catchall' );
 	my $catchall = $catchall_inventory->data_live();

--- a/conf-default/plugins/jnxCoStable.pm
+++ b/conf-default/plugins/jnxCoStable.pm
@@ -54,7 +54,7 @@ sub update_plugin
 	my ($node,$S,$C,$NG,$node_obj) = @args{qw(node sys config nmisng node_obj)};
 
 	my $NI              = $S->nmisng_node;
-	my $nodeobj         = $NG->node(name => $node);
+	my $nodeobj         = $node_obj;
 	my $NC              = $nodeobj->configuration;
 	my $catchall        = $S->inventory( concept => 'catchall' )->data_live();
 	my $unmanagedMsg;

--- a/conf-default/plugins/jnxCoStable.pm
+++ b/conf-default/plugins/jnxCoStable.pm
@@ -147,7 +147,7 @@ sub update_plugin
 						subconcept => "Juniper_CoS",
 						enabled => 0
 					);
-					my ( $op, $subError ) = $inventory->save( node => $node_obj ); # update not required
+					my ( $op, $subError ) = $inventory->save( node => $nodeobj ); # update not required
 					if ($subError)
 					{
 						$NG->log->error("Failed to unmanage inventory for Class of Service Index '$index': $subError");
@@ -183,7 +183,7 @@ sub update_plugin
 			$NG->log->debug2(sub {"jnxCoStable: cosDescription = '$juniperCoSData->{cosDescription}'"});
 			$NG->log->debug("jnxCoStable: update_plugin: Found COS Entry with interface '$juniperCoSData->{IntName}' and '$juniperCoSData->{jnxCosFcName}'.");
 			# The above has added data to the inventory, that we now save.
-			my ( $op, $subError ) = $inventory->save( node => $node_obj ); # update not required
+			my ( $op, $subError ) = $inventory->save( node => $nodeobj ); # update not required
 			if ($subError)
 			{
 				$NG->log->error("Failed to save inventory for Class of Service Index '$index': $subError");

--- a/conf-default/plugins/jnxCoStable.pm
+++ b/conf-default/plugins/jnxCoStable.pm
@@ -54,7 +54,7 @@ sub update_plugin
 	my ($node,$S,$C,$NG,$node_obj) = @args{qw(node sys config nmisng node_obj)};
 
 	my $NI              = $S->nmisng_node;
-	my $nodeobj         = $node_obj;
+	my $nodeobj         = $node_obj // $S->nmisng_node;
 	my $NC              = $nodeobj->configuration;
 	my $catchall        = $S->inventory( concept => 'catchall' )->data_live();
 	my $unmanagedMsg;

--- a/conf-default/plugins/jnxCoStable.pm
+++ b/conf-default/plugins/jnxCoStable.pm
@@ -51,7 +51,7 @@ my $deleteCOSForUnmanagedInterfaces = 1;
 sub update_plugin
 {
 	my (%args) = @_;
-	my ($node,$S,$C,$NG) = @args{qw(node sys config nmisng)};
+	my ($node,$S,$C,$NG,$node_obj) = @args{qw(node sys config nmisng node_obj)};
 
 	my $NI              = $S->nmisng_node;
 	my $nodeobj         = $NG->node(name => $node);
@@ -147,7 +147,7 @@ sub update_plugin
 						subconcept => "Juniper_CoS",
 						enabled => 0
 					);
-					my ( $op, $subError ) = $inventory->save( node => $node ); # update not required
+					my ( $op, $subError ) = $inventory->save( node => $node_obj ); # update not required
 					if ($subError)
 					{
 						$NG->log->error("Failed to unmanage inventory for Class of Service Index '$index': $subError");
@@ -183,7 +183,7 @@ sub update_plugin
 			$NG->log->debug2(sub {"jnxCoStable: cosDescription = '$juniperCoSData->{cosDescription}'"});
 			$NG->log->debug("jnxCoStable: update_plugin: Found COS Entry with interface '$juniperCoSData->{IntName}' and '$juniperCoSData->{jnxCosFcName}'.");
 			# The above has added data to the inventory, that we now save.
-			my ( $op, $subError ) = $inventory->save( node => $node ); # update not required
+			my ( $op, $subError ) = $inventory->save( node => $node_obj ); # update not required
 			if ($subError)
 			{
 				$NG->log->error("Failed to save inventory for Class of Service Index '$index': $subError");

--- a/conf-default/plugins/lldpTable.pm
+++ b/conf-default/plugins/lldpTable.pm
@@ -61,6 +61,7 @@ sub update_plugin
 {
 	my (%args) = @_;
 	my ($node,$S,$C,$NG,$node_obj) = @args{qw(node sys config nmisng node_obj)};
+	my $nodeobj = $node_obj // $S->nmisng_node;
 
 	# anything to do? does this node collect lldp information?
 	my $ids = $S->nmisng_node->get_inventory_ids(
@@ -315,7 +316,7 @@ sub update_plugin
 		if ($mustsave)
 		{
 			$lldpinventory->data($data); # set changed info
-			my (undef,$error) = $lldpinventory->save( node => $node_obj ); # and save to the db, update not required because it wasn't made here
+			my (undef,$error) = $lldpinventory->save( node => $nodeobj ); # and save to the db, update not required because it wasn't made here
 			$NG->log->error("Failed to save inventory for $lldpinventory->{_id}: $error")
 					if ($error);
 		}

--- a/conf-default/plugins/lldpTable.pm
+++ b/conf-default/plugins/lldpTable.pm
@@ -60,7 +60,7 @@ sub or_terms_to_query_or {
 sub update_plugin
 {
 	my (%args) = @_;
-	my ($node,$S,$C,$NG) = @args{qw(node sys config nmisng)};
+	my ($node,$S,$C,$NG,$node_obj) = @args{qw(node sys config nmisng node_obj)};
 
 	# anything to do? does this node collect lldp information?
 	my $ids = $S->nmisng_node->get_inventory_ids(
@@ -315,7 +315,7 @@ sub update_plugin
 		if ($mustsave)
 		{
 			$lldpinventory->data($data); # set changed info
-			my (undef,$error) = $lldpinventory->save( node => $node ); # and save to the db, update not required because it wasn't made here
+			my (undef,$error) = $lldpinventory->save( node => $node_obj ); # and save to the db, update not required because it wasn't made here
 			$NG->log->error("Failed to save inventory for $lldpinventory->{_id}: $error")
 					if ($error);
 		}

--- a/conf-default/plugins/mplsVpn.pm
+++ b/conf-default/plugins/mplsVpn.pm
@@ -39,7 +39,7 @@ use Data::Dumper;
 sub update_plugin
 {
 	my (%args) = @_;
-	my ($node,$S,$C,$NG) = @args{qw(node sys config nmisng)};
+	my ($node,$S,$C,$NG,$node_obj) = @args{qw(node sys config nmisng node_obj)};
 
 	my $nodeobj = $NG->node(name => $node);
 	my $IF = $nodeobj->ifinfo;
@@ -105,7 +105,7 @@ sub update_plugin
 				$NG->log->debug5(sub {"Node '$node' 'mplsVpnVrf' entry $i After " . Dumper($entry)});
 				# Save the results in the database.
 				$mplsVpnVrf->data($entry);
-				my ( $op, $saveError ) = $mplsVpnVrf->save( node => $node ); # update not required
+				my ( $op, $saveError ) = $mplsVpnVrf->save( node => $node_obj ); # update not required
 				if ($saveError)
 				{
 					$NG->log->error("Failed to save Concept 'mplsVpnVrf' inventory for ID '$mplsVpnVrfId' in Node '$node'; Error: $saveError");
@@ -157,7 +157,7 @@ sub update_plugin
 				$NG->log->debug5(sub {"Node '$node' Concept 'mplsL3VpnVrf' entry $i After " . Dumper($entry)});
 				# Save the results back to the database.
 				$mplsL3VpnVrf->data($entry);
-				my ( $op, $saveError ) = $mplsL3VpnVrf->save( node => $node ); # update not required
+				my ( $op, $saveError ) = $mplsL3VpnVrf->save( node => $node_obj ); # update not required
 				if ($saveError)
 				{
 					$NG->log->error("Failed to save Concept 'mplsL3VpnVrf' inventory for ID '$mplsL3VpnVrfId' in Node '$node'; Error: $saveError");
@@ -215,7 +215,7 @@ sub update_plugin
 				}
 				# Save the results back to the database.
 				$mplsL3VpnIfConf->data($entry);
-				my ( $op, $saveError ) = $mplsL3VpnIfConf->save( node => $node ); # update not required
+				my ( $op, $saveError ) = $mplsL3VpnIfConf->save( node => $node_obj ); # update not required
 				if ($saveError)
 				{
 					$NG->log->error("Failed to save Concept 'mplsL3VpnIfConf' inventory for ID '$mplsL3VpnIfConfId' in Node '$node'; Error: $saveError");
@@ -273,7 +273,7 @@ sub update_plugin
 				$NG->log->debug5(sub {"Node '$node' Concept 'mplsVpnInterface' entry $i After " . Dumper($entry)});
 				# Save the results back to the database.
 				$mplsVpnInterface->data($entry);
-				my ( $op, $saveError ) = $mplsVpnInterface->save( node => $node ); # update not required
+				my ( $op, $saveError ) = $mplsVpnInterface->save( node => $node_obj ); # update not required
 				if ($saveError)
 				{
 					$NG->log->error("Failed to save Concept 'mplsVpnInterface' inventory for ID '$mplsVpnInterfaceId' in Node '$node'; Error: $saveError");
@@ -350,7 +350,7 @@ sub update_plugin
 				$NG->log->debug5(sub {"Node '$node' Concept 'mplsL3VpnVrfRT' entry $i After " . Dumper($entry)});
 				# Save the results back to the database.
 				$mplsL3VpnVrfRT->data($entry);
-				my ( $op, $saveError ) = $mplsL3VpnVrfRT->save( node => $node ); # update not required
+				my ( $op, $saveError ) = $mplsL3VpnVrfRT->save( node => $node_obj ); # update not required
 				if ($saveError)
 				{
 					$NG->log->error("Failed to save Concept 'mplsL3VpnVrfRT' inventory for ID '$mplsL3VpnVrfRTId' in Node '$node'; Error: $saveError");
@@ -413,7 +413,7 @@ sub update_plugin
 				$NG->log->debug5(sub {"Node '$node' Concept 'mplsVpnVrfRouteTarget' entry $i After " . Dumper($entry)});
 				# Save the results back to the database.
 				$mplsVpnVrfRouteTarget->data($entry);
-				my ( $op, $saveError ) = $mplsVpnVrfRouteTarget->save( node => $node ); # update not required
+				my ( $op, $saveError ) = $mplsVpnVrfRouteTarget->save( node => $node_obj ); # update not required
 				if ($saveError)
 				{
 					$NG->log->error("Failed to save Concept 'mplsVpnVrfRouteTarget' inventory for ID '$mplsVpnVrfRouteTargetId' in Node '$node'; Error: $saveError");
@@ -464,7 +464,7 @@ sub update_plugin
 				$NG->log->debug5(sub {"Node '$node' Concept 'mplsLdpEntity' entry $i After " . Dumper($entry)});
 				# Save the results back to the database.
 				$mplsLdpEntity->data($entry);
-				my ( $op, $saveError ) = $mplsLdpEntity->save( node => $node ); # update not required
+				my ( $op, $saveError ) = $mplsLdpEntity->save( node => $node_obj ); # update not required
 				if ($saveError)
 				{
 					$NG->log->error("Failed to save Concept 'mplsLdpEntity' inventory for ID '$mplsLdpEntityId' in Node '$node'; Error: $saveError");
@@ -515,7 +515,7 @@ sub update_plugin
 				$NG->log->debug5(sub {"Node '$node' Concept 'mplsVpnLdpCisco' entry $i After " . Dumper($entry)});
 				# Save the results back to the database.
 				$mplsVpnLdpCisco->data($entry);
-				my ( $op, $saveError ) = $mplsVpnLdpCisco->save( node => $node ); # update not required
+				my ( $op, $saveError ) = $mplsVpnLdpCisco->save( node => $node_obj ); # update not required
 				if ($saveError)
 				{
 					$NG->log->error("Failed to save Concept 'mplsVpnLdpCisco' inventory for ID '$mplsVpnLdpCiscoId' in Node '$node'; Error: $saveError");

--- a/conf-default/plugins/mplsVpn.pm
+++ b/conf-default/plugins/mplsVpn.pm
@@ -105,7 +105,7 @@ sub update_plugin
 				$NG->log->debug5(sub {"Node '$node' 'mplsVpnVrf' entry $i After " . Dumper($entry)});
 				# Save the results in the database.
 				$mplsVpnVrf->data($entry);
-				my ( $op, $saveError ) = $mplsVpnVrf->save( node => $node_obj ); # update not required
+				my ( $op, $saveError ) = $mplsVpnVrf->save( node => $nodeobj ); # update not required
 				if ($saveError)
 				{
 					$NG->log->error("Failed to save Concept 'mplsVpnVrf' inventory for ID '$mplsVpnVrfId' in Node '$node'; Error: $saveError");
@@ -157,7 +157,7 @@ sub update_plugin
 				$NG->log->debug5(sub {"Node '$node' Concept 'mplsL3VpnVrf' entry $i After " . Dumper($entry)});
 				# Save the results back to the database.
 				$mplsL3VpnVrf->data($entry);
-				my ( $op, $saveError ) = $mplsL3VpnVrf->save( node => $node_obj ); # update not required
+				my ( $op, $saveError ) = $mplsL3VpnVrf->save( node => $nodeobj ); # update not required
 				if ($saveError)
 				{
 					$NG->log->error("Failed to save Concept 'mplsL3VpnVrf' inventory for ID '$mplsL3VpnVrfId' in Node '$node'; Error: $saveError");
@@ -215,7 +215,7 @@ sub update_plugin
 				}
 				# Save the results back to the database.
 				$mplsL3VpnIfConf->data($entry);
-				my ( $op, $saveError ) = $mplsL3VpnIfConf->save( node => $node_obj ); # update not required
+				my ( $op, $saveError ) = $mplsL3VpnIfConf->save( node => $nodeobj ); # update not required
 				if ($saveError)
 				{
 					$NG->log->error("Failed to save Concept 'mplsL3VpnIfConf' inventory for ID '$mplsL3VpnIfConfId' in Node '$node'; Error: $saveError");
@@ -273,7 +273,7 @@ sub update_plugin
 				$NG->log->debug5(sub {"Node '$node' Concept 'mplsVpnInterface' entry $i After " . Dumper($entry)});
 				# Save the results back to the database.
 				$mplsVpnInterface->data($entry);
-				my ( $op, $saveError ) = $mplsVpnInterface->save( node => $node_obj ); # update not required
+				my ( $op, $saveError ) = $mplsVpnInterface->save( node => $nodeobj ); # update not required
 				if ($saveError)
 				{
 					$NG->log->error("Failed to save Concept 'mplsVpnInterface' inventory for ID '$mplsVpnInterfaceId' in Node '$node'; Error: $saveError");
@@ -350,7 +350,7 @@ sub update_plugin
 				$NG->log->debug5(sub {"Node '$node' Concept 'mplsL3VpnVrfRT' entry $i After " . Dumper($entry)});
 				# Save the results back to the database.
 				$mplsL3VpnVrfRT->data($entry);
-				my ( $op, $saveError ) = $mplsL3VpnVrfRT->save( node => $node_obj ); # update not required
+				my ( $op, $saveError ) = $mplsL3VpnVrfRT->save( node => $nodeobj ); # update not required
 				if ($saveError)
 				{
 					$NG->log->error("Failed to save Concept 'mplsL3VpnVrfRT' inventory for ID '$mplsL3VpnVrfRTId' in Node '$node'; Error: $saveError");
@@ -413,7 +413,7 @@ sub update_plugin
 				$NG->log->debug5(sub {"Node '$node' Concept 'mplsVpnVrfRouteTarget' entry $i After " . Dumper($entry)});
 				# Save the results back to the database.
 				$mplsVpnVrfRouteTarget->data($entry);
-				my ( $op, $saveError ) = $mplsVpnVrfRouteTarget->save( node => $node_obj ); # update not required
+				my ( $op, $saveError ) = $mplsVpnVrfRouteTarget->save( node => $nodeobj ); # update not required
 				if ($saveError)
 				{
 					$NG->log->error("Failed to save Concept 'mplsVpnVrfRouteTarget' inventory for ID '$mplsVpnVrfRouteTargetId' in Node '$node'; Error: $saveError");
@@ -464,7 +464,7 @@ sub update_plugin
 				$NG->log->debug5(sub {"Node '$node' Concept 'mplsLdpEntity' entry $i After " . Dumper($entry)});
 				# Save the results back to the database.
 				$mplsLdpEntity->data($entry);
-				my ( $op, $saveError ) = $mplsLdpEntity->save( node => $node_obj ); # update not required
+				my ( $op, $saveError ) = $mplsLdpEntity->save( node => $nodeobj ); # update not required
 				if ($saveError)
 				{
 					$NG->log->error("Failed to save Concept 'mplsLdpEntity' inventory for ID '$mplsLdpEntityId' in Node '$node'; Error: $saveError");
@@ -515,7 +515,7 @@ sub update_plugin
 				$NG->log->debug5(sub {"Node '$node' Concept 'mplsVpnLdpCisco' entry $i After " . Dumper($entry)});
 				# Save the results back to the database.
 				$mplsVpnLdpCisco->data($entry);
-				my ( $op, $saveError ) = $mplsVpnLdpCisco->save( node => $node_obj ); # update not required
+				my ( $op, $saveError ) = $mplsVpnLdpCisco->save( node => $nodeobj ); # update not required
 				if ($saveError)
 				{
 					$NG->log->error("Failed to save Concept 'mplsVpnLdpCisco' inventory for ID '$mplsVpnLdpCiscoId' in Node '$node'; Error: $saveError");

--- a/conf-default/plugins/mplsVpn.pm
+++ b/conf-default/plugins/mplsVpn.pm
@@ -41,7 +41,7 @@ sub update_plugin
 	my (%args) = @_;
 	my ($node,$S,$C,$NG,$node_obj) = @args{qw(node sys config nmisng node_obj)};
 
-	my $nodeobj = $node_obj;
+	my $nodeobj = $node_obj // $S->nmisng_node;
 	my $IF = $nodeobj->ifinfo;
 
 	my $changesweremade = 0;

--- a/conf-default/plugins/mplsVpn.pm
+++ b/conf-default/plugins/mplsVpn.pm
@@ -41,7 +41,7 @@ sub update_plugin
 	my (%args) = @_;
 	my ($node,$S,$C,$NG,$node_obj) = @args{qw(node sys config nmisng node_obj)};
 
-	my $nodeobj = $NG->node(name => $node);
+	my $nodeobj = $node_obj;
 	my $IF = $nodeobj->ifinfo;
 
 	my $changesweremade = 0;

--- a/lib/NMISNG/Node.pm
+++ b/lib/NMISNG/Node.pm
@@ -4898,6 +4898,7 @@ sub collect_systemhealth_info
 							$self->nmisng->log->logprefix("$plugin\[$$\] ");
 				
 							eval { ( $plugin_healthIndexTable, @errors ) = &$can_funcname( node => $name,
+																			node_obj => $self,
 																			sys => $S,
 																			config => $C,
 																			thissection => $thissection,
@@ -7405,6 +7406,7 @@ sub update
 			my $prevprefix = $self->nmisng->log->logprefix;
 			$self->nmisng->log->logprefix("$plugin\[$$\] ");
 			eval { ( $status, @errors ) = &$funcname( node => $name,
+																								node_obj => $self,
 																								sys => $S,
 																								config => $C,
 																								nmisng => $self->nmisng, ); };
@@ -9715,6 +9717,7 @@ sub collect
 		my $prevprefix = $self->nmisng->log->logprefix;
 		$self->nmisng->log->logprefix("$plugin\[$$\] ");
 		eval { ( $status, @errors ) = &$funcname( node => $name,
+																							node_obj => $self,
 																							sys => $S,
 																							config => $C,
 																							nmisng => $self->nmisng ); };

--- a/test/dev-tools.pl
+++ b/test/dev-tools.pl
@@ -227,6 +227,7 @@ elsif ($Q->{act} =~ /^plugin/)
 				next if ( !$funcname );
 				$ran_something = 1;
 				eval { ( $status, @errors ) = &$funcname( node => $node,
+										node_obj => $nodeobj,
 										sys => $S,
 										config => $C,
 										nmisng => $nmisng, ); };

--- a/test/t_plugin_nodeobj.pl
+++ b/test/t_plugin_nodeobj.pl
@@ -80,6 +80,17 @@ is(ref($NodeObjProbe::SEEN{node_obj}), "NMISNG::Node", "node_obj is an NMISNG::N
 is($NodeObjProbe::SEEN{node}, $node->name, "node argument is still the name string (back-compat)");
 $nmisng->{_plugins} = undef;
 
+# BACK-COMPAT: a converted plugin invoked with the OLD documented args (node/sys/config/nmisng,
+# WITHOUT node_obj) must still resolve the current node via $S->nmisng_node (find-free) and not die
+# on the node-object deref. AdtranInterface derefs $nodeobj->configuration immediately, then returns
+# early for the non-Adtran test node. Before the `// $S->nmisng_node` fallback this died on undef.
+{
+  require "$FindBin::Bin/../conf-default/plugins/AdtranInterface.pm";
+  eval { AdtranInterface::update_plugin(
+      node => $node->name, sys => $S, config => $C, nmisng => $nmisng ); };  # deliberately no node_obj
+  is($@, '', "converted plugin runs with old args (no node_obj) via \$S->nmisng_node fallback");
+}
+
 # drop the temp db so repeated runs (Tasks 2-5) start clean (idiom from test/t_nmisng.pl)
 $nmisng->get_db()->drop();
 

--- a/test/t_plugin_nodeobj.pl
+++ b/test/t_plugin_nodeobj.pl
@@ -4,7 +4,7 @@ use strict; use warnings;
 use FindBin; use lib "$FindBin::Bin/lib"; use lib "$FindBin::Bin/../lib";
 use Test::More;
 use NMISNG; use NMISNG::Util; use NMISNG::Log; use NMISNG::DB; use NMISNG::Sys;
-use Compat::NMIS;
+use Compat::NMIS;  # required: collect() calls Compat::NMIS::notify internally
 
 my $C = NMISNG::Util::loadConfTable();
 $C->{db_name} = "t_plugnodeobj-$$";
@@ -60,7 +60,7 @@ $nmisng->{_plugins} = ['NodeObjProbe'];   # short-circuits NMISNG::plugins() (it
 my $cp = $node->inventory_path(concept=>"catchall", data=>{}, path_keys=>[]);
 my ($catchall_inv, $cerr) = $node->inventory(concept=>"catchall", model_class=>"system",
                                               path=>$cp, path_keys=>[], create=>1);
-die "Could not create catchall: $cerr" if $cerr;
+BAIL_OUT("setup failed: could not create catchall inventory: $cerr") if $cerr;
 my $cdata = $catchall_inv->data_live();
 $cdata->{nodedown}   = "false";
 $cdata->{snmpdown}   = "false";
@@ -79,5 +79,8 @@ ok(defined $NodeObjProbe::SEEN{node_obj}, "collect_plugin received a node_obj ar
 is(ref($NodeObjProbe::SEEN{node_obj}), "NMISNG::Node", "node_obj is an NMISNG::Node object");
 is($NodeObjProbe::SEEN{node}, $node->name, "node argument is still the name string (back-compat)");
 $nmisng->{_plugins} = undef;
+
+# drop the temp db so repeated runs (Tasks 2-5) start clean (idiom from test/t_nmisng.pl)
+$nmisng->get_db()->drop();
 
 done_testing;

--- a/test/t_plugin_nodeobj.pl
+++ b/test/t_plugin_nodeobj.pl
@@ -83,4 +83,19 @@ $nmisng->{_plugins} = undef;
 # drop the temp db so repeated runs (Tasks 2-5) start clean (idiom from test/t_nmisng.pl)
 $nmisng->get_db()->drop();
 
+# STATIC GUARD: after the fixups, no in-tree plugin may pass the bare $node name string to save,
+# nor re-resolve the current node with node(name => $node). \$node\b does not match \$node_obj.
+{
+  my $dir = "$FindBin::Bin/../conf-default/plugins";
+  for my $file (sort glob("$dir/*.pm")) {
+    open my $fh, "<", $file or next;
+    local $/; my $src = <$fh>; close $fh;
+    my $base = $file; $base =~ s{.*/}{};
+    ok($src !~ /->\s*save\s*\(\s*node\s*=>\s*\$node\b/,
+       "$base: no save(node => \$node) with the bare name string");
+    ok($src !~ /->\s*node\s*\(\s*name\s*=>\s*\$node\b/,
+       "$base: no \$NG->node(name => \$node) re-resolve of the current node");
+  }
+}
+
 done_testing;

--- a/test/t_plugin_nodeobj.pl
+++ b/test/t_plugin_nodeobj.pl
@@ -1,0 +1,83 @@
+#!/usr/bin/perl
+# Plugin node-object parameter: save invariant, dispatcher wiring, plugin-source guard.
+use strict; use warnings;
+use FindBin; use lib "$FindBin::Bin/lib"; use lib "$FindBin::Bin/../lib";
+use Test::More;
+use NMISNG; use NMISNG::Util; use NMISNG::Log; use NMISNG::DB; use NMISNG::Sys;
+use Compat::NMIS;
+
+my $C = NMISNG::Util::loadConfTable();
+$C->{db_name} = "t_plugnodeobj-$$";
+my $nmisng = NMISNG->new(config=>$C, log=>NMISNG::Log->new(level=>'error'));
+
+# count nodes-collection finds
+my @nf; my $orig = \&NMISNG::DB::find;
+{ no warnings 'redefine';
+  *NMISNG::DB::find = sub { my %a=@_;
+    my $n=(ref($a{collection})&&$a{collection}->can("name"))?$a{collection}->name:"$a{collection}";
+    push @nf, 1 if $n =~ /(?:^|\.)nodes$/;
+    return $orig->(@_); }; }
+
+# a node + one interface inventory to save
+my $uuid = "f00d0001-0000-0000-0000-000000000001";
+my $node = $nmisng->node(uuid=>$uuid, create=>1);
+$node->cluster_id($C->{cluster_id}); $node->name("plugnodeobj");
+$node->configuration({host=>"127.0.0.1",group=>"NMIS9",active=>1,collect=>1,model=>"Generic"}); $node->save();
+my $p = $node->inventory_path(concept=>"interface", data=>{ifDescr=>"e0"}, path_keys=>["ifDescr"]);
+my ($inv) = $node->inventory(concept=>"interface", path=>$p, path_keys=>["ifDescr"], model_class=>"interface", create=>1);
+$inv->data({index=>1, ifIndex=>1, ifDescr=>"e0"}); $inv->save(node=>$node);
+
+# INVARIANT: saving WITH the object does no nodes find; saving with the NAME string does.
+@nf = (); $inv->data({index=>1, ifIndex=>1, ifDescr=>"e0", note=>"a"}); $inv->save(node=>$node);
+is(scalar(@nf), 0, "save(node => OBJECT) issues no nodes find");
+
+@nf = (); $inv->data({index=>1, ifIndex=>1, ifDescr=>"e0", note=>"b"}); $inv->save(node=>$node->name);
+ok(scalar(@nf) >= 1, "save(node => NAME STRING) re-resolves (>=1 nodes find), got ".scalar(@nf));
+
+{ no warnings 'redefine'; *NMISNG::DB::find = $orig; }  # restore before the rest
+
+# collect() calls update() internally; update() calls RRDs::info bare (Node.pm ~7444, ~9749).
+# RRDs is loaded lazily by NMISNG::rrdfunc::require_RRDs; stub it out so collect() can reach
+# the collect_plugin loop without crashing on missing RRD files.
+NMISNG::rrdfunc::require_RRDs();   # ensure RRDs is loaded first, then stub
+{ no warnings qw(redefine prototype); *RRDs::info = sub { return {}; }; }
+
+# WIRING: a stub plugin injected into the loader must receive node_obj as an NMISNG::Node.
+# Harness path taken: collect() fatals without a catchall inventory, so we create one explicitly
+# and set nodedown/snmpdown => "false" to prevent early-return before the plugin loop.
+# This is the brief's documented fallback (mark node up via catchall data_live, save, re-run).
+{
+  package NodeObjProbe;
+  our %SEEN;
+  sub collect_plugin { my (%a) = @_; %SEEN = %a; return (1); }
+}
+$nmisng->{_plugins} = ['NodeObjProbe'];   # short-circuits NMISNG::plugins() (it caches _plugins)
+
+# collect() fetches its own catchall inventory from MongoDB (line ~9457 in Node.pm).
+# Create it now so collect() doesn't fatal on an undefined catchall.
+# Also set nodedown/snmpdown => "false" so collect() does not early-return before the
+# plugin loop (brief fallback: mark node up via catchall data_live).
+my $cp = $node->inventory_path(concept=>"catchall", data=>{}, path_keys=>[]);
+my ($catchall_inv, $cerr) = $node->inventory(concept=>"catchall", model_class=>"system",
+                                              path=>$cp, path_keys=>[], create=>1);
+die "Could not create catchall: $cerr" if $cerr;
+my $cdata = $catchall_inv->data_live();
+$cdata->{nodedown}   = "false";
+$cdata->{snmpdown}   = "false";
+$cdata->{nodeModel}  = "Generic";
+$cdata->{nodeType}   = "router";
+# last_update must be set or collect() redirects to update() at ~line 9531
+$cdata->{last_update} = time();
+$catchall_inv->save(node=>$node);
+
+my $S = NMISNG::Sys->new(nmisng=>$nmisng);
+$S->init(node=>$node, snmp=>0, wmi=>0);
+# drive collect far enough to reach the collect_plugin loop.
+$node->collect(wantsnmp=>0, wantwmi=>0, force=>1);
+
+ok(defined $NodeObjProbe::SEEN{node_obj}, "collect_plugin received a node_obj argument");
+is(ref($NodeObjProbe::SEEN{node_obj}), "NMISNG::Node", "node_obj is an NMISNG::Node object");
+is($NodeObjProbe::SEEN{node}, $node->name, "node argument is still the name string (back-compat)");
+$nmisng->{_plugins} = undef;
+
+done_testing;

--- a/test/t_plugin_nodeobj.pl
+++ b/test/t_plugin_nodeobj.pl
@@ -96,6 +96,9 @@ $nmisng->get_db()->drop();
 
 # STATIC GUARD: after the fixups, no in-tree plugin may pass the bare $node name string to save,
 # nor re-resolve the current node with node(name => $node). \$node\b does not match \$node_obj.
+# Saves must also use the fallback-resolved $nodeobj (= $node_obj // $S->nmisng_node), not the
+# raw $node_obj argument: an old-style caller that omits node_obj would otherwise pass undef and
+# force Inventory::save to re-resolve the node from MongoDB, defeating the whole optimization.
 {
   my $dir = "$FindBin::Bin/../conf-default/plugins";
   for my $file (sort glob("$dir/*.pm")) {
@@ -106,6 +109,8 @@ $nmisng->get_db()->drop();
        "$base: no save(node => \$node) with the bare name string");
     ok($src !~ /->\s*node\s*\(\s*name\s*=>\s*\$node\b/,
        "$base: no \$NG->node(name => \$node) re-resolve of the current node");
+    ok($src !~ /->\s*save\s*\(\s*node\s*=>\s*\$node_obj\b/,
+       "$base: no save(node => \$node_obj) raw arg; use the \$nodeobj fallback");
   }
 }
 

--- a/test/t_plugin_nodeobj_realnode.pl
+++ b/test/t_plugin_nodeobj_realnode.pl
@@ -1,0 +1,22 @@
+#!/usr/bin/perl
+# Throwaway acceptance measurement: count nodes-collection finds during a real collect.
+# Run on this branch (fixed) and on an unmodified origin/nmis9_dev checkout (baseline)
+# to show the node_obj change removes the redundant per-save node re-resolves.
+# Usage: perl test/t_plugin_nodeobj_realnode.pl [nodename]
+use strict; use warnings;
+use FindBin; use lib "$FindBin::Bin/lib"; use lib "$FindBin::Bin/../lib";
+use NMISNG; use NMISNG::Util; use NMISNG::Log; use NMISNG::DB; use Compat::NMIS;
+
+my $C = NMISNG::Util::loadConfTable();
+my $nmisng = NMISNG->new(config=>$C, log=>NMISNG::Log->new(level=>'error'));
+
+my $TOTAL = 0; my $ON = 0; my $orig = \&NMISNG::DB::find;
+{ no warnings 'redefine';
+  *NMISNG::DB::find = sub { my %a=@_;
+    my $n=(ref($a{collection})&&$a{collection}->can("name"))?$a{collection}->name:"$a{collection}";
+    $TOTAL++ if ($ON && $n =~ /(?:^|\.)nodes$/);
+    return $orig->(@_); }; }
+
+my $node = $nmisng->node(name => $ARGV[0] // "realnode188") or die "node not found\n";
+$ON = 1; $node->collect(wantsnmp=>1, wantwmi=>0, force=>1); $ON = 0;
+print "nodes-collection finds during collect: $TOTAL\n";

--- a/test/t_plugin_nodeobj_realnode.pl
+++ b/test/t_plugin_nodeobj_realnode.pl
@@ -1,10 +1,20 @@
 #!/usr/bin/perl
-# Throwaway acceptance measurement: count nodes-collection finds during a real collect.
-# Run on this branch (fixed) and on an unmodified origin/nmis9_dev checkout (baseline)
+# Throwaway acceptance measurement: count nodes-collection finds during a real collect,
 # to show the node_obj change removes the redundant per-save node re-resolves.
-# Usage: perl test/t_plugin_nodeobj_realnode.pl [nodename]
+#
+# OPT-IN ONLY. This performs a real SNMP collect against a live node, so it is skipped
+# by default and stays inert under broad runs such as `prove test/t_*.pl`. To run it,
+# name the node via the NMIS_REALNODE env var:
+#   NMIS_REALNODE=realnode188 perl test/t_plugin_nodeobj_realnode.pl
+# Compare the printed count against the same node on an unmodified origin/nmis9_dev checkout.
 use strict; use warnings;
 use FindBin; use lib "$FindBin::Bin/lib"; use lib "$FindBin::Bin/../lib";
+use Test::More;
+
+my $nodename = $ENV{NMIS_REALNODE};
+plan skip_all => "real-node acceptance measurement; set NMIS_REALNODE=<nodename> to run"
+	unless $nodename;
+
 use NMISNG; use NMISNG::Util; use NMISNG::Log; use NMISNG::DB; use Compat::NMIS;
 
 my $C = NMISNG::Util::loadConfTable();
@@ -17,6 +27,8 @@ my $TOTAL = 0; my $ON = 0; my $orig = \&NMISNG::DB::find;
     $TOTAL++ if ($ON && $n =~ /(?:^|\.)nodes$/);
     return $orig->(@_); }; }
 
-my $node = $nmisng->node(name => $ARGV[0] // "realnode188") or die "node not found\n";
+my $node = $nmisng->node(name => $nodename) or BAIL_OUT("node $nodename not found");
 $ON = 1; $node->collect(wantsnmp=>1, wantwmi=>0, force=>1); $ON = 0;
-print "nodes-collection finds during collect: $TOTAL\n";
+diag("nodes-collection finds during collect: $TOTAL");
+ok(1, "collect completed for $nodename ($TOTAL nodes-collection finds)");
+done_testing;

--- a/test/t_plugin_nodeobj_realnode.pl
+++ b/test/t_plugin_nodeobj_realnode.pl
@@ -15,7 +15,10 @@ my $nodename = $ENV{NMIS_REALNODE};
 plan skip_all => "real-node acceptance measurement; set NMIS_REALNODE=<nodename> to run"
 	unless $nodename;
 
-use NMISNG; use NMISNG::Util; use NMISNG::Log; use NMISNG::DB; use Compat::NMIS;
+# Loaded only when opted in. These pull the full NMIS stack (and deps such as boolean.pm),
+# so we require() them AFTER the skip above — a compile-time `use` would load them before the
+# skip can fire and break the default skip where those deps are absent (e.g. broad prove runs).
+require NMISNG; require NMISNG::Util; require NMISNG::Log; require NMISNG::DB; require Compat::NMIS;
 
 my $C = NMISNG::Util::loadConfTable();
 my $nmisng = NMISNG->new(config=>$C, log=>NMISNG::Log->new(level=>'error'));


### PR DESCRIPTION
## Goal

Stop collect/update plugins from forcing NMIS to re-fetch the node from MongoDB on every inventory save. The already-loaded `NMISNG::Node` object is now passed into plugins as a new additive `node_obj` argument, and in-tree plugins use it instead of re-resolving the node.

## Background

When a plugin calls `$inventory->save(node => $name)` with a name **string**, `Inventory::save` cannot use it and re-resolves the node from the `nodes` collection — two finds per save (a `get_nodes_model` lookup plus a `Node::new`/`_load`). Many plugins also re-resolved the node themselves via `$NG->node(name => $node)`. On a real net-snmp node this added up to dozens of redundant `nodes` finds per collect.

## Change

- **`lib/NMISNG/Node.pm`** — added `node_obj => $self` (the node being collected) to the three per-node plugin dispatchers: `collect_plugin`, `update_plugin`, and the health-index/`custom_health` hook. The existing `node => $name` string argument is **kept** for backward compatibility, so external/custom plugins that don't know `node_obj` keep working unchanged.
- **`conf-default/plugins/` (30 files)** — in-tree plugins now:
  - `save( node => $node_obj )` instead of `save( node => $node )` (41 save sites, 14 plugins), preserving every other save argument (e.g. `update => 1`);
  - use `node_obj` in place of their own `$NG->node(name => $node)` re-resolve of the **current** node (18 calls, 16 plugins).
  - Calls that resolve a **different** node (RadwinWireless `hsuName`, VirtMachines `vmName`, cdpTable remote-by-uuid) were deliberately left unchanged.
- **`test/t_plugin_nodeobj.pl`** — new test: the save invariant (object => 0 `nodes` finds; name string => ≥1), the dispatcher wiring (a stub plugin receives `node_obj` as an `NMISNG::Node` while `node` stays the name string), and a static source guard that scans every plugin and fails for any remaining bare-name `save`/re-resolve.
- **`test/t_plugin_nodeobj_realnode.pl`** — throwaway manual acceptance measurement (needs a live net-snmp node).

## Verification

- `test/t_plugin_nodeobj.pl`: 73/73 passing (invariant + wiring + guard across all in-tree plugins).
- All 30 changed plugin files compile (`perl -Ilib -c` → `syntax OK`).
- Real-node acceptance on a net-snmp node (18 interfaces, ~16 Host_Resources inventories), same db/node/SNMP source with only the code swapped:
  - baseline (`nmis9_dev`): **57** `nodes`-collection finds during one collect
  - this branch: **19** — **38 redundant plugin re-resolve finds eliminated (~67%)**
  - collect still succeeds and writes the same data (inventory unchanged).

## Notes / out of scope

This is an additive, behaviour-preserving performance change. A few pre-existing dead-code spots surfaced during review (F5BigIP unused `$nodeobj`, a duplicate args block in ZyxelInterface, a duplicate `my ($op,$error)` in ciscoMemory) were faithfully preserved and are better addressed in a separate non-functional cleanup. Health-index hook plugins that live in model files (not `conf-default/plugins/`) are not touched here; the dispatcher is wired for them as a follow-up.