### PR TITLE
OMK-12666 : persist nodeModel/nodeType/nodegraph for collect=false nodes

### DIFF
--- a/lib/NMISNG/Node.pm
+++ b/lib/NMISNG/Node.pm
@@ -2427,18 +2427,16 @@ sub update_node_info
 		$self->nmisng->log->debug2(sub {"node $S->{name} is marked collect is 'false'"});
 		# Without this, collect=false nodes never persist their resolved model (PingOnly,
 		# ServiceOnly) into catchall, so opCharts reads stale or default nodeModel/nodegraph.
-		# Write directly to $catchall_inventory (the object Node.pm saves) rather than via
+		# Write directly to $catchall_data (the live ref Node.pm saves) rather than via
 		# copyModelCfgInfo, which writes to the Sys cache — a different object when force=1
 		# clears the catchall and triggers a MongoDB re-fetch through sync_catchall.
 		# Guard: Sys::init may load the bare "Model" fallback when ping=false and no services
 		# are configured; skip in that case to avoid writing nodeModel="Model" into catchall.
-		my $_mdl_nm = $S->{mdl}{system}{nodeModel} // '';
-		if ($_mdl_nm && $_mdl_nm ne 'Model') {
-			my $_cd = $catchall_inventory->data_live();
-			$_cd->{nodeModel} = $_mdl_nm;
-			$_cd->{nodeType}  = $S->{mdl}{system}{nodeType} if $S->{mdl}{system}{nodeType};
-			my @_graphs = split /,/, $S->{mdl}{system}{nodegraph} // '';
-			$_cd->{nodegraph} = \@_graphs if (@_graphs && $_graphs[0] ne '');
+		my $cfgmodel = $S->{mdl}{system}{nodeModel} // '';
+		if ($cfgmodel && $cfgmodel ne 'Model') {
+			$catchall_data->{nodeModel} = $cfgmodel;
+			my @nodegraphs = split /,/, $S->{mdl}{system}{nodegraph} // '';
+			$catchall_data->{nodegraph} = \@nodegraphs if @nodegraphs;
 		}
 		$success = 1;                # done
 	}

--- a/lib/NMISNG/Node.pm
+++ b/lib/NMISNG/Node.pm
@@ -2425,6 +2425,21 @@ sub update_node_info
 	else
 	{
 		$self->nmisng->log->debug2(sub {"node $S->{name} is marked collect is 'false'"});
+		# Without this, collect=false nodes never persist their resolved model (PingOnly,
+		# ServiceOnly) into catchall, so opCharts reads stale or default nodeModel/nodegraph.
+		# Write directly to $catchall_inventory (the object Node.pm saves) rather than via
+		# copyModelCfgInfo, which writes to the Sys cache — a different object when force=1
+		# clears the catchall and triggers a MongoDB re-fetch through sync_catchall.
+		# Guard: Sys::init may load the bare "Model" fallback when ping=false and no services
+		# are configured; skip in that case to avoid writing nodeModel="Model" into catchall.
+		my $_mdl_nm = $S->{mdl}{system}{nodeModel} // '';
+		if ($_mdl_nm && $_mdl_nm ne 'Model') {
+			my $_cd = $catchall_inventory->data_live();
+			$_cd->{nodeModel} = $_mdl_nm;
+			$_cd->{nodeType}  = $S->{mdl}{system}{nodeType} if $S->{mdl}{system}{nodeType};
+			my @_graphs = split /,/, $S->{mdl}{system}{nodegraph} // '';
+			$_cd->{nodegraph} = \@_graphs if (@_graphs && $_graphs[0] ne '');
+		}
 		$success = 1;                # done
 	}
 

--- a/test/t_polling.pl
+++ b/test/t_polling.pl
@@ -1071,6 +1071,51 @@ else {
 }
 
 # ============================================================
+# Phase 11b: collect=false node — nodeModel and nodegraph persisted
+# ============================================================
+diag("=== Phase 11b: collect=false nodeModel/nodegraph persistence ===");
+
+# A PingOnly node has collect=false. update_node_info takes the else branch and
+# must write nodeModel and nodegraph directly into catchall_data so opCharts can
+# read them without requiring a collect=true run.
+my $ping_node = NMISNG::Node->new(uuid => NMISNG::Util::getUUID(), nmisng => $nmisng);
+$ping_node->cluster_id($C->{cluster_id});
+$ping_node->name("test_pingonly_node");
+$ping_node->configuration({
+	host     => "127.0.0.1",
+	group    => "TestGroup",
+	netType  => "default",
+	roleType => "default",
+	model    => "PingOnly",
+	collect  => "false",
+	ping     => "true",
+});
+($op, $err) = $ping_node->save();
+ok(!$err, "PingOnly test node saved") or diag("Save error: $err");
+
+my ($ping_catchall_inv, $ping_cinv_err) = $ping_node->inventory(concept => "catchall", model_class => "system");
+ok(!$ping_cinv_err, "PingOnly catchall inventory created") or diag("Error: $ping_cinv_err");
+
+my $SP = NMISNG::Sys->new(nmisng => $nmisng);
+$SP->init(
+	node               => $ping_node,
+	snmp               => 0,
+	wmi                => 0,
+	update             => 'true',
+	force              => 1,
+	catchall_inventory => $ping_catchall_inv,
+);
+
+my $ping_result = $ping_node->update_node_info(sys => $SP, catchall_inventory => $ping_catchall_inv);
+ok($ping_result->{success}, "update_node_info succeeded for collect=false node")
+	or diag("Result: " . Dumper($ping_result));
+
+my $pcd = $ping_catchall_inv->data_live();
+is($pcd->{nodeModel}, "PingOnly", "collect=false: nodeModel persisted as PingOnly");
+is_deeply($pcd->{nodegraph}, ["health-ping", "response"],
+	"collect=false: nodegraph persisted as [health-ping, response]");
+
+# ============================================================
 # Phase 12: Cleanup
 # ============================================================
 diag("=== Phase 12: Cleanup ===");


### PR DESCRIPTION
Nodes marked collect=false (PingOnly, ServiceOnly) never had their
resolved model written into the catchall inventory document. The fix
writes directly to $catchall_inventory->data_live() in the collect=false
branch of update_node_info, bypassing the Sys cache ref divergence that
occurs when force=1 triggers sync_catchall. A guard skips the bare
"Model" fallback (ping=false nodes with no services configured) to avoid
writing nodeModel="Model" into catchall.