### PR TITLE
OMK-12375. Defer Mojo::UserAgent load in NMISNG::RPC.

### DIFF
--- a/lib/NMISNG/RPC.pm
+++ b/lib/NMISNG/RPC.pm
@@ -5,13 +5,19 @@ our $VERSION = "9.4.8";
 use Mojo::Base -base;
 use Carp;
 use JSON::XS;
-use Mojo::UserAgent;
 use Try::Tiny;
 
+# Mojo::UserAgent is deliberately NOT loaded at compile time. It pulls in the
+# full Mojo IOLoop/transactor/TLS stack (~7-8 MB RSS) which every nmisd worker
+# would otherwise inherit via NMISNG::Sys -> NMISNG::Engine::SnmpRPC, even
+# though only the (non-default) SNMP-over-RPC engine ever needs it. Loading it
+# lazily in the ua builder keeps it out of the baseline for the common case of
+# direct Net::SNMP polling.
 #Wraps Mojo user agent to make JSON-RPC 2.0 requests, inspired by MojoX::JSONRPC2::HTTP;
 #We will need a long requesttime out for large snmp requests
 use constant REQUEST_TIMEOUT    => 300;
 has ua  => sub {
+    require Mojo::UserAgent;
     Mojo::UserAgent->new
         ->inactivity_timeout(0)
         ->request_timeout(REQUEST_TIMEOUT)


### PR DESCRIPTION
Every nmisd worker loads NMISNG::Sys, which pulls in NMISNG::Engine::SnmpRPC and hence NMISNG::RPC. That module did 'use Mojo::UserAgent' at compile time, dragging the full Mojo IOLoop/transactor/TLS stack (~7.5 MB RSS) into every worker's baseline, even though only the non-default SNMP-over-RPC engine ever instantiates a user agent. Standard direct Net::SNMP polling never needs it.

Move the load into the lazy 'ua' attribute builder via require, so Mojo::UserAgent is pulled in only when an RPC client actually builds its user agent. Measured worker-stack startup RSS drops from ~128.0 MB to ~120.3 MB with no behaviour change (verified the ua builder still returns a working Mojo::UserAgent).