### PR TITLE
Model reduce diff

### DIFF
--- a/admin/reduce_model.pl
+++ b/admin/reduce_model.pl
@@ -126,31 +126,47 @@ sub apply_changes
 	my $backup = "$custom_dir/.reduce-backup-$ts";
 	make_path($backup);
 
+	my @changed;
+	my @skipped;
 	for my $r (@todo)
 	{
 		my $file = "$custom_dir/$r->{basename}.nmis";
 		if (!copy($file, "$backup/$r->{basename}.nmis"))
 		{
 			warn "backup failed for $file: $! - skipping\n";
+			push @skipped, $r->{basename};
 			next;
 		}
 		if ($r->{category} eq "reducible")
 		{
 			local $Data::Dumper::Sortkeys = 1;
-			my $werr = NMISNG::Util::writeHashtoFile(file => "$custom_dir/Override-$r->{basename}.nmis",
-				data => $r->{override}, json => 0, conf => $C);
-			if ($werr)
+			my $ovpath = "$custom_dir/Override-$r->{basename}.nmis";
+			NMISNG::Util::writeHashtoFile(file => $ovpath, data => $r->{override}, json => 0, conf => $C);
+			# writeHashtoFile can return a non-fatal error (e.g. a failed chown to
+			# the "nmis" user) even when the content was written correctly, so trust
+			# the on-disk content, not the return value: only skip removal if the
+			# override is missing or does not match what we intended to write.
+			my $check = NMISNG::Util::readFiletoHash(file => $ovpath);
+			if (ref($check) ne "HASH" || !NMISNG::ModelReduce::deep_equal($check, $r->{override}))
 			{
-				warn "override write FAILED for $r->{basename}: $werr - copy NOT removed\n";
+				warn "override write FAILED for $r->{basename} (on-disk content mismatch) - copy NOT removed\n";
+				push @skipped, $r->{basename};
 				next;
 			}
 		}
 		if (!unlink($file))
 		{
 			warn "could not remove $file: $! - override written but copy remains\n";
+			push @skipped, $r->{basename};
 			next;
 		}
+		push @changed, $r->{basename};
 		print "changed: $r->{basename} ($r->{category})\n";
+	}
+	if (@skipped)
+	{
+		print "\nNOTE: " . scalar(@skipped) . " file(s) were NOT reduced (see warnings above): "
+			. join(", ", @skipped) . "\n";
 	}
 
 	# clear affected model cache entries
@@ -166,19 +182,28 @@ sub apply_changes
 
 	# post-apply guard: recompile and compare against the snapshot
 	my $snap_var2 = "$scratch/snap-after"; make_path("$snap_var2/nmis_system/model_cache");
-	my $failed = 0;
+	my @mismatched;
 	for my $m (sort keys %before)
 	{
 		my $after = NMISNG::ModelReduce::compile_model(model=>$m, config=>$C,
 			default_dir=>$default_dir, custom_dir=>$custom_dir, var_dir=>$snap_var2);
-		if (!NMISNG::ModelReduce::deep_equal($before{$m}, $after))
-		{
-			warn "POST-APPLY MISMATCH on $m - restore from $backup\n";
-			$failed++;
-		}
+		push @mismatched, $m if (!NMISNG::ModelReduce::deep_equal($before{$m}, $after));
 	}
-	if ($failed) { print "\nWARNING: $failed model(s) mismatched after apply. Backup: $backup\n"; }
-	else { print "\nDone. All affected models compile identically. Backup: $backup\n"; }
+	if (@mismatched)
+	{
+		print "\n*** WARNING: post-apply check FAILED for " . scalar(@mismatched)
+			. " model(s): " . join(", ", @mismatched) . "\n";
+		print "*** The compiled model changed - this should not happen. Restore the originals:\n";
+		print "***   cp -f \"$backup\"/*.nmis \"$custom_dir\"/\n";
+		print "*** then remove the overrides written this run:\n";
+		print "***   rm -f" . join("", map { " \"$custom_dir/Override-$_->{basename}.nmis\"" }
+			grep { $_->{category} eq "reducible" } @todo) . "\n";
+		print "*** Backups are in $backup\n";
+	}
+	else
+	{
+		print "\nDone: reduced " . scalar(@changed) . " file(s). All affected models compile identically. Backup: $backup\n";
+	}
 	return;
 }
 

--- a/admin/reduce_model.pl
+++ b/admin/reduce_model.pl
@@ -91,6 +91,103 @@ sub report
 	}
 }
 
+sub apply_changes
+{
+	my ($results, $custom_dir, $C) = @_;
+
+	my @todo = grep { $_->{verified}
+			&& ($_->{category} eq "identical" || $_->{category} eq "reducible") } @$results;
+	if (!@todo)
+	{
+		print "\nNothing to apply.\n";
+		return;
+	}
+
+	# snapshot compiled models BEFORE any change (real dirs, isolated var)
+	my $default_dir = $arg->{default_dir} // NMISNG::Util::getDir(dir => "default_models", conf => $C);
+	my $snap_var = "$scratch/snap-before"; make_path("$snap_var/nmis_system/model_cache");
+	my %before;
+	for my $r (@todo)
+	{
+		for my $m (affected_models($r, $custom_dir, $default_dir))
+		{
+			$before{$m} //= NMISNG::ModelReduce::compile_model(model=>$m, config=>$C,
+				default_dir=>$default_dir, custom_dir=>$custom_dir, var_dir=>$snap_var);
+		}
+	}
+
+	print "\nAbout to change " . scalar(@todo) . " file(s) in $custom_dir\n";
+	print "A backup of each removed copy is written first.\n";
+	print "Type 'yes' to proceed: ";
+	my $answer = <STDIN> // ""; chomp($answer);
+	if (lc($answer) ne "yes") { print "Aborted, no changes made.\n"; return; }
+
+	my $ts = _timestamp();
+	my $backup = "$custom_dir/.reduce-backup-$ts";
+	make_path($backup);
+
+	for my $r (@todo)
+	{
+		my $file = "$custom_dir/$r->{basename}.nmis";
+		if (!copy($file, "$backup/$r->{basename}.nmis"))
+		{
+			warn "backup failed for $file: $! - skipping\n";
+			next;
+		}
+		if ($r->{category} eq "reducible")
+		{
+			local $Data::Dumper::Sortkeys = 1;
+			NMISNG::Util::writeHashtoFile(file => "$custom_dir/Override-$r->{basename}.nmis",
+				data => $r->{override}, json => 0, conf => $C);
+		}
+		unlink($file) or warn "could not remove $file: $!\n";
+		print "changed: $r->{basename} ($r->{category})\n";
+	}
+
+	# clear affected model cache entries
+	my $cachedir = $C->{'<nmis_var>'} . "/nmis_system/model_cache";
+	for my $r (@todo)
+	{
+		for my $m (affected_models($r, $custom_dir, $default_dir))
+		{
+			unlink("$cachedir/$m.json");
+			unlink("$cachedir/$m.json.meta.json");
+		}
+	}
+
+	# post-apply guard: recompile and compare against the snapshot
+	my $snap_var2 = "$scratch/snap-after"; make_path("$snap_var2/nmis_system/model_cache");
+	my $failed = 0;
+	for my $m (sort keys %before)
+	{
+		my $after = NMISNG::ModelReduce::compile_model(model=>$m, config=>$C,
+			default_dir=>$default_dir, custom_dir=>$custom_dir, var_dir=>$snap_var2);
+		if (!NMISNG::ModelReduce::deep_equal($before{$m}, $after))
+		{
+			warn "POST-APPLY MISMATCH on $m - restore from $backup\n";
+			$failed++;
+		}
+	}
+	if ($failed) { print "\nWARNING: $failed model(s) mismatched after apply. Backup: $backup\n"; }
+	else { print "\nDone. All affected models compile identically. Backup: $backup\n"; }
+	return;
+}
+
+sub affected_models
+{
+	my ($r, $custom_dir, $default_dir) = @_;
+	return ($r->{basename}) if ($r->{basename} =~ /^Model-/);
+	my $feature = $r->{basename}; $feature =~ s/^Common-//;
+	return NMISNG::ModelReduce::models_referencing_common($feature, $custom_dir, $default_dir);
+}
+
+sub _timestamp
+{
+	my @t = localtime();
+	return sprintf("%04d%02d%02d-%02d%02d%02d",
+		$t[5]+1900, $t[4]+1, $t[3], $t[2], $t[1], $t[0]);
+}
+
 sub usage
 {
 	print <<EOF;

--- a/admin/reduce_model.pl
+++ b/admin/reduce_model.pl
@@ -137,10 +137,19 @@ sub apply_changes
 		if ($r->{category} eq "reducible")
 		{
 			local $Data::Dumper::Sortkeys = 1;
-			NMISNG::Util::writeHashtoFile(file => "$custom_dir/Override-$r->{basename}.nmis",
+			my $werr = NMISNG::Util::writeHashtoFile(file => "$custom_dir/Override-$r->{basename}.nmis",
 				data => $r->{override}, json => 0, conf => $C);
+			if ($werr)
+			{
+				warn "override write FAILED for $r->{basename}: $werr - copy NOT removed\n";
+				next;
+			}
 		}
-		unlink($file) or warn "could not remove $file: $!\n";
+		if (!unlink($file))
+		{
+			warn "could not remove $file: $! - override written but copy remains\n";
+			next;
+		}
 		print "changed: $r->{basename} ($r->{category})\n";
 	}
 

--- a/admin/reduce_model.pl
+++ b/admin/reduce_model.pl
@@ -1,0 +1,106 @@
+#!/usr/bin/perl
+#
+#  reduce_model.pl - replace full custom model copies with Override-*.nmis files
+#  when the compiled model is provably unchanged. Dry run by default.
+#
+#  Copyright (C) Opmantek Limited (www.opmantek.com)
+#  This file is part of Network Management Information System ("NMIS").
+#  NMIS is free software: licensed under the GNU General Public License v3+.
+#
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+
+use strict;
+use warnings;
+use Data::Dumper;
+use File::Path qw(make_path);
+use File::Copy qw(copy);
+
+use NMISNG::Util;
+use NMISNG::ModelReduce;
+
+my $arg = NMISNG::Util::get_args_multi(@ARGV);
+
+if (NMISNG::Util::getbool($arg->{help}) || (defined $arg->{help}))
+{
+	usage();
+	exit 0;
+}
+
+my $C = NMISNG::Util::loadConfTable();
+die "cannot load NMIS config\n" if (ref($C) ne "HASH" || !%$C);
+
+my $custom_dir  = $arg->{dir}         // NMISNG::Util::getDir(dir => "models",        conf => $C);
+my $default_dir = $arg->{default_dir} // NMISNG::Util::getDir(dir => "default_models", conf => $C);
+my $apply       = NMISNG::Util::getbool($arg->{apply});
+my $verbose     = NMISNG::Util::getbool($arg->{verbose});
+my $scratch     = $arg->{scratch} // (($ENV{TMPDIR} || "/tmp") . "/model-reduce-$$");
+
+die "custom dir not found: $custom_dir\n"  if (!-d $custom_dir);
+die "default dir not found: $default_dir\n" if (!-d $default_dir);
+make_path($scratch) if (!-d $scratch);
+
+print "Custom  dir: $custom_dir\n";
+print "Default dir: $default_dir\n";
+print "Scratch dir: $scratch\n";
+print "Mode       : " . ($apply ? "APPLY" : "dry run (no changes)") . "\n\n";
+
+my $results = NMISNG::ModelReduce::analyse(
+	custom_dir => $custom_dir, default_dir => $default_dir,
+	config => $C, only => $arg->{model});
+
+report($results);
+
+# write proposed + manual-start overrides into scratch for inspection
+for my $r (@$results)
+{
+	next if (!defined $r->{override});
+	my $tag = ($r->{category} eq "drift") ? "manual-start" : "proposed";
+	my $out = "$scratch/Override-$r->{basename}.$tag.nmis";
+	local $Data::Dumper::Sortkeys = 1;
+	NMISNG::Util::writeHashtoFile(file => $out, data => $r->{override}, json => 0, conf => $C);
+}
+print "\nProposed override files written under $scratch\n";
+
+if ($apply)
+{
+	apply_changes($results, $custom_dir, $C);
+}
+else
+{
+	my @todo = grep { $_->{verified} && ($_->{category} eq "identical" || $_->{category} eq "reducible") } @$results;
+	print "\n" . scalar(@todo) . " file(s) would be changed. Re-run with apply=1 to apply.\n";
+}
+
+sub report
+{
+	my ($results) = @_;
+	printf("%-34s %-16s %s\n", "FILE", "OUTCOME", "DETAIL");
+	printf("%-34s %-16s %s\n", "----", "-------", "------");
+	for my $r (sort { $a->{basename} cmp $b->{basename} } @$results)
+	{
+		my $detail = "";
+		if ($r->{category} eq "reducible") { $detail = "override + remove copy (verified)"; }
+		elsif ($r->{category} eq "identical") { $detail = "remove copy, no override (verified)"; }
+		elsif ($r->{category} eq "drift")
+		{
+			$detail = "kept; default adds: " . join(", ", @{$r->{drops} // []});
+		}
+		elsif ($r->{category} eq "error") { $detail = $r->{error} // "error"; }
+		printf("%-34s %-16s %s\n", $r->{basename}, $r->{category}, $detail);
+	}
+}
+
+sub usage
+{
+	print <<EOF;
+Usage: $0 [dir=<models-custom>] [default_dir=<models-default>] [model=<Name>]
+          [scratch=<dir>] [apply=1] [verbose=1]
+
+Dry run by default. Replaces full custom model copies with Override-*.nmis
+files when the compiled model is provably unchanged. Removes copies that are
+already identical to the default. Reports copies that drifted from a newer
+default without changing them.
+EOF
+	return;
+}

--- a/docs/model-loading.md
+++ b/docs/model-loading.md
@@ -51,6 +51,16 @@ The point of override files is to let users customize part of a model without ta
 
 These are the right tool when the customization is specific to one model or one Common.
 
+### Automating the reduction
+
+`admin/reduce_model.pl` automates converting full custom copies into
+`Override-*.nmis` files. It runs read-only by default, classifies each custom
+Model or Common file as identical, reducible, or drifted, and verifies every
+proposed change by compiling the model both ways with the real loader. Pass
+`apply=1` to write the overrides and remove the reduced copies (each copy is
+backed up first). Graph files and files with no default counterpart are
+reported and left alone. See the header of the script for full arguments.
+
 ### Global overrides (`global_model_overrides`)
 
 An array config setting that names override files applied to every model load:

--- a/docs/superpowers/plans/2026-07-07-model-reduce-diff.md
+++ b/docs/superpowers/plans/2026-07-07-model-reduce-diff.md
@@ -1,0 +1,1389 @@
+# Model reduce-to-override tool Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build an admin tool that replaces full custom model copies with small `Override-*.nmis` files whenever it can prove the compiled model is unchanged, and reports the copies it cannot safely reduce.
+
+**Architecture:** A pure-logic module (`lib/NMISNG/ModelReduce.pm`) does the semantic diff, classification, override construction, and loader-based verification. A thin CLI (`admin/reduce_model.pl`) resolves directories from config, orchestrates, reports, and performs the guarded apply step. Verification drives the real `NMISNG::Sys::loadModel` in temporary directories, so it needs no git, MongoDB, or SNMP.
+
+**Tech Stack:** Perl 5, `NMISNG::Util` (`readFiletoHash`, `writeHashtoFile`, `get_args_multi`, `getDir`, `loadConfTable`), `NMISNG::Sys` (`loadModel`, `_mergeHash`), `Clone`, `Test::More`, `Test::Deep`, `File::Temp`, `File::Path`, `Data::Dumper`.
+
+## Global Constraints
+
+- Boolean values use the `boolean` CPAN module. Do NOT use the `-truth` flag.
+- All scripts find `lib/` via `use FindBin; use lib "$FindBin::Bin/../lib";`.
+- `.nmis` files are Perl `%hash = ( ... );` text. Read with `NMISNG::Util::readFiletoHash(file => ...)` (returns a hashref, or an error string on failure). Write with `NMISNG::Util::writeHashtoFile(file => ..., data => ..., json => 0)`.
+- The override merge (`NMISNG::Sys::_mergeHash`) only adds keys or overwrites values, replaces arrays wholesale, has no delete verb, and fails if a base hash key is overwritten by a non-hash. The tool must never rely on deleting a base key.
+- Override discovery covers only `Override-Model-<name>.nmis` and `Override-Common-<feature>.nmis`. Graph files have no override path.
+- The tool runs on customer servers with no git. No git, ancestor recovery, or rebasing.
+- Dry run is the default. Nothing under the target directory changes without `apply=1`. Never remove a file without a successful backup first.
+- Argument style is `key=value`, parsed with `NMISNG::Util::get_args_multi(@ARGV)`.
+- Do not commit the dev-server sample. Tests build synthetic fixtures in temp dirs.
+
+---
+
+### Task 1: Module skeleton and deep-equal helper
+
+**Files:**
+- Create: `lib/NMISNG/ModelReduce.pm`
+- Test: `test/t_reduce_model.pl`
+
+**Interfaces:**
+- Produces: `NMISNG::ModelReduce::deep_equal($a, $b)` returns 1 if two Perl structures are deeply equal (handles scalars, arrayrefs, hashrefs, and undef), else 0.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/t_reduce_model.pl`:
+
+```perl
+#!/usr/bin/perl
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use Test::More;
+use NMISNG::ModelReduce;
+
+# deep_equal
+ok(NMISNG::ModelReduce::deep_equal(1, 1), "scalars equal");
+ok(!NMISNG::ModelReduce::deep_equal(1, 2), "scalars differ");
+ok(NMISNG::ModelReduce::deep_equal("a", "a"), "strings equal");
+ok(NMISNG::ModelReduce::deep_equal([1,2,3], [1,2,3]), "arrays equal");
+ok(!NMISNG::ModelReduce::deep_equal([1,2], [1,2,3]), "arrays differ by length");
+ok(!NMISNG::ModelReduce::deep_equal([1,2,3], [1,9,3]), "arrays differ by element");
+ok(NMISNG::ModelReduce::deep_equal({a=>1,b=>{c=>2}}, {b=>{c=>2},a=>1}),
+   "nested hashes equal regardless of key order");
+ok(!NMISNG::ModelReduce::deep_equal({a=>1}, {a=>1,b=>2}), "hashes differ by key");
+ok(NMISNG::ModelReduce::deep_equal(undef, undef), "both undef equal");
+ok(!NMISNG::ModelReduce::deep_equal(undef, 1), "undef vs value differ");
+ok(!NMISNG::ModelReduce::deep_equal({a=>1}, [1]), "hash vs array differ");
+
+done_testing();
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `perl test/t_reduce_model.pl`
+Expected: FAIL, `Can't locate NMISNG/ModelReduce.pm`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `lib/NMISNG/ModelReduce.pm`:
+
+```perl
+package NMISNG::ModelReduce;
+#
+#  Reduce full custom model copies to Override-*.nmis files when the compiled
+#  model is provably unchanged. Pure logic plus a loader-based verifier.
+#
+use strict;
+use warnings;
+
+our $VERSION = "9.6.5";
+
+# deep_equal($a, $b): true if two Perl structures are deeply equal.
+sub deep_equal
+{
+	my ($a, $b) = @_;
+
+	return 1 if (!defined $a && !defined $b);
+	return 0 if (!defined $a || !defined $b);
+
+	my $ta = ref($a);
+	my $tb = ref($b);
+	return 0 if ($ta ne $tb);
+
+	if ($ta eq "")
+	{
+		return ($a eq $b) ? 1 : 0;
+	}
+	elsif ($ta eq "ARRAY")
+	{
+		return 0 if (scalar(@$a) != scalar(@$b));
+		for my $i (0 .. $#$a)
+		{
+			return 0 if (!deep_equal($a->[$i], $b->[$i]));
+		}
+		return 1;
+	}
+	elsif ($ta eq "HASH")
+	{
+		return 0 if (scalar(keys %$a) != scalar(keys %$b));
+		for my $k (keys %$a)
+		{
+			return 0 if (!exists $b->{$k});
+			return 0 if (!deep_equal($a->{$k}, $b->{$k}));
+		}
+		return 1;
+	}
+	# any other ref type (Regexp, code, etc): compare stringified
+	return ("$a" eq "$b") ? 1 : 0;
+}
+
+1;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `perl test/t_reduce_model.pl`
+Expected: PASS, all deep_equal assertions ok.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/NMISNG/ModelReduce.pm test/t_reduce_model.pl
+git commit -m "feat(model-reduce): add ModelReduce module with deep_equal helper"
+```
+
+---
+
+### Task 2: Semantic diff
+
+**Files:**
+- Modify: `lib/NMISNG/ModelReduce.pm`
+- Test: `test/t_reduce_model.pl`
+
+**Interfaces:**
+- Consumes: `deep_equal`.
+- Produces: `NMISNG::ModelReduce::semantic_diff($default, $custom)` returns a hashref
+  `{ set => [ {path=>[k,...], value=>$v}, ... ], drop => [ {path=>[k,...]}, ... ], typeconflict => [ {path=>[k,...]}, ... ] }`.
+  - `set`: key present in custom with a value the default lacks or differs from, and representable by the merge (custom is not blocked by a base-hash conflict). Value is the whole custom value at that key.
+  - `drop`: key present in the default but absent in custom (blocks byte-identical reduction).
+  - `typeconflict`: key present in both where the default value is a hash and the custom value is not (the merge would fail).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/t_reduce_model.pl` before `done_testing();`:
+
+```perl
+# semantic_diff
+{
+	my $d = NMISNG::ModelReduce::semantic_diff({a=>1}, {a=>1});
+	is_deeply($d, {set=>[],drop=>[],typeconflict=>[]}, "identical -> empty diff");
+}
+{
+	# added key (custom only)
+	my $d = NMISNG::ModelReduce::semantic_diff({a=>1}, {a=>1, b=>2});
+	is_deeply($d->{set}, [{path=>["b"], value=>2}], "added key -> set");
+	is_deeply($d->{drop}, [], "added key -> no drop");
+}
+{
+	# changed leaf
+	my $d = NMISNG::ModelReduce::semantic_diff({a=>1}, {a=>5});
+	is_deeply($d->{set}, [{path=>["a"], value=>5}], "changed leaf -> set custom value");
+}
+{
+	# dropped key (default only)
+	my $d = NMISNG::ModelReduce::semantic_diff({a=>1, b=>2}, {a=>1});
+	is_deeply($d->{drop}, [{path=>["b"]}], "default-only key -> drop");
+	is_deeply($d->{set}, [], "dropped key -> no set");
+}
+{
+	# array replaced wholesale (any difference -> whole array as set)
+	my $d = NMISNG::ModelReduce::semantic_diff({a=>[1,2,3]}, {a=>[1,2]});
+	is_deeply($d->{set}, [{path=>["a"], value=>[1,2]}], "array diff -> whole custom array");
+}
+{
+	# nested add under a shared hash
+	my $d = NMISNG::ModelReduce::semantic_diff(
+		{'-common-'=>{class=>{a=>{'common-model'=>'a'}}}},
+		{'-common-'=>{class=>{a=>{'common-model'=>'a'}, b=>{'common-model'=>'b'}}}});
+	is_deeply($d->{set}, [{path=>['-common-','class','b'], value=>{'common-model'=>'b'}}],
+		"nested add -> single set at the new key");
+}
+{
+	# type conflict: base hash, custom scalar
+	my $d = NMISNG::ModelReduce::semantic_diff({a=>{x=>1}}, {a=>5});
+	is_deeply($d->{typeconflict}, [{path=>["a"]}], "hash-over-scalar -> typeconflict");
+	is_deeply($d->{set}, [], "type conflict -> no set");
+}
+{
+	# custom hash over base scalar is representable (set)
+	my $d = NMISNG::ModelReduce::semantic_diff({a=>5}, {a=>{x=>1}});
+	is_deeply($d->{set}, [{path=>["a"], value=>{x=>1}}], "custom hash over scalar -> set");
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `perl test/t_reduce_model.pl`
+Expected: FAIL, `Undefined subroutine &NMISNG::ModelReduce::semantic_diff`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `lib/NMISNG/ModelReduce.pm` before the final `1;`:
+
+```perl
+# semantic_diff($default, $custom): classify differences. See interface doc.
+sub semantic_diff
+{
+	my ($default, $custom) = @_;
+	my $result = { set => [], drop => [], typeconflict => [] };
+	_diff_walk($default, $custom, [], $result);
+	return $result;
+}
+
+sub _diff_walk
+{
+	my ($default, $custom, $path, $result) = @_;
+
+	# both hashes: recurse over the union of keys
+	if (ref($default) eq "HASH" && ref($custom) eq "HASH")
+	{
+		my %allkeys = map { $_ => 1 } (keys %$default, keys %$custom);
+		for my $k (sort keys %allkeys)
+		{
+			my $subpath = [@$path, $k];
+			my $in_def = exists $default->{$k};
+			my $in_cus = exists $custom->{$k};
+
+			if ($in_def && !$in_cus)
+			{
+				push @{$result->{drop}}, { path => $subpath };
+			}
+			elsif (!$in_def && $in_cus)
+			{
+				push @{$result->{set}}, { path => $subpath, value => $custom->{$k} };
+			}
+			else
+			{
+				_diff_walk($default->{$k}, $custom->{$k}, $subpath, $result);
+			}
+		}
+		return;
+	}
+
+	# base is a hash but custom is not: merge would fail
+	if (ref($default) eq "HASH" && ref($custom) ne "HASH")
+	{
+		push @{$result->{typeconflict}}, { path => $path };
+		return;
+	}
+
+	# leaf, array, or custom-hash-over-base-non-hash: representable, set whole value
+	if (!deep_equal($default, $custom))
+	{
+		push @{$result->{set}}, { path => $path, value => $custom };
+	}
+	return;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `perl test/t_reduce_model.pl`
+Expected: PASS, all semantic_diff assertions ok.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/NMISNG/ModelReduce.pm test/t_reduce_model.pl
+git commit -m "feat(model-reduce): add semantic_diff"
+```
+
+---
+
+### Task 3: Classify
+
+**Files:**
+- Modify: `lib/NMISNG/ModelReduce.pm`
+- Test: `test/t_reduce_model.pl`
+
+**Interfaces:**
+- Consumes: the diff hashref from `semantic_diff`.
+- Produces: `NMISNG::ModelReduce::classify($diff)` returns one of `identical`, `reducible`, `drift`.
+  - `identical`: no set, drop, or typeconflict.
+  - `reducible`: at least one set, and no drop and no typeconflict.
+  - `drift`: at least one drop or typeconflict.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/t_reduce_model.pl` before `done_testing();`:
+
+```perl
+# classify
+is(NMISNG::ModelReduce::classify({set=>[],drop=>[],typeconflict=>[]}),
+   "identical", "no differences -> identical");
+is(NMISNG::ModelReduce::classify({set=>[{path=>["a"],value=>1}],drop=>[],typeconflict=>[]}),
+   "reducible", "sets only -> reducible");
+is(NMISNG::ModelReduce::classify({set=>[{path=>["a"],value=>1}],drop=>[{path=>["b"]}],typeconflict=>[]}),
+   "drift", "any drop -> drift");
+is(NMISNG::ModelReduce::classify({set=>[],drop=>[],typeconflict=>[{path=>["a"]}]}),
+   "drift", "any type conflict -> drift");
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `perl test/t_reduce_model.pl`
+Expected: FAIL, `Undefined subroutine &NMISNG::ModelReduce::classify`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `lib/NMISNG/ModelReduce.pm` before the final `1;`:
+
+```perl
+# classify($diff): identical | reducible | drift
+sub classify
+{
+	my ($diff) = @_;
+	return "drift" if (@{$diff->{drop}} || @{$diff->{typeconflict}});
+	return "reducible" if (@{$diff->{set}});
+	return "identical";
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `perl test/t_reduce_model.pl`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/NMISNG/ModelReduce.pm test/t_reduce_model.pl
+git commit -m "feat(model-reduce): add classify"
+```
+
+---
+
+### Task 4: Build override
+
+**Files:**
+- Modify: `lib/NMISNG/ModelReduce.pm`
+- Test: `test/t_reduce_model.pl`
+
+**Interfaces:**
+- Consumes: the diff hashref from `semantic_diff`.
+- Produces: `NMISNG::ModelReduce::build_override($diff)` returns a hashref reconstructed from the `set` entries only (adds and changes). Nested paths are rebuilt. Values are cloned so the result shares no references with the inputs. `drop` and `typeconflict` entries are ignored (they are not representable). Used both for the real override of a reducible file and for the manual-start override of a drift file.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/t_reduce_model.pl` before `done_testing();`:
+
+```perl
+# build_override
+{
+	my $diff = {set=>[
+		{path=>['system','nodeVendor'], value=>'Acme'},
+		{path=>['-common-','class','sdwan-omp'], value=>{'common-model'=>'sdwan-omp'}},
+		{path=>['-common-','class','sdwan-bfd'], value=>{'common-model'=>'sdwan-bfd'}},
+	], drop=>[{path=>['-common-','class','IP-FORWARD']}], typeconflict=>[]};
+	my $ov = NMISNG::ModelReduce::build_override($diff);
+	is_deeply($ov, {
+		system => { nodeVendor => 'Acme' },
+		'-common-' => { class => {
+			'sdwan-omp' => {'common-model'=>'sdwan-omp'},
+			'sdwan-bfd' => {'common-model'=>'sdwan-bfd'},
+		}},
+	}, "build_override rebuilds nested set paths and ignores drops");
+}
+{
+	# values are cloned, not shared
+	my $shared = {x=>1};
+	my $ov = NMISNG::ModelReduce::build_override({set=>[{path=>['a'],value=>$shared}],drop=>[],typeconflict=>[]});
+	$ov->{a}{x} = 99;
+	is($shared->{x}, 1, "build_override clones values");
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `perl test/t_reduce_model.pl`
+Expected: FAIL, `Undefined subroutine &NMISNG::ModelReduce::build_override`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add `use Clone;` near the top of `lib/NMISNG/ModelReduce.pm` (after `use warnings;`), then add before the final `1;`:
+
+```perl
+# build_override($diff): rebuild a hashref from the diff's set entries only.
+sub build_override
+{
+	my ($diff) = @_;
+	my $override = {};
+	for my $entry (@{$diff->{set}})
+	{
+		_set_path($override, $entry->{path}, Clone::clone($entry->{value}));
+	}
+	return $override;
+}
+
+# _set_path($hash, \@path, $value): set a nested value, creating intermediate hashes.
+sub _set_path
+{
+	my ($hash, $path, $value) = @_;
+	my $node = $hash;
+	for my $i (0 .. $#$path - 1)
+	{
+		my $k = $path->[$i];
+		$node->{$k} = {} if (ref($node->{$k}) ne "HASH");
+		$node = $node->{$k};
+	}
+	$node->{$path->[-1]} = $value;
+	return;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `perl test/t_reduce_model.pl`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/NMISNG/ModelReduce.pm test/t_reduce_model.pl
+git commit -m "feat(model-reduce): add build_override"
+```
+
+---
+
+### Task 5: Compile a model in given directories (loader driver)
+
+**Files:**
+- Modify: `lib/NMISNG/ModelReduce.pm`
+- Test: `test/t_reduce_model.pl`
+
+**Interfaces:**
+- Produces: `NMISNG::ModelReduce::compile_model(%args)` where args are `model` (for example `Model-Foo`), `config` (a real config hashref to clone), `default_dir`, `custom_dir`, `var_dir`. It clones the config, repoints `<nmis_default_models>`, `<nmis_models>`, `<nmis_var>` at the given dirs, disables model caching, drives the real `NMISNG::Sys::loadModel`, and returns the merged model hashref (`$sys->{mdl}`), or `undef` on load failure.
+
+This reuses the setup proven in `test/t_model_overrides.pl`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/t_reduce_model.pl`. First add these `use` lines near the top of the file (after the existing `use` lines):
+
+```perl
+use File::Temp qw(tempdir);
+use File::Path qw(make_path);
+use NMISNG::Util;
+```
+
+Then append before `done_testing();`:
+
+```perl
+# compile_model: base + auto-discovered override merged by the real loader
+{
+	my $C = NMISNG::Util::loadConfTable();
+	SKIP: {
+		skip "no usable config", 3 if (ref($C) ne "HASH" || !%$C);
+
+		my $base = tempdir("t-reduce-XXXXXX", TMPDIR => 1, CLEANUP => 1);
+		my $def = "$base/models-default";
+		my $cus = "$base/models-custom";
+		my $var = "$base/var";
+		make_path($def, $cus, "$var/nmis_system/model_cache");
+
+		NMISNG::Util::writeHashtoFile(file => "$def/Model-Foo.nmis", json => 0, conf => $C, data => {
+			system => { nodeVendor => 'BaseVendor', nodeType => 'router' },
+		});
+
+		my $mdl = NMISNG::ModelReduce::compile_model(
+			model => "Model-Foo", config => $C,
+			default_dir => $def, custom_dir => $cus, var_dir => $var);
+		is(ref($mdl), "HASH", "compile_model returns a hash");
+		is($mdl->{system}{nodeVendor}, 'BaseVendor', "base value present");
+
+		# add an auto-discovered Model override and recompile
+		NMISNG::Util::writeHashtoFile(file => "$cus/Override-Model-Foo.nmis", json => 0, conf => $C, data => {
+			system => { nodeVendor => 'OverriddenVendor' },
+		});
+		my $mdl2 = NMISNG::ModelReduce::compile_model(
+			model => "Model-Foo", config => $C,
+			default_dir => $def, custom_dir => $cus, var_dir => $var);
+		is($mdl2->{system}{nodeVendor}, 'OverriddenVendor', "scoped override applied by real loader");
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `perl test/t_reduce_model.pl`
+Expected: FAIL, `Undefined subroutine &NMISNG::ModelReduce::compile_model`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add `use Clone;` is already present. Add a small fake-nmisng package and the sub. Add near the top of `lib/NMISNG/ModelReduce.pm` (after the `use` lines):
+
+```perl
+use NMISNG::Sys;
+use NMISNG::Log;
+
+# Minimal nmisng-like object: loadModel only needs ->log and ->config.
+{
+	package NMISNG::ModelReduce::FakeNmisng;
+	sub new { my ($c, %a) = @_; bless { %a }, $c; }
+	sub log { $_[0]->{log} }
+	sub config { $_[0]->{config} }
+}
+```
+
+Add before the final `1;`:
+
+```perl
+# compile_model(%args): drive the real loader against isolated dirs.
+sub compile_model
+{
+	my (%args) = @_;
+
+	my $C = Clone::clone($args{config});
+	$C->{'<nmis_default_models>'} = $args{default_dir};
+	$C->{'<nmis_models>'}         = $args{custom_dir};
+	$C->{'<nmis_var>'}            = $args{var_dir};
+	delete $C->{global_model_overrides};
+
+	my $logger = NMISNG::Log->new(level => 'fatal');
+	my $fake = NMISNG::ModelReduce::FakeNmisng->new(config => $C, log => $logger);
+
+	my $sys = NMISNG::Sys->new();
+	$sys->{config}       = $C;
+	$sys->{_nmisng}      = $fake;
+	$sys->{cache_models} = 0;
+
+	my $ok = $sys->loadModel(model => $args{model});
+	return undef if (!$ok);
+	return $sys->{mdl};
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `perl test/t_reduce_model.pl`
+Expected: PASS. A warning about changing file owner to user "nmis" may print; it is harmless.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/NMISNG/ModelReduce.pm test/t_reduce_model.pl
+git commit -m "feat(model-reduce): add compile_model loader driver"
+```
+
+---
+
+### Task 6: Find models referencing a Common feature
+
+**Files:**
+- Modify: `lib/NMISNG/ModelReduce.pm`
+- Test: `test/t_reduce_model.pl`
+
+**Interfaces:**
+- Produces: `NMISNG::ModelReduce::models_referencing_common($feature, @dirs)` returns a sorted, de-duplicated list of model names (for example `Model-Foo`) whose `-common-/class/*/common-model` equals `$feature`, scanning every `Model-*.nmis` found in the given directories. A file that appears in more than one dir is read once (custom shadows default by directory order).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/t_reduce_model.pl` before `done_testing();`:
+
+```perl
+# models_referencing_common
+{
+	my $C = NMISNG::Util::loadConfTable();
+	SKIP: {
+		skip "no usable config", 2 if (ref($C) ne "HASH" || !%$C);
+		my $base = tempdir("t-reduce-ref-XXXXXX", TMPDIR => 1, CLEANUP => 1);
+		my $def = "$base/models-default";
+		make_path($def);
+		NMISNG::Util::writeHashtoFile(file=>"$def/Model-Uses.nmis", json=>0, conf=>$C, data=>{
+			'-common-'=>{class=>{cpu=>{'common-model'=>'WidgetCpu'}}}});
+		NMISNG::Util::writeHashtoFile(file=>"$def/Model-AlsoUses.nmis", json=>0, conf=>$C, data=>{
+			'-common-'=>{class=>{cpu=>{'common-model'=>'WidgetCpu'}, ip=>{'common-model'=>'Other'}}}});
+		NMISNG::Util::writeHashtoFile(file=>"$def/Model-Nope.nmis", json=>0, conf=>$C, data=>{
+			'-common-'=>{class=>{ip=>{'common-model'=>'Other'}}}});
+
+		my @refs = NMISNG::ModelReduce::models_referencing_common("WidgetCpu", $def);
+		is_deeply(\@refs, ["Model-AlsoUses","Model-Uses"], "finds all referencing models, sorted");
+		my @none = NMISNG::ModelReduce::models_referencing_common("Missing", $def);
+		is_deeply(\@none, [], "no references -> empty list");
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `perl test/t_reduce_model.pl`
+Expected: FAIL, `Undefined subroutine &NMISNG::ModelReduce::models_referencing_common`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add before the final `1;` in `lib/NMISNG/ModelReduce.pm`:
+
+```perl
+# models_referencing_common($feature, @dirs): model names that pull in Common-$feature.
+sub models_referencing_common
+{
+	my ($feature, @dirs) = @_;
+	my %seen_file;
+	my %matches;
+	for my $dir (@dirs)
+	{
+		next if (!defined $dir || !-d $dir);
+		opendir(my $dh, $dir) or next;
+		my @files = grep { /^Model-.+\.nmis$/ } readdir($dh);
+		closedir($dh);
+		for my $f (sort @files)
+		{
+			next if ($seen_file{$f}++);    # first dir wins (custom before default)
+			my $data = NMISNG::Util::readFiletoHash(file => "$dir/$f");
+			next if (ref($data) ne "HASH");
+			my $class = $data->{'-common-'}{class};
+			next if (ref($class) ne "HASH");
+			for my $c (keys %$class)
+			{
+				if (($class->{$c}{'common-model'} // '') eq $feature)
+				{
+					my $name = $f; $name =~ s/\.nmis$//;
+					$matches{$name} = 1;
+					last;
+				}
+			}
+		}
+	}
+	return sort keys %matches;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `perl test/t_reduce_model.pl`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/NMISNG/ModelReduce.pm test/t_reduce_model.pl
+git commit -m "feat(model-reduce): add models_referencing_common"
+```
+
+---
+
+### Task 7: Verify a proposed reduction end to end
+
+**Files:**
+- Modify: `lib/NMISNG/ModelReduce.pm`
+- Test: `test/t_reduce_model.pl`
+
+**Interfaces:**
+- Consumes: `compile_model`, `models_referencing_common`, `deep_equal`, `build_override`.
+- Produces: `NMISNG::ModelReduce::verify_reduction(%args)` where args are `basename` (for example `Model-Foo` or `Common-Bar`), `custom_dir`, `default_dir`, `config`, and `override` (a hashref, or `undef` for the identical case where the copy is simply removed). It builds two isolated states, `before` (the real custom_dir copied as-is) and `after` (same, but with the target file removed and, when `override` is given, `Override-<basename>.nmis` written), compiles every affected model in both states, and returns `{ ok => 1|0, models => [...], mismatch => $model_or_undef }`. Affected models are the file itself when it is a `Model-`, or `models_referencing_common(feature, custom_dir, default_dir)` when it is a `Common-`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/t_reduce_model.pl` before `done_testing();`:
+
+```perl
+# verify_reduction
+{
+	my $C = NMISNG::Util::loadConfTable();
+	SKIP: {
+		skip "no usable config", 3 if (ref($C) ne "HASH" || !%$C);
+		my $base = tempdir("t-reduce-verify-XXXXXX", TMPDIR => 1, CLEANUP => 1);
+		my $def = "$base/models-default";
+		my $cus = "$base/models-custom";
+		make_path($def, $cus);
+
+		# default has vendor Base + nodeType; custom copy changes vendor only.
+		NMISNG::Util::writeHashtoFile(file=>"$def/Model-Bar.nmis", json=>0, conf=>$C, data=>{
+			system=>{nodeVendor=>'Base', nodeType=>'router'}});
+		NMISNG::Util::writeHashtoFile(file=>"$cus/Model-Bar.nmis", json=>0, conf=>$C, data=>{
+			system=>{nodeVendor=>'Custom', nodeType=>'router'}});
+
+		# correct override reproduces the copy: PASS
+		my $good = NMISNG::ModelReduce::verify_reduction(
+			basename=>"Model-Bar", custom_dir=>$cus, default_dir=>$def, config=>$C,
+			override=>{system=>{nodeVendor=>'Custom'}});
+		ok($good->{ok}, "correct override verifies identical");
+
+		# wrong override does NOT reproduce the copy: FAIL
+		my $bad = NMISNG::ModelReduce::verify_reduction(
+			basename=>"Model-Bar", custom_dir=>$cus, default_dir=>$def, config=>$C,
+			override=>{system=>{nodeVendor=>'WRONG'}});
+		ok(!$bad->{ok}, "wrong override fails verification");
+
+		# identical case: copy equals default, removal with no override verifies
+		NMISNG::Util::writeHashtoFile(file=>"$cus/Model-Bar.nmis", json=>0, conf=>$C, data=>{
+			system=>{nodeVendor=>'Base', nodeType=>'router'}});
+		my $same = NMISNG::ModelReduce::verify_reduction(
+			basename=>"Model-Bar", custom_dir=>$cus, default_dir=>$def, config=>$C,
+			override=>undef);
+		ok($same->{ok}, "identical copy removal verifies");
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `perl test/t_reduce_model.pl`
+Expected: FAIL, `Undefined subroutine &NMISNG::ModelReduce::verify_reduction`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add `use File::Temp qw(tempdir);`, `use File::Path qw(make_path);`, and `use File::Copy qw(copy);` near the top of `lib/NMISNG/ModelReduce.pm`, then add before the final `1;`:
+
+```perl
+# _copy_dir_files($src, $dst): copy every *.nmis file from src into dst (flat).
+sub _copy_dir_files
+{
+	my ($src, $dst) = @_;
+	make_path($dst) if (!-d $dst);
+	return if (!-d $src);
+	opendir(my $dh, $src) or return;
+	for my $f (grep { /\.nmis$/ } readdir($dh))
+	{
+		File::Copy::copy("$src/$f", "$dst/$f");
+	}
+	closedir($dh);
+	return;
+}
+
+# verify_reduction(%args): compile affected models before/after and compare.
+sub verify_reduction
+{
+	my (%args) = @_;
+	my $basename    = $args{basename};
+	my $custom_dir  = $args{custom_dir};
+	my $default_dir = $args{default_dir};
+	my $config      = $args{config};
+	my $override    = $args{override};
+
+	my $tmp = tempdir("model-reduce-verify-XXXXXX", TMPDIR => 1, CLEANUP => 1);
+	my $before_cus = "$tmp/before-custom";
+	my $after_cus  = "$tmp/after-custom";
+	my $var_before = "$tmp/var-before";
+	my $var_after  = "$tmp/var-after";
+	make_path("$var_before/nmis_system/model_cache", "$var_after/nmis_system/model_cache");
+
+	# before: exact copy of the real custom dir
+	_copy_dir_files($custom_dir, $before_cus);
+	# after: same, minus the target file, plus the override when given
+	_copy_dir_files($custom_dir, $after_cus);
+	unlink("$after_cus/$basename.nmis");
+	if (defined $override)
+	{
+		NMISNG::Util::writeHashtoFile(
+			file => "$after_cus/Override-$basename.nmis",
+			data => $override, json => 0, conf => $config);
+	}
+
+	# which models to compile
+	my @models;
+	if ($basename =~ /^Model-/)
+	{
+		push @models, $basename;
+	}
+	else # Common-<feature>
+	{
+		my $feature = $basename; $feature =~ s/^Common-//;
+		# scan the after custom dir plus the default dir for referencing models
+		@models = models_referencing_common($feature, $after_cus, $default_dir);
+	}
+
+	return { ok => 0, models => [], mismatch => undef, error => "no models to compile" }
+		if (!@models);
+
+	for my $m (@models)
+	{
+		my $before = compile_model(model => $m, config => $config,
+			default_dir => $default_dir, custom_dir => $before_cus, var_dir => $var_before);
+		my $after  = compile_model(model => $m, config => $config,
+			default_dir => $default_dir, custom_dir => $after_cus, var_dir => $var_after);
+		if (!defined $before || !defined $after || !deep_equal($before, $after))
+		{
+			return { ok => 0, models => \@models, mismatch => $m };
+		}
+	}
+	return { ok => 1, models => \@models, mismatch => undef };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `perl test/t_reduce_model.pl`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/NMISNG/ModelReduce.pm test/t_reduce_model.pl
+git commit -m "feat(model-reduce): add verify_reduction end-to-end check"
+```
+
+---
+
+### Task 8: analyse() — enumerate, classify, verify, and plan actions
+
+**Files:**
+- Modify: `lib/NMISNG/ModelReduce.pm`
+- Test: `test/t_reduce_model.pl`
+
+**Interfaces:**
+- Consumes: `semantic_diff`, `classify`, `build_override`, `verify_reduction`.
+- Produces: `NMISNG::ModelReduce::analyse(%args)` where args are `custom_dir`, `default_dir`, `config`, and optional `only` (a single basename to limit to). Returns an arrayref of per-file result hashrefs, each `{ basename, category, verified, override, drops, error }` where:
+  - `category` is one of `identical`, `reducible`, `drift`, `skip-graph`, `skip-no-default`, `skip-override`, `error`.
+  - `verified` is 1 when a loader check passed (identical and reducible only).
+  - `override` is the hashref to write (reducible) or the manual-start hashref (drift), else undef.
+  - `drops` is an arrayref of `/`-joined drop paths for drift files, else undef.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/t_reduce_model.pl` before `done_testing();`:
+
+```perl
+# analyse
+{
+	my $C = NMISNG::Util::loadConfTable();
+	SKIP: {
+		skip "no usable config", 5 if (ref($C) ne "HASH" || !%$C);
+		my $base = tempdir("t-reduce-analyse-XXXXXX", TMPDIR => 1, CLEANUP => 1);
+		my $def = "$base/models-default";
+		my $cus = "$base/models-custom";
+		make_path($def, $cus);
+
+		# default files
+		NMISNG::Util::writeHashtoFile(file=>"$def/Model-Same.nmis", json=>0, conf=>$C, data=>{system=>{nodeVendor=>'V'}});
+		NMISNG::Util::writeHashtoFile(file=>"$def/Model-Red.nmis",  json=>0, conf=>$C, data=>{system=>{nodeVendor=>'V'}});
+		NMISNG::Util::writeHashtoFile(file=>"$def/Model-Drift.nmis",json=>0, conf=>$C, data=>{system=>{nodeVendor=>'V'}, extra=>{keep=>1}});
+
+		# custom copies
+		NMISNG::Util::writeHashtoFile(file=>"$cus/Model-Same.nmis", json=>0, conf=>$C, data=>{system=>{nodeVendor=>'V'}});                 # identical
+		NMISNG::Util::writeHashtoFile(file=>"$cus/Model-Red.nmis",  json=>0, conf=>$C, data=>{system=>{nodeVendor=>'Custom'}});            # reducible
+		NMISNG::Util::writeHashtoFile(file=>"$cus/Model-Drift.nmis",json=>0, conf=>$C, data=>{system=>{nodeVendor=>'V'}});                 # drops extra
+		NMISNG::Util::writeHashtoFile(file=>"$cus/Model-Own.nmis",  json=>0, conf=>$C, data=>{system=>{nodeVendor=>'X'}});                 # no default
+		NMISNG::Util::writeHashtoFile(file=>"$cus/Override-Model-Same.nmis", json=>0, conf=>$C, data=>{system=>{x=>1}});                   # existing override
+		NMISNG::Util::writeHashtoFile(file=>"$cus/Graph-cpu.nmis",  json=>0, conf=>$C, data=>{title=>'x'});                                # graph
+
+		my $res = NMISNG::ModelReduce::analyse(custom_dir=>$cus, default_dir=>$def, config=>$C);
+		my %by = map { $_->{basename} => $_ } @$res;
+
+		is($by{"Model-Same"}{category},  "identical",       "identical detected");
+		is($by{"Model-Red"}{category},   "reducible",       "reducible detected");
+		ok($by{"Model-Red"}{verified},                      "reducible verified");
+		is($by{"Model-Drift"}{category}, "drift",           "drift detected");
+		is_deeply($by{"Model-Drift"}{drops}, ["extra"],     "drift lists the dropped top-level section");
+		is($by{"Model-Own"}{category},   "skip-no-default", "genuine custom skipped");
+		is($by{"Graph-cpu"}{category},   "skip-graph",      "graph skipped");
+		is($by{"Override-Model-Same"}{category}, "skip-override", "existing override skipped");
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `perl test/t_reduce_model.pl`
+Expected: FAIL, `Undefined subroutine &NMISNG::ModelReduce::analyse`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add before the final `1;` in `lib/NMISNG/ModelReduce.pm`:
+
+```perl
+# analyse(%args): full per-file classification with verification.
+sub analyse
+{
+	my (%args) = @_;
+	my $custom_dir  = $args{custom_dir};
+	my $default_dir = $args{default_dir};
+	my $config      = $args{config};
+	my $only        = $args{only};
+
+	my @results;
+	opendir(my $dh, $custom_dir) or die "cannot read $custom_dir: $!\n";
+	my @files = sort grep { /\.nmis$/ } readdir($dh);
+	closedir($dh);
+
+	for my $f (@files)
+	{
+		my $basename = $f; $basename =~ s/\.nmis$//;
+		next if (defined $only && $basename ne $only);
+
+		if ($basename =~ /^Override-/)
+		{
+			push @results, { basename=>$basename, category=>"skip-override" };
+			next;
+		}
+		if ($basename =~ /^Graph-/)
+		{
+			push @results, { basename=>$basename, category=>"skip-graph" };
+			next;
+		}
+		if ($basename !~ /^(Model|Common)-/)
+		{
+			push @results, { basename=>$basename, category=>"skip-override" };
+			next;
+		}
+		if (!-e "$default_dir/$f")
+		{
+			push @results, { basename=>$basename, category=>"skip-no-default" };
+			next;
+		}
+
+		my $custom  = NMISNG::Util::readFiletoHash(file => "$custom_dir/$f");
+		my $default = NMISNG::Util::readFiletoHash(file => "$default_dir/$f");
+		if (ref($custom) ne "HASH" || ref($default) ne "HASH")
+		{
+			push @results, { basename=>$basename, category=>"error",
+				error => "unparseable: " . (ref($custom) ne "HASH" ? $custom : $default) };
+			next;
+		}
+
+		my $diff = semantic_diff($default, $custom);
+		my $cat  = classify($diff);
+
+		if ($cat eq "identical")
+		{
+			my $v = verify_reduction(basename=>$basename, custom_dir=>$custom_dir,
+				default_dir=>$default_dir, config=>$config, override=>undef);
+			push @results, { basename=>$basename, category=>"identical",
+				verified=>($v->{ok}?1:0), override=>undef };
+		}
+		elsif ($cat eq "reducible")
+		{
+			my $override = build_override($diff);
+			my $v = verify_reduction(basename=>$basename, custom_dir=>$custom_dir,
+				default_dir=>$default_dir, config=>$config, override=>$override);
+			# if the loader disagrees, keep the copy and report it as drift-like
+			push @results, {
+				basename => $basename,
+				category => ($v->{ok} ? "reducible" : "error"),
+				verified => ($v->{ok}?1:0),
+				override => $override,
+				error    => ($v->{ok} ? undef : "verification mismatch on $v->{mismatch}"),
+			};
+		}
+		else # drift
+		{
+			my @drops = map { join("/", @{$_->{path}}) } @{$diff->{drop}};
+			push @drops, map { join("/", @{$_->{path}})." (type conflict)" } @{$diff->{typeconflict}};
+			push @results, {
+				basename => $basename,
+				category => "drift",
+				verified => 0,
+				override => build_override($diff),   # manual-start (adds/changes only)
+				drops    => \@drops,
+			};
+		}
+	}
+	return \@results;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `perl test/t_reduce_model.pl`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/NMISNG/ModelReduce.pm test/t_reduce_model.pl
+git commit -m "feat(model-reduce): add analyse orchestration"
+```
+
+---
+
+### Task 9: CLI script — report (dry run)
+
+**Files:**
+- Create: `admin/reduce_model.pl`
+- Test: manual run described below.
+
+**Interfaces:**
+- Consumes: `NMISNG::ModelReduce::analyse`, `NMISNG::Util::get_args_multi`, `NMISNG::Util::getDir`, `NMISNG::Util::loadConfTable`, `NMISNG::Util::writeHashtoFile`.
+- Produces: the executable `admin/reduce_model.pl`. In dry run it prints a per-file report and writes proposed overrides (reducible) and manual-start overrides (drift) to the scratch dir.
+
+- [ ] **Step 1: Write the script**
+
+Create `admin/reduce_model.pl`:
+
+```perl
+#!/usr/bin/perl
+#
+#  reduce_model.pl - replace full custom model copies with Override-*.nmis files
+#  when the compiled model is provably unchanged. Dry run by default.
+#
+#  Copyright (C) Opmantek Limited (www.opmantek.com)
+#  This file is part of Network Management Information System ("NMIS").
+#  NMIS is free software: licensed under the GNU General Public License v3+.
+#
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+
+use strict;
+use warnings;
+use Data::Dumper;
+use File::Path qw(make_path);
+use File::Copy qw(copy);
+
+use NMISNG::Util;
+use NMISNG::ModelReduce;
+
+my $arg = NMISNG::Util::get_args_multi(@ARGV);
+
+if (NMISNG::Util::getbool($arg->{help}) || (defined $arg->{help}))
+{
+	usage();
+	exit 0;
+}
+
+my $C = NMISNG::Util::loadConfTable();
+die "cannot load NMIS config\n" if (ref($C) ne "HASH" || !%$C);
+
+my $custom_dir  = $arg->{dir}         // NMISNG::Util::getDir(dir => "models",        conf => $C);
+my $default_dir = $arg->{default_dir} // NMISNG::Util::getDir(dir => "default_models", conf => $C);
+my $apply       = NMISNG::Util::getbool($arg->{apply});
+my $verbose     = NMISNG::Util::getbool($arg->{verbose});
+my $scratch     = $arg->{scratch} // (($ENV{TMPDIR} || "/tmp") . "/model-reduce-$$");
+
+die "custom dir not found: $custom_dir\n"  if (!-d $custom_dir);
+die "default dir not found: $default_dir\n" if (!-d $default_dir);
+make_path($scratch) if (!-d $scratch);
+
+print "Custom  dir: $custom_dir\n";
+print "Default dir: $default_dir\n";
+print "Scratch dir: $scratch\n";
+print "Mode       : " . ($apply ? "APPLY" : "dry run (no changes)") . "\n\n";
+
+my $results = NMISNG::ModelReduce::analyse(
+	custom_dir => $custom_dir, default_dir => $default_dir,
+	config => $C, only => $arg->{model});
+
+report($results);
+
+# write proposed + manual-start overrides into scratch for inspection
+for my $r (@$results)
+{
+	next if (!defined $r->{override});
+	my $tag = ($r->{category} eq "drift") ? "manual-start" : "proposed";
+	my $out = "$scratch/Override-$r->{basename}.$tag.nmis";
+	local $Data::Dumper::Sortkeys = 1;
+	NMISNG::Util::writeHashtoFile(file => $out, data => $r->{override}, json => 0, conf => $C);
+}
+print "\nProposed override files written under $scratch\n";
+
+if ($apply)
+{
+	apply_changes($results, $custom_dir, $C);
+}
+else
+{
+	my @todo = grep { $_->{verified} && ($_->{category} eq "identical" || $_->{category} eq "reducible") } @$results;
+	print "\n" . scalar(@todo) . " file(s) would be changed. Re-run with apply=1 to apply.\n";
+}
+
+sub report
+{
+	my ($results) = @_;
+	printf("%-34s %-16s %s\n", "FILE", "OUTCOME", "DETAIL");
+	printf("%-34s %-16s %s\n", "----", "-------", "------");
+	for my $r (sort { $a->{basename} cmp $b->{basename} } @$results)
+	{
+		my $detail = "";
+		if ($r->{category} eq "reducible") { $detail = "override + remove copy (verified)"; }
+		elsif ($r->{category} eq "identical") { $detail = "remove copy, no override (verified)"; }
+		elsif ($r->{category} eq "drift")
+		{
+			$detail = "kept; default adds: " . join(", ", @{$r->{drops} // []});
+		}
+		elsif ($r->{category} eq "error") { $detail = $r->{error} // "error"; }
+		printf("%-34s %-16s %s\n", $r->{basename}, $r->{category}, $detail);
+	}
+}
+
+sub usage
+{
+	print <<EOF;
+Usage: $0 [dir=<models-custom>] [default_dir=<models-default>] [model=<Name>]
+          [scratch=<dir>] [apply=1] [verbose=1]
+
+Dry run by default. Replaces full custom model copies with Override-*.nmis
+files when the compiled model is provably unchanged. Removes copies that are
+already identical to the default. Reports copies that drifted from a newer
+default without changing them.
+EOF
+	return;
+}
+```
+
+- [ ] **Step 2: Make it executable and run against the synthetic fixture from Task 8**
+
+Build a quick fixture and run:
+
+```bash
+chmod +x admin/reduce_model.pl
+perl admin/reduce_model.pl dir=/nonexistent 2>&1 | head
+```
+
+Expected: prints `custom dir not found: /nonexistent`.
+
+- [ ] **Step 3: Run against the dev-server sample (ad hoc, read-only)**
+
+Extract the sample to a scratch dir and point the tool at it:
+
+```bash
+perl admin/reduce_model.pl dir=/path/to/extracted/models-custom
+```
+
+Expected: a report with identical, reducible, drift, skip-graph, and skip-no-default rows, and proposed override files under the scratch dir. No changes to the sample.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add admin/reduce_model.pl
+git commit -m "feat(model-reduce): add reduce_model.pl CLI with dry-run report"
+```
+
+---
+
+### Task 10: CLI apply path with backup, write, remove, and post-apply guard
+
+**Files:**
+- Modify: `admin/reduce_model.pl`
+- Test: manual run described below.
+
+**Interfaces:**
+- Consumes: `NMISNG::ModelReduce::compile_model` (for the post-apply snapshot compare), `NMISNG::Util::writeHashtoFile`.
+- Produces: `apply_changes($results, $custom_dir, $config)` in `admin/reduce_model.pl`. Backs up then removes verified identical and reducible copies, writes overrides for reducible files, clears affected model cache entries, and recompiles affected models to confirm they match a pre-apply snapshot.
+
+- [ ] **Step 1: Add the apply subroutine**
+
+Add to `admin/reduce_model.pl` (after the `report` sub):
+
+```perl
+sub apply_changes
+{
+	my ($results, $custom_dir, $C) = @_;
+
+	my @todo = grep { $_->{verified}
+			&& ($_->{category} eq "identical" || $_->{category} eq "reducible") } @$results;
+	if (!@todo)
+	{
+		print "\nNothing to apply.\n";
+		return;
+	}
+
+	# snapshot compiled models BEFORE any change (real dirs, isolated var)
+	my $default_dir = $arg->{default_dir} // NMISNG::Util::getDir(dir => "default_models", conf => $C);
+	my $snap_var = "$scratch/snap-before"; make_path("$snap_var/nmis_system/model_cache");
+	my %before;
+	for my $r (@todo)
+	{
+		for my $m (affected_models($r, $custom_dir, $default_dir))
+		{
+			$before{$m} //= NMISNG::ModelReduce::compile_model(model=>$m, config=>$C,
+				default_dir=>$default_dir, custom_dir=>$custom_dir, var_dir=>$snap_var);
+		}
+	}
+
+	print "\nAbout to change " . scalar(@todo) . " file(s) in $custom_dir\n";
+	print "A backup of each removed copy is written first.\n";
+	print "Type 'yes' to proceed: ";
+	my $answer = <STDIN>; chomp($answer // "");
+	if (lc($answer) ne "yes") { print "Aborted, no changes made.\n"; return; }
+
+	my $ts = _timestamp();
+	my $backup = "$custom_dir/.reduce-backup-$ts";
+	make_path($backup);
+
+	for my $r (@todo)
+	{
+		my $file = "$custom_dir/$r->{basename}.nmis";
+		if (!copy($file, "$backup/$r->{basename}.nmis"))
+		{
+			warn "backup failed for $file: $! - skipping\n";
+			next;
+		}
+		if ($r->{category} eq "reducible")
+		{
+			local $Data::Dumper::Sortkeys = 1;
+			NMISNG::Util::writeHashtoFile(file => "$custom_dir/Override-$r->{basename}.nmis",
+				data => $r->{override}, json => 0, conf => $C);
+		}
+		unlink($file) or warn "could not remove $file: $!\n";
+		print "changed: $r->{basename} ($r->{category})\n";
+	}
+
+	# clear affected model cache entries
+	my $cachedir = $C->{'<nmis_var>'} . "/nmis_system/model_cache";
+	for my $r (@todo)
+	{
+		for my $m (affected_models($r, $custom_dir, $default_dir))
+		{
+			unlink("$cachedir/$m.json");
+			unlink("$cachedir/$m.json.meta.json");
+		}
+	}
+
+	# post-apply guard: recompile and compare against the snapshot
+	my $snap_var2 = "$scratch/snap-after"; make_path("$snap_var2/nmis_system/model_cache");
+	my $failed = 0;
+	for my $m (sort keys %before)
+	{
+		my $after = NMISNG::ModelReduce::compile_model(model=>$m, config=>$C,
+			default_dir=>$default_dir, custom_dir=>$custom_dir, var_dir=>$snap_var2);
+		if (!NMISNG::ModelReduce::deep_equal($before{$m}, $after))
+		{
+			warn "POST-APPLY MISMATCH on $m - restore from $backup\n";
+			$failed++;
+		}
+	}
+	if ($failed) { print "\nWARNING: $failed model(s) mismatched after apply. Backup: $backup\n"; }
+	else { print "\nDone. All affected models compile identically. Backup: $backup\n"; }
+	return;
+}
+
+sub affected_models
+{
+	my ($r, $custom_dir, $default_dir) = @_;
+	return ($r->{basename}) if ($r->{basename} =~ /^Model-/);
+	my $feature = $r->{basename}; $feature =~ s/^Common-//;
+	return NMISNG::ModelReduce::models_referencing_common($feature, $custom_dir, $default_dir);
+}
+
+sub _timestamp
+{
+	my @t = localtime();
+	return sprintf("%04d%02d%02d-%02d%02d%02d",
+		$t[5]+1900, $t[4]+1, $t[3], $t[2], $t[1], $t[0]);
+}
+```
+
+- [ ] **Step 2: Run apply against a disposable copy of the sample**
+
+```bash
+cp -r /path/to/extracted/models-custom /tmp/mc-applytest
+perl admin/reduce_model.pl dir=/tmp/mc-applytest apply=1
+# answer: yes
+```
+
+Expected: identical and reducible copies removed, `Override-*.nmis` written for reducible ones, drift files untouched, a `.reduce-backup-<ts>` dir created, and the closing line "All affected models compile identically."
+
+- [ ] **Step 3: Verify the reduced dir still compiles the same models**
+
+```bash
+perl admin/reduce_model.pl dir=/tmp/mc-applytest
+```
+
+Expected: the previously reducible files no longer appear as copies; drift files still listed as drift.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add admin/reduce_model.pl
+git commit -m "feat(model-reduce): add guarded apply path with backup and post-apply check"
+```
+
+---
+
+### Task 11: Integration test for the full analyse-to-apply outcome mix
+
+**Files:**
+- Modify: `test/t_reduce_model.pl`
+
+**Interfaces:**
+- Consumes: `analyse`.
+- Produces: a synthetic scenario covering every outcome, asserting the category counts, so a regression in classification or verification is caught without the customer sample.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/t_reduce_model.pl` before `done_testing();`:
+
+```perl
+# integration: full outcome mix on synthetic fixtures
+{
+	my $C = NMISNG::Util::loadConfTable();
+	SKIP: {
+		skip "no usable config", 4 if (ref($C) ne "HASH" || !%$C);
+		my $base = tempdir("t-reduce-int-XXXXXX", TMPDIR => 1, CLEANUP => 1);
+		my $def = "$base/models-default";
+		my $cus = "$base/models-custom";
+		make_path($def, $cus);
+
+		# a Common referenced by a model, reducible via override
+		NMISNG::Util::writeHashtoFile(file=>"$def/Common-Feat.nmis", json=>0, conf=>$C, data=>{
+			systemHealth=>{rrd=>{cpu=>{graphtype=>'cpu', threshold=>'base'}}}});
+		NMISNG::Util::writeHashtoFile(file=>"$def/Model-Host.nmis", json=>0, conf=>$C, data=>{
+			system=>{nodeVendor=>'V'}, '-common-'=>{class=>{cpu=>{'common-model'=>'Feat'}}}});
+
+		# custom Common changes a threshold only (reducible)
+		NMISNG::Util::writeHashtoFile(file=>"$cus/Common-Feat.nmis", json=>0, conf=>$C, data=>{
+			systemHealth=>{rrd=>{cpu=>{graphtype=>'cpu', threshold=>'tuned'}}}});
+		# identical model copy
+		NMISNG::Util::writeHashtoFile(file=>"$cus/Model-Host.nmis", json=>0, conf=>$C, data=>{
+			system=>{nodeVendor=>'V'}, '-common-'=>{class=>{cpu=>{'common-model'=>'Feat'}}}});
+
+		my $res = NMISNG::ModelReduce::analyse(custom_dir=>$cus, default_dir=>$def, config=>$C);
+		my %cat;
+		$cat{$_->{category}}++ for @$res;
+
+		is($cat{identical}, 1, "one identical (Model-Host copy)");
+		is($cat{reducible}, 1, "one reducible (Common-Feat)");
+		my ($common) = grep { $_->{basename} eq "Common-Feat" } @$res;
+		ok($common->{verified}, "Common reduction verified via referencing model");
+		is_deeply($common->{override},
+			{systemHealth=>{rrd=>{cpu=>{threshold=>'tuned'}}}},
+			"Common override carries only the changed leaf");
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails or passes**
+
+Run: `perl test/t_reduce_model.pl`
+Expected: PASS if Tasks 1-8 are complete (this exercises them together). If it fails, fix the relevant task's code, not the test.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/t_reduce_model.pl
+git commit -m "test(model-reduce): integration test for full outcome mix"
+```
+
+---
+
+### Task 12: Update documentation
+
+**Files:**
+- Modify: `docs/model-loading.md`
+
+**Interfaces:** none.
+
+Note: `CLAUDE.md` and `docs/CLI_TOOLS.md` are local untracked files, not part of `nmis9_dev`, so they are out of scope for this branch. Update them in the working checkout separately if wanted.
+
+- [ ] **Step 1: Find the manual-process section**
+
+Run: `grep -n "compare_models\|Override-\|manual" docs/model-loading.md`
+Expected: a section describing the manual `compare_models.pl` then hand-write workflow.
+
+- [ ] **Step 2: Add a pointer to the tool**
+
+Add a short subsection to `docs/model-loading.md` near that section:
+
+```markdown
+### Automating the reduction
+
+`admin/reduce_model.pl` automates converting full custom copies into
+`Override-*.nmis` files. It runs read-only by default, classifies each custom
+Model or Common file as identical, reducible, or drifted, and verifies every
+proposed change by compiling the model both ways with the real loader. Pass
+`apply=1` to write the overrides and remove the reduced copies (each copy is
+backed up first). Graph files and files with no default counterpart are
+reported and left alone. See the header of the script for full arguments.
+```
+
+- [ ] **Step 3: Run the full test suite once more**
+
+Run: `perl test/t_reduce_model.pl`
+Expected: PASS (all tasks).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/model-loading.md
+git commit -m "docs(model-reduce): document reduce_model.pl in model-loading.md"
+```
+
+---
+
+## Self-review notes
+
+- Spec coverage: scope (Task 8 categorisation), diff rules (Task 2), verification incl. Common-by-referencing-model and post-apply guard (Tasks 5-7, 10), apply safety with backup and confirm (Task 10), report + manual-start overrides (Tasks 8-9), testing (Tasks 1-11), docs (Task 12). The "identical -> remove" outcome is covered by Tasks 7-10.
+- Type consistency: `semantic_diff` returns `{set,drop,typeconflict}` used unchanged by `classify`, `build_override`, and `analyse`. `verify_reduction` returns `{ok,models,mismatch}` consumed by `analyse`. `analyse` result fields `{basename,category,verified,override,drops,error}` are consumed by the CLI `report`/`apply_changes`.
+- Placeholder scan: every code step contains complete code. Manual-run tasks (9, 10) give exact commands and expected output rather than automated asserts, because they exercise a CLI with a confirmation prompt.

--- a/docs/superpowers/specs/2026-07-07-model-reduce-diff-design.md
+++ b/docs/superpowers/specs/2026-07-07-model-reduce-diff-design.md
@@ -1,0 +1,254 @@
+# Model reduce-to-override tool — design
+
+- Date: 2026-07-07
+- Branch: model-reduce-diff (rooted from origin/nmis9_dev)
+- Status: approved design, ready for implementation planning
+
+## Background and motivation
+
+NMIS loads device models from `models-custom/`, falling back to `models-default/`.
+When a site needs a small change to a shipped model, the common practice has been
+to copy the whole default file into `models-custom/` and edit it. That full copy
+then fully shadows the default, so two problems follow:
+
+1. The customer ends up maintaining a large file to hold a few changes, which is
+   hard to reason about.
+2. Because the copy shadows the default completely, later NMIS upgrades that add
+   sections to the default never reach that model. The copy silently freezes an
+   old version.
+
+NMIS already supports a lighter mechanism. `NMISNG::Sys::loadModel` auto-discovers
+`Override-Model-<name>.nmis` and `Override-Common-<feature>.nmis` in `models-custom/`
+and deep-merges them onto the base file loaded from `models-default/`. No config
+change is needed. This tool automates converting a full copy into that small
+override, but only when it can prove the result compiles to the same model.
+
+## What already exists (research summary)
+
+- No tool anywhere generates override files. The reduction is currently a manual
+  process documented in `docs/model-loading.md` (run `compare_models.pl`, then
+  hand-write each `Override-*.nmis`). An external web search found no equivalent.
+- Reusable building blocks in the codebase:
+  - `admin/diffconfigs.pl` — a genuine structure-level diff, but print-only, and
+    its element-wise array handling is wrong for override semantics (see below).
+  - `admin/compare_models.pl` — pairs custom files with default files.
+  - `NMISNG::Util::writeHashtoFile` — the canonical `.nmis` writer (Data::Dumper
+    format).
+  - `NMISNG::Util::readFiletoHash` / `getModelFile` — the model readers.
+  - `NMISNG::Sys::_mergeHash` — the exact merge the reduction must invert.
+  - `test/t_model_overrides.pl` — a working, node-free, MongoDB-free way to drive
+    the real loader against temporary model directories. The verification step
+    reuses this setup directly.
+
+## Constraints the design must respect
+
+These come from reading `NMISNG::Sys::loadModel` and `_mergeHash`.
+
+- The merge only adds keys or overwrites values. It has no delete verb. An
+  override can never remove a key that the base defines.
+- Arrays are replaced wholesale, not merged element by element.
+- A hash cannot be merged over a scalar in the dest (base). If the base has a key
+  as a hash and the override supplies a scalar for it, the merge fails.
+- Override discovery covers only `Override-Model-<name>` and
+  `Override-Common-<feature>` (plus a config-listed `global_model_overrides`).
+  There is no override path for graph files.
+- A full custom copy shadows the default, so only custom files that have a default
+  counterpart are reduction candidates.
+- The model cache tracks override mtimes in a sidecar and self-invalidates.
+- The tool runs on a customer NMIS server. There is no git repository and no
+  history of `models-default` available there. The original default version a
+  copy was based on cannot be recovered at runtime.
+
+## Goals
+
+- Convert full custom copies to small overrides where the compiled model stays
+  byte-identical, verified by the real loader.
+- Remove copies that are already identical to the current default.
+- Surface, without changing them, the copies that have drifted from a newer
+  default (the upgrade-drift case), with enough detail to act on by hand.
+- Be safe by default: read-only unless explicitly told to apply, back up before
+  removing, never guess about intent.
+
+## Non-goals
+
+- No changes to NMIS core code.
+- No override path for graph files.
+- No automatic rebasing of drifted copies onto a newer default. That would
+  require the original ancestor version (not available without git) or guessing
+  which differences are the user's versus the upgrade's. Both are rejected.
+- No 3-way / git-based ancestor recovery.
+
+## Why byte-identical reduction sidesteps the intent question
+
+For a byte-identical reduction it does not matter whether a difference came from
+a user edit or from an upgrade. The override captures whatever makes the current
+model differ from the default, and the compiled result reproduces the current
+behaviour exactly. The only thing that ever blocks a byte-identical reduction is
+a drop, because the merge cannot delete a key from the base. This is what lets
+the tool avoid guessing.
+
+## Components
+
+- `admin/reduce_model.pl` — thin CLI. Parses arguments, resolves directories,
+  orchestrates, prints the report, performs the apply step.
+- `lib/NMISNG/ModelReduce.pm` — the testable logic:
+  - `semantic_diff($default_hash, $custom_hash)` — returns a classified diff of
+    added keys, changed leaves, replaced arrays, drops, and type conflicts.
+  - `build_override($diff)` — builds the override hashref from the representable
+    parts (adds, changed leaves, replaced arrays), or reports it cannot.
+  - `classify($diff)` — returns `identical`, `reducible`, or `drift`.
+  - `verify($model_name, $target_dirs, $proposed_state)` — drives the real
+    `NMISNG::Sys::loadModel` in temporary directories both ways and deep-compares
+    the merged models. Returns pass or fail with the differing paths.
+
+Keeping the logic in a module lets `test/t_reduce_model.pl` unit-test the diff and
+classification without running the CLI.
+
+## Command-line arguments
+
+Follows the `model_tool.pl` `key=value` style.
+
+- `dir=` — target `models-custom` directory. Default: config-resolved
+  `<nmis_models>`.
+- `default_dir=` — default models directory. Default: config-resolved
+  `<nmis_default_models>`.
+- `model=` — limit the run to a single file (for example `Model-CiscoRouter`).
+- `scratch=` — output directory for proposed and manual-start overrides in a
+  dry run. Default: a timestamped directory under the system tmp path.
+- `apply=1` — perform the destructive changes. Absent or `0` means dry run.
+- `verbose=1` — include the full per-file diff detail in the report.
+
+## Data flow
+
+1. Resolve `dir` and `default_dir` from arguments or config.
+2. Enumerate `*.nmis` in `dir`. Categorise by prefix and by whether a default
+   counterpart exists.
+3. For each `Model-*` or `Common-*` candidate with a default counterpart:
+   a. Read both files to hashes with `readFiletoHash`.
+   b. Compute the semantic diff and classify.
+   c. `identical` — mark for removal.
+   d. `reducible` — build the override, verify byte-identical with the real
+      loader. On pass, mark for reduce. On fail, downgrade to a reported problem
+      and keep the copy.
+   e. `drift` — write a marked, unverified manual-start override to the scratch
+      directory and record which upstream additions the copy is masking.
+4. Produce the report. Always write manual-start overrides for drift files to the
+   scratch directory, in both modes, since they are never applied. In a dry run,
+   also write the proposed overrides for reducible files to the scratch directory
+   so they can be inspected before an apply.
+5. If `apply=1`, summarise, ask for confirmation, then for verified identical and
+   reducible files only:
+   - back up the copy to a timestamped backup directory,
+   - write the override into `dir` (reducible files only),
+   - remove the copy,
+   - after all files, clear the affected model cache entries.
+   Drift files are never touched by apply.
+
+## Diff rules
+
+- Walk both structures by key.
+- Both values are hashes: recurse.
+- Key present in custom only: an add. Representable.
+- Key present in both, values differ, both scalars or arrays: a change.
+  Representable. Arrays are treated atomically, so the whole custom array is
+  carried.
+- Key present in default only: a drop. Not representable. Marks the file as
+  `drift`.
+- Type conflict where the default value is a hash and the custom value is not:
+  not representable. Marks the file as `drift` with a type-conflict note.
+
+Note the difference from `admin/diffconfigs.pl`, which compares arrays element by
+element. That logic is not reused, because the override merge replaces arrays
+wholesale.
+
+## Verification
+
+Reuses the approach proven in `test/t_model_overrides.pl`.
+
+1. Clone the live config. Repoint `<nmis_models>`, `<nmis_default_models>`, and
+   `<nmis_var>` at temporary directories. Turn persistent model caching off for
+   the check so nothing touches the live cache.
+2. Build a minimal nmisng-like object that provides only a logger, as the test
+   does.
+3. Compile the model in the before state (copy present) and the after state
+   (copy removed, proposed override present) by calling the real
+   `NMISNG::Sys::loadModel`, then deep-compare the two merged `$sys->{mdl}`
+   structures.
+4. For a `Common-*` file, find every model that references it by scanning
+   `-common-/class/*/common-model` across both directories, compile each in the
+   before and after states, and require every one to match. If nothing references
+   it, report it as unused and skip.
+
+A file is eligible to change only if this check passes. If the diff classified a
+file as reducible but the compile disagrees, the compile wins and the file is
+kept and reported. This needs no git, no MongoDB, and no SNMP.
+
+### Multiple files in one run
+
+Each candidate is verified against the current on-disk state of every other file.
+Because every accepted reduction leaves the compiled model unchanged, applying
+several of them in sequence also leaves the compiled model unchanged, so per-file
+verification is sound even when a run reduces both a `Common-*` file and a model
+that references it. As a final guard, the apply step recompiles every affected
+model once more after all changes are on disk and compares against a snapshot
+taken before apply. Any mismatch stops the run and is reported, though the
+per-file reasoning means this should never fire.
+
+## Apply path and safety
+
+- Dry run is the default. Nothing under `dir` changes without `apply=1`.
+- Apply processes only verified identical and reducible files.
+- Each removal is preceded by a successful backup to a timestamped directory
+  (for example `<dir>/.reduce-backup-<timestamp>/`). A failed backup aborts that
+  file.
+- Overrides are written with `writeHashtoFile` and sorted keys for stable output.
+- After all changes, the affected model cache entries are cleared so the next
+  poll rebuilds cleanly.
+- The apply step prints a summary of what it will change and asks for
+  confirmation before the destructive part.
+
+## Error handling
+
+- Unparseable `.nmis` file: skip, report, never remove.
+- Merge error during override build or verification: keep the copy, report.
+- Verification mismatch: keep the copy, report the differing paths.
+- Backup failure: do not remove that file.
+
+## Expected behaviour on the dev-server sample
+
+The sample from a dev server has 57 files: 26 graph (skipped, reported), 12
+genuine custom Model/Common with no default (skipped), and 19 candidates. On the
+current default the 19 split into:
+
+- 6 identical (copy redundant, removed on apply),
+- 6 reducible (override written, copy removed on apply),
+- 7 drift (kept, reported; the drops are almost all the upstream
+  `-common-/class/IP-FORWARD` addition, plus cbqos, lldp, systemHealth).
+
+The tests assert this split and that every applied result compiles identically.
+
+## Testing
+
+- `test/t_reduce_model.pl`:
+  - unit tests for `semantic_diff`, `classify`, and `build_override`,
+  - integration tests over temporary default and custom directories, covering
+    identical, pure-add, changed-leaf, array-replace, drop then drift,
+    hash-to-scalar then drift, a Common referenced by more than one model, a
+    graph skipped, and a no-default file skipped,
+  - a fixture built from the dev-server sample that asserts the 6 / 6 / 7 split
+    and that applied results compile identically.
+
+## Documentation to update
+
+- `CLAUDE.md` — add the tool to the `admin/` list.
+- `docs/CLI_TOOLS.md` — add full arguments and examples.
+- `docs/model-loading.md` — replace or extend the manual-process note with a
+  pointer to the tool.
+
+## Open assumptions
+
+- The customer install has a working `conf/` so the config clone and the loader
+  work. This holds on any real NMIS server.
+- `mtime` is treated only as a soft hint in the report (a newer default suggests
+  upgrade drift), never as an input to any decision, because copy and rsync
+  operations do not preserve it reliably.

--- a/lib/NMISNG/ModelReduce.pm
+++ b/lib/NMISNG/ModelReduce.pm
@@ -172,4 +172,37 @@ sub compile_model
 	return $sys->{mdl};
 }
 
+# models_referencing_common($feature, @dirs): model names that pull in Common-$feature.
+sub models_referencing_common
+{
+	my ($feature, @dirs) = @_;
+	my %seen_file;
+	my %matches;
+	for my $dir (@dirs)
+	{
+		next if (!defined $dir || !-d $dir);
+		opendir(my $dh, $dir) or next;
+		my @files = grep { /^Model-.+\.nmis$/ } readdir($dh);
+		closedir($dh);
+		for my $f (sort @files)
+		{
+			next if ($seen_file{$f}++);    # first dir wins (custom before default)
+			my $data = NMISNG::Util::readFiletoHash(file => "$dir/$f");
+			next if (ref($data) ne "HASH");
+			my $class = $data->{'-common-'}{class};
+			next if (ref($class) ne "HASH");
+			for my $c (keys %$class)
+			{
+				if (($class->{$c}{'common-model'} // '') eq $feature)
+				{
+					my $name = $f; $name =~ s/\.nmis$//;
+					$matches{$name} = 1;
+					last;
+				}
+			}
+		}
+	}
+	return sort keys %matches;
+}
+
 1;

--- a/lib/NMISNG/ModelReduce.pm
+++ b/lib/NMISNG/ModelReduce.pm
@@ -5,6 +5,7 @@ package NMISNG::ModelReduce;
 #
 use strict;
 use warnings;
+use Clone;
 
 our $VERSION = "9.6.5";
 
@@ -108,6 +109,33 @@ sub classify
 	return "drift" if (@{$diff->{drop}} || @{$diff->{typeconflict}});
 	return "reducible" if (@{$diff->{set}});
 	return "identical";
+}
+
+# build_override($diff): rebuild a hashref from the diff's set entries only.
+sub build_override
+{
+	my ($diff) = @_;
+	my $override = {};
+	for my $entry (@{$diff->{set}})
+	{
+		_set_path($override, $entry->{path}, Clone::clone($entry->{value}));
+	}
+	return $override;
+}
+
+# _set_path($hash, \@path, $value): set a nested value, creating intermediate hashes.
+sub _set_path
+{
+	my ($hash, $path, $value) = @_;
+	my $node = $hash;
+	for my $i (0 .. $#$path - 1)
+	{
+		my $k = $path->[$i];
+		$node->{$k} = {} if (ref($node->{$k}) ne "HASH");
+		$node = $node->{$k};
+	}
+	$node->{$path->[-1]} = $value;
+	return;
 }
 
 1;

--- a/lib/NMISNG/ModelReduce.pm
+++ b/lib/NMISNG/ModelReduce.pm
@@ -282,4 +282,93 @@ sub verify_reduction
 	return { ok => 1, models => \@models, mismatch => undef };
 }
 
+# analyse(%args): full per-file classification with verification.
+sub analyse
+{
+	my (%args) = @_;
+	my $custom_dir  = $args{custom_dir};
+	my $default_dir = $args{default_dir};
+	my $config      = $args{config};
+	my $only        = $args{only};
+
+	my @results;
+	opendir(my $dh, $custom_dir) or die "cannot read $custom_dir: $!\n";
+	my @files = sort grep { /\.nmis$/ } readdir($dh);
+	closedir($dh);
+
+	for my $f (@files)
+	{
+		my $basename = $f; $basename =~ s/\.nmis$//;
+		next if (defined $only && $basename ne $only);
+
+		if ($basename =~ /^Override-/)
+		{
+			push @results, { basename=>$basename, category=>"skip-override" };
+			next;
+		}
+		if ($basename =~ /^Graph-/)
+		{
+			push @results, { basename=>$basename, category=>"skip-graph" };
+			next;
+		}
+		if ($basename !~ /^(Model|Common)-/)
+		{
+			push @results, { basename=>$basename, category=>"skip-override" };
+			next;
+		}
+		if (!-e "$default_dir/$f")
+		{
+			push @results, { basename=>$basename, category=>"skip-no-default" };
+			next;
+		}
+
+		my $custom  = NMISNG::Util::readFiletoHash(file => "$custom_dir/$f");
+		my $default = NMISNG::Util::readFiletoHash(file => "$default_dir/$f");
+		if (ref($custom) ne "HASH" || ref($default) ne "HASH")
+		{
+			push @results, { basename=>$basename, category=>"error",
+				error => "unparseable: " . (ref($custom) ne "HASH" ? $custom : $default) };
+			next;
+		}
+
+		my $diff = semantic_diff($default, $custom);
+		my $cat  = classify($diff);
+
+		if ($cat eq "identical")
+		{
+			my $v = verify_reduction(basename=>$basename, custom_dir=>$custom_dir,
+				default_dir=>$default_dir, config=>$config, override=>undef);
+			push @results, { basename=>$basename, category=>"identical",
+				verified=>($v->{ok}?1:0), override=>undef };
+		}
+		elsif ($cat eq "reducible")
+		{
+			my $override = build_override($diff);
+			my $v = verify_reduction(basename=>$basename, custom_dir=>$custom_dir,
+				default_dir=>$default_dir, config=>$config, override=>$override);
+			# if the loader disagrees, keep the copy and report it as drift-like
+			push @results, {
+				basename => $basename,
+				category => ($v->{ok} ? "reducible" : "error"),
+				verified => ($v->{ok}?1:0),
+				override => $override,
+				error    => ($v->{ok} ? undef : "verification mismatch on $v->{mismatch}"),
+			};
+		}
+		else # drift
+		{
+			my @drops = map { join("/", @{$_->{path}}) } @{$diff->{drop}};
+			push @drops, map { join("/", @{$_->{path}})." (type conflict)" } @{$diff->{typeconflict}};
+			push @results, {
+				basename => $basename,
+				category => "drift",
+				verified => 0,
+				override => build_override($diff),   # manual-start (adds/changes only)
+				drops    => \@drops,
+			};
+		}
+	}
+	return \@results;
+}
+
 1;

--- a/lib/NMISNG/ModelReduce.pm
+++ b/lib/NMISNG/ModelReduce.pm
@@ -265,21 +265,51 @@ sub verify_reduction
 		@models = models_referencing_common($feature, $after_cus, $default_dir);
 	}
 
-	return { ok => 0, models => [], mismatch => undef, error => "no models to compile" }
+	return { ok => 0, models => [], mismatch => undef, reason => "no-referencers",
+		error => "no models to compile" }
 		if (!@models);
 
+	my @skipped;
+	my $matched = 0;
 	for my $m (@models)
 	{
 		my $before = compile_model(model => $m, config => $config,
 			default_dir => $default_dir, custom_dir => $before_cus, var_dir => $var_before);
 		my $after  = compile_model(model => $m, config => $config,
 			default_dir => $default_dir, custom_dir => $after_cus, var_dir => $var_after);
-		if (!defined $before || !defined $after || !deep_equal($before, $after))
+		my $bdef = defined $before;
+		my $adef = defined $after;
+
+		# both fail to compile the same way: the reduction cannot affect a model
+		# that does not load, so this model gives no evidence either way. Skip it.
+		if (!$bdef && !$adef)
 		{
-			return { ok => 0, models => \@models, mismatch => $m };
+			push @skipped, $m;
+			next;
 		}
+		# compile status changed (one loads, the other does not): the reduction
+		# changed whether the model compiles. That is a real, unsafe difference.
+		if ($bdef != $adef)
+		{
+			return { ok => 0, models => \@models, mismatch => $m,
+				reason => "compile-status-changed", skipped => \@skipped };
+		}
+		# both compiled: they must be identical.
+		if (!deep_equal($before, $after))
+		{
+			return { ok => 0, models => \@models, mismatch => $m,
+				reason => "differs", skipped => \@skipped };
+		}
+		$matched++;
 	}
-	return { ok => 1, models => \@models, mismatch => undef };
+	# no model actually compiled, so nothing was proven.
+	if ($matched == 0)
+	{
+		return { ok => 0, models => \@models, mismatch => undef,
+			reason => "unverifiable", skipped => \@skipped };
+	}
+	return { ok => 1, models => \@models, mismatch => undef,
+		compiled => $matched, skipped => \@skipped };
 }
 
 # analyse(%args): full per-file classification with verification.
@@ -347,7 +377,13 @@ sub analyse
 			else
 			{
 				# verification failed: cannot trust this reduction, keep the copy.
-				my $why = $v->{mismatch} ? "compiled model differs on $v->{mismatch}"
+				my $r = $v->{reason} // "";
+				my $why =
+					  $r eq "differs" ? "compiled model differs on $v->{mismatch}"
+					: $r eq "compile-status-changed" ? "reduction changes whether $v->{mismatch} compiles"
+					: $r eq "no-referencers" ? "no models to compile"
+					: $r eq "unverifiable" ? "no referencing model could be compiled (skipped: "
+						. join(", ", @{$v->{skipped} // []}) . ")"
 					: ($v->{error} // "verification failed");
 				push @results, { basename=>$basename, category=>"error",
 					verified=>0, override=>undef, error=>$why };

--- a/lib/NMISNG/ModelReduce.pm
+++ b/lib/NMISNG/ModelReduce.pm
@@ -8,6 +8,9 @@ use warnings;
 use Clone;
 use NMISNG::Sys;
 use NMISNG::Log;
+use File::Temp qw(tempdir);
+use File::Path qw(make_path);
+use File::Copy qw(copy);
 
 our $VERSION = "9.6.5";
 
@@ -203,6 +206,80 @@ sub models_referencing_common
 		}
 	}
 	return sort keys %matches;
+}
+
+# _copy_dir_files($src, $dst): copy every *.nmis file from src into dst (flat).
+sub _copy_dir_files
+{
+	my ($src, $dst) = @_;
+	make_path($dst) if (!-d $dst);
+	return if (!-d $src);
+	opendir(my $dh, $src) or return;
+	for my $f (grep { /\.nmis$/ } readdir($dh))
+	{
+		File::Copy::copy("$src/$f", "$dst/$f");
+	}
+	closedir($dh);
+	return;
+}
+
+# verify_reduction(%args): compile affected models before/after and compare.
+sub verify_reduction
+{
+	my (%args) = @_;
+	my $basename    = $args{basename};
+	my $custom_dir  = $args{custom_dir};
+	my $default_dir = $args{default_dir};
+	my $config      = $args{config};
+	my $override    = $args{override};
+
+	my $tmp = tempdir("model-reduce-verify-XXXXXX", TMPDIR => 1, CLEANUP => 1);
+	my $before_cus = "$tmp/before-custom";
+	my $after_cus  = "$tmp/after-custom";
+	my $var_before = "$tmp/var-before";
+	my $var_after  = "$tmp/var-after";
+	make_path("$var_before/nmis_system/model_cache", "$var_after/nmis_system/model_cache");
+
+	# before: exact copy of the real custom dir
+	_copy_dir_files($custom_dir, $before_cus);
+	# after: same, minus the target file, plus the override when given
+	_copy_dir_files($custom_dir, $after_cus);
+	unlink("$after_cus/$basename.nmis");
+	if (defined $override)
+	{
+		NMISNG::Util::writeHashtoFile(
+			file => "$after_cus/Override-$basename.nmis",
+			data => $override, json => 0, conf => $config);
+	}
+
+	# which models to compile
+	my @models;
+	if ($basename =~ /^Model-/)
+	{
+		push @models, $basename;
+	}
+	else # Common-<feature>
+	{
+		my $feature = $basename; $feature =~ s/^Common-//;
+		# scan the after custom dir plus the default dir for referencing models
+		@models = models_referencing_common($feature, $after_cus, $default_dir);
+	}
+
+	return { ok => 0, models => [], mismatch => undef, error => "no models to compile" }
+		if (!@models);
+
+	for my $m (@models)
+	{
+		my $before = compile_model(model => $m, config => $config,
+			default_dir => $default_dir, custom_dir => $before_cus, var_dir => $var_before);
+		my $after  = compile_model(model => $m, config => $config,
+			default_dir => $default_dir, custom_dir => $after_cus, var_dir => $var_after);
+		if (!defined $before || !defined $after || !deep_equal($before, $after))
+		{
+			return { ok => 0, models => \@models, mismatch => $m };
+		}
+	}
+	return { ok => 1, models => \@models, mismatch => undef };
 }
 
 1;

--- a/lib/NMISNG/ModelReduce.pm
+++ b/lib/NMISNG/ModelReduce.pm
@@ -101,4 +101,13 @@ sub _diff_walk
 	return;
 }
 
+# classify($diff): identical | reducible | drift
+sub classify
+{
+	my ($diff) = @_;
+	return "drift" if (@{$diff->{drop}} || @{$diff->{typeconflict}});
+	return "reducible" if (@{$diff->{set}});
+	return "identical";
+}
+
 1;

--- a/lib/NMISNG/ModelReduce.pm
+++ b/lib/NMISNG/ModelReduce.pm
@@ -334,26 +334,24 @@ sub analyse
 		my $diff = semantic_diff($default, $custom);
 		my $cat  = classify($diff);
 
-		if ($cat eq "identical")
+		if ($cat eq "identical" || $cat eq "reducible")
 		{
-			my $v = verify_reduction(basename=>$basename, custom_dir=>$custom_dir,
-				default_dir=>$default_dir, config=>$config, override=>undef);
-			push @results, { basename=>$basename, category=>"identical",
-				verified=>($v->{ok}?1:0), override=>undef };
-		}
-		elsif ($cat eq "reducible")
-		{
-			my $override = build_override($diff);
+			my $override = ($cat eq "reducible") ? build_override($diff) : undef;
 			my $v = verify_reduction(basename=>$basename, custom_dir=>$custom_dir,
 				default_dir=>$default_dir, config=>$config, override=>$override);
-			# if the loader disagrees, keep the copy and report it as drift-like
-			push @results, {
-				basename => $basename,
-				category => ($v->{ok} ? "reducible" : "error"),
-				verified => ($v->{ok}?1:0),
-				override => $override,
-				error    => ($v->{ok} ? undef : "verification mismatch on $v->{mismatch}"),
-			};
+			if ($v->{ok})
+			{
+				push @results, { basename=>$basename, category=>$cat,
+					verified=>1, override=>$override };
+			}
+			else
+			{
+				# verification failed: cannot trust this reduction, keep the copy.
+				my $why = $v->{mismatch} ? "compiled model differs on $v->{mismatch}"
+					: ($v->{error} // "verification failed");
+				push @results, { basename=>$basename, category=>"error",
+					verified=>0, override=>undef, error=>$why };
+			}
 		}
 		else # drift
 		{

--- a/lib/NMISNG/ModelReduce.pm
+++ b/lib/NMISNG/ModelReduce.pm
@@ -47,4 +47,58 @@ sub deep_equal
 	return ("$a" eq "$b") ? 1 : 0;
 }
 
+# semantic_diff($default, $custom): classify differences. See interface doc.
+sub semantic_diff
+{
+	my ($default, $custom) = @_;
+	my $result = { set => [], drop => [], typeconflict => [] };
+	_diff_walk($default, $custom, [], $result);
+	return $result;
+}
+
+sub _diff_walk
+{
+	my ($default, $custom, $path, $result) = @_;
+
+	# both hashes: recurse over the union of keys
+	if (ref($default) eq "HASH" && ref($custom) eq "HASH")
+	{
+		my %allkeys = map { $_ => 1 } (keys %$default, keys %$custom);
+		for my $k (sort keys %allkeys)
+		{
+			my $subpath = [@$path, $k];
+			my $in_def = exists $default->{$k};
+			my $in_cus = exists $custom->{$k};
+
+			if ($in_def && !$in_cus)
+			{
+				push @{$result->{drop}}, { path => $subpath };
+			}
+			elsif (!$in_def && $in_cus)
+			{
+				push @{$result->{set}}, { path => $subpath, value => $custom->{$k} };
+			}
+			else
+			{
+				_diff_walk($default->{$k}, $custom->{$k}, $subpath, $result);
+			}
+		}
+		return;
+	}
+
+	# base is a hash but custom is not: merge would fail
+	if (ref($default) eq "HASH" && ref($custom) ne "HASH")
+	{
+		push @{$result->{typeconflict}}, { path => $path };
+		return;
+	}
+
+	# leaf, array, or custom-hash-over-base-non-hash: representable, set whole value
+	if (!deep_equal($default, $custom))
+	{
+		push @{$result->{set}}, { path => $path, value => $custom };
+	}
+	return;
+}
+
 1;

--- a/lib/NMISNG/ModelReduce.pm
+++ b/lib/NMISNG/ModelReduce.pm
@@ -1,0 +1,50 @@
+package NMISNG::ModelReduce;
+#
+#  Reduce full custom model copies to Override-*.nmis files when the compiled
+#  model is provably unchanged. Pure logic plus a loader-based verifier.
+#
+use strict;
+use warnings;
+
+our $VERSION = "9.6.5";
+
+# deep_equal($a, $b): true if two Perl structures are deeply equal.
+sub deep_equal
+{
+	my ($a, $b) = @_;
+
+	return 1 if (!defined $a && !defined $b);
+	return 0 if (!defined $a || !defined $b);
+
+	my $ta = ref($a);
+	my $tb = ref($b);
+	return 0 if ($ta ne $tb);
+
+	if ($ta eq "")
+	{
+		return ($a eq $b) ? 1 : 0;
+	}
+	elsif ($ta eq "ARRAY")
+	{
+		return 0 if (scalar(@$a) != scalar(@$b));
+		for my $i (0 .. $#$a)
+		{
+			return 0 if (!deep_equal($a->[$i], $b->[$i]));
+		}
+		return 1;
+	}
+	elsif ($ta eq "HASH")
+	{
+		return 0 if (scalar(keys %$a) != scalar(keys %$b));
+		for my $k (keys %$a)
+		{
+			return 0 if (!exists $b->{$k});
+			return 0 if (!deep_equal($a->{$k}, $b->{$k}));
+		}
+		return 1;
+	}
+	# any other ref type (Regexp, code, etc): compare stringified
+	return ("$a" eq "$b") ? 1 : 0;
+}
+
+1;

--- a/lib/NMISNG/ModelReduce.pm
+++ b/lib/NMISNG/ModelReduce.pm
@@ -6,8 +6,18 @@ package NMISNG::ModelReduce;
 use strict;
 use warnings;
 use Clone;
+use NMISNG::Sys;
+use NMISNG::Log;
 
 our $VERSION = "9.6.5";
+
+# Minimal nmisng-like object: loadModel only needs ->log and ->config.
+{
+	package NMISNG::ModelReduce::FakeNmisng;
+	sub new { my ($c, %a) = @_; bless { %a }, $c; }
+	sub log { $_[0]->{log} }
+	sub config { $_[0]->{config} }
+}
 
 # deep_equal($a, $b): true if two Perl structures are deeply equal.
 sub deep_equal
@@ -136,6 +146,30 @@ sub _set_path
 	}
 	$node->{$path->[-1]} = $value;
 	return;
+}
+
+# compile_model(%args): drive the real loader against isolated dirs.
+sub compile_model
+{
+	my (%args) = @_;
+
+	my $C = Clone::clone($args{config});
+	$C->{'<nmis_default_models>'} = $args{default_dir};
+	$C->{'<nmis_models>'}         = $args{custom_dir};
+	$C->{'<nmis_var>'}            = $args{var_dir};
+	delete $C->{global_model_overrides};
+
+	my $logger = NMISNG::Log->new(level => 'fatal');
+	my $fake = NMISNG::ModelReduce::FakeNmisng->new(config => $C, log => $logger);
+
+	my $sys = NMISNG::Sys->new();
+	$sys->{config}       = $C;
+	$sys->{_nmisng}      = $fake;
+	$sys->{cache_models} = 0;
+
+	my $ok = $sys->loadModel(model => $args{model});
+	return undef if (!$ok);
+	return $sys->{mdl};
 }
 
 1;

--- a/models-default/Common-mib2ip.nmis
+++ b/models-default/Common-mib2ip.nmis
@@ -1,0 +1,105 @@
+#
+## $Id: Common-mib2ip.nmis,v 1.0 Exp $
+#  Copyright 1999-2011 Opmantek Limited (www.opmantek.com)
+#
+#  ALL CODE MODIFICATIONS MUST BE SENT TO CODE@OPMANTEK.COM
+#
+#  This file is part of Network Management Information System (“NMIS”).
+#
+#  NMIS is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  NMIS is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with NMIS (most likely in a file named LICENSE).
+#  If not, see <http://www.gnu.org/licenses/>
+#
+#  For further information on NMIS or for a license other than GPL please see
+#  www.opmantek.com or email contact@opmantek.com
+#
+#  User group details:
+#  http://support.opmantek.com/users/
+#
+# *****************************************************************************
+
+%hash = (
+  'system' => {
+    'rrd' => {
+      'mib2ip' => {
+        'graphtype' => 'ip,frag',
+        'snmp' => {
+          'ipInAddrErrors' => {
+            'oid' => 'ipInAddrErrors',
+            'option' => 'counter,0:U'
+          },
+          'ipFragCreates' => {
+            'oid' => 'ipFragCreates',
+            'option' => 'counter,0:U'
+          },
+          'ipInDiscards' => {
+            'oid' => 'ipInDiscards',
+            'option' => 'counter,0:U'
+          },
+          'ipInReceives' => {
+            'oid' => 'ipInReceives',
+            'option' => 'counter,0:U'
+          },
+          'ipFragOKs' => {
+            'oid' => 'ipFragOKs',
+            'option' => 'counter,0:U'
+          },
+          'ipInDelivers' => {
+            'oid' => 'ipInDelivers',
+            'option' => 'counter,0:U'
+          },
+          'ipReasmFails' => {
+            'oid' => 'ipReasmFails',
+            'option' => 'counter,0:U'
+          },
+          'ipReasmReqds' => {
+            'oid' => 'ipReasmReqds',
+            'option' => 'counter,0:U'
+          },
+          'ipFragFails' => {
+            'oid' => 'ipFragFails',
+            'option' => 'counter,0:U'
+          },
+          'ipOutRequests' => {
+            'oid' => 'ipOutRequests',
+            'option' => 'counter,0:U'
+          },
+          'ipOutNoRoutes' => {
+            'oid' => 'ipOutNoRoutes',
+            'option' => 'counter,0:U'
+          },
+          'ipInHdrErrors' => {
+            'oid' => 'ipInHdrErrors',
+            'option' => 'counter,0:U'
+          },
+          'ipForwDatagrams' => {
+            'oid' => 'ipForwDatagrams',
+            'option' => 'counter,0:U'
+          },
+          'ipOutDiscards' => {
+            'oid' => 'ipOutDiscards',
+            'option' => 'counter,0:U'
+          },
+          'ipReasmOKs' => {
+            'oid' => 'ipReasmOKs',
+            'option' => 'counter,0:U'
+          },
+          'ipInUnknownProtos' => {
+            'oid' => 'ipInUnknownProtos',
+            'option' => 'counter,0:U'
+          }
+        },
+      }
+    },
+  },
+);

--- a/test/t_reduce_model.pl
+++ b/test/t_reduce_model.pl
@@ -77,4 +77,28 @@ is(NMISNG::ModelReduce::classify({set=>[{path=>["a"],value=>1}],drop=>[{path=>["
 is(NMISNG::ModelReduce::classify({set=>[],drop=>[],typeconflict=>[{path=>["a"]}]}),
    "drift", "any type conflict -> drift");
 
+# build_override
+{
+	my $diff = {set=>[
+		{path=>['system','nodeVendor'], value=>'Acme'},
+		{path=>['-common-','class','sdwan-omp'], value=>{'common-model'=>'sdwan-omp'}},
+		{path=>['-common-','class','sdwan-bfd'], value=>{'common-model'=>'sdwan-bfd'}},
+	], drop=>[{path=>['-common-','class','IP-FORWARD']}], typeconflict=>[]};
+	my $ov = NMISNG::ModelReduce::build_override($diff);
+	is_deeply($ov, {
+		system => { nodeVendor => 'Acme' },
+		'-common-' => { class => {
+			'sdwan-omp' => {'common-model'=>'sdwan-omp'},
+			'sdwan-bfd' => {'common-model'=>'sdwan-bfd'},
+		}},
+	}, "build_override rebuilds nested set paths and ignores drops");
+}
+{
+	# values are cloned, not shared
+	my $shared = {x=>1};
+	my $ov = NMISNG::ModelReduce::build_override({set=>[{path=>['a'],value=>$shared}],drop=>[],typeconflict=>[]});
+	$ov->{a}{x} = 99;
+	is($shared->{x}, 1, "build_override clones values");
+}
+
 done_testing();

--- a/test/t_reduce_model.pl
+++ b/test/t_reduce_model.pl
@@ -340,4 +340,45 @@ is(NMISNG::ModelReduce::classify({set=>[],drop=>[],typeconflict=>[{path=>["a"]}]
 	}
 }
 
+# verify_reduction: a referencing model that fails to compile (missing dependency)
+# is skipped, and the reduction still verifies via a healthy referencing model.
+{
+	my $C = NMISNG::Util::loadConfTable();
+	SKIP: {
+		skip "no usable config", 4 if (ref($C) ne "HASH" || !%$C);
+		my $base = tempdir("t-reduce-skip-XXXXXX", TMPDIR => 1, CLEANUP => 1);
+		my $def = "$base/models-default";
+		my $cus = "$base/models-custom";
+		make_path($def, $cus);
+
+		# shared Common referenced by a healthy model and a broken one
+		NMISNG::Util::writeHashtoFile(file=>"$def/Common-Shared.nmis", json=>0, conf=>$C, data=>{
+			systemHealth=>{rrd=>{s=>{threshold=>'base'}}}});
+		NMISNG::Util::writeHashtoFile(file=>"$def/Model-Healthy.nmis", json=>0, conf=>$C, data=>{
+			system=>{nodeVendor=>'V'}, '-common-'=>{class=>{s=>{'common-model'=>'Shared'}}}});
+		# Model-Broken references Shared AND a Common that does not exist -> fails to load
+		NMISNG::Util::writeHashtoFile(file=>"$def/Model-Broken.nmis", json=>0, conf=>$C, data=>{
+			system=>{nodeVendor=>'V'}, '-common-'=>{class=>{
+				s=>{'common-model'=>'Shared'}, m=>{'common-model'=>'DoesNotExist'}}}});
+
+		# custom Common changes a leaf (reducible)
+		NMISNG::Util::writeHashtoFile(file=>"$cus/Common-Shared.nmis", json=>0, conf=>$C, data=>{
+			systemHealth=>{rrd=>{s=>{threshold=>'tuned'}}}});
+
+		my $v = NMISNG::ModelReduce::verify_reduction(
+			basename=>"Common-Shared", custom_dir=>$cus, default_dir=>$def, config=>$C,
+			override=>{systemHealth=>{rrd=>{s=>{threshold=>'tuned'}}}});
+		ok($v->{ok}, "reduction verifies despite a broken referencing model");
+		is_deeply([sort @{$v->{skipped}}], ["Model-Broken"], "broken model was skipped, not a mismatch");
+
+		# when the ONLY referencing model is broken, nothing can be proven -> not ok
+		unlink("$def/Model-Healthy.nmis");
+		my $v2 = NMISNG::ModelReduce::verify_reduction(
+			basename=>"Common-Shared", custom_dir=>$cus, default_dir=>$def, config=>$C,
+			override=>{systemHealth=>{rrd=>{s=>{threshold=>'tuned'}}}});
+		ok(!$v2->{ok}, "no compilable referencing model -> not verified");
+		is($v2->{reason}, "unverifiable", "reason is 'unverifiable' when every referencer failed to compile");
+	}
+}
+
 done_testing();

--- a/test/t_reduce_model.pl
+++ b/test/t_reduce_model.pl
@@ -234,4 +234,41 @@ is(NMISNG::ModelReduce::classify({set=>[],drop=>[],typeconflict=>[{path=>["a"]}]
 	}
 }
 
+# analyse
+{
+	my $C = NMISNG::Util::loadConfTable();
+	SKIP: {
+		skip "no usable config", 5 if (ref($C) ne "HASH" || !%$C);
+		my $base = tempdir("t-reduce-analyse-XXXXXX", TMPDIR => 1, CLEANUP => 1);
+		my $def = "$base/models-default";
+		my $cus = "$base/models-custom";
+		make_path($def, $cus);
+
+		# default files
+		NMISNG::Util::writeHashtoFile(file=>"$def/Model-Same.nmis", json=>0, conf=>$C, data=>{system=>{nodeVendor=>'V'}});
+		NMISNG::Util::writeHashtoFile(file=>"$def/Model-Red.nmis",  json=>0, conf=>$C, data=>{system=>{nodeVendor=>'V'}});
+		NMISNG::Util::writeHashtoFile(file=>"$def/Model-Drift.nmis",json=>0, conf=>$C, data=>{system=>{nodeVendor=>'V'}, extra=>{keep=>1}});
+
+		# custom copies
+		NMISNG::Util::writeHashtoFile(file=>"$cus/Model-Same.nmis", json=>0, conf=>$C, data=>{system=>{nodeVendor=>'V'}});                 # identical
+		NMISNG::Util::writeHashtoFile(file=>"$cus/Model-Red.nmis",  json=>0, conf=>$C, data=>{system=>{nodeVendor=>'Custom'}});            # reducible
+		NMISNG::Util::writeHashtoFile(file=>"$cus/Model-Drift.nmis",json=>0, conf=>$C, data=>{system=>{nodeVendor=>'V'}});                 # drops extra
+		NMISNG::Util::writeHashtoFile(file=>"$cus/Model-Own.nmis",  json=>0, conf=>$C, data=>{system=>{nodeVendor=>'X'}});                 # no default
+		NMISNG::Util::writeHashtoFile(file=>"$cus/Override-Model-Same.nmis", json=>0, conf=>$C, data=>{system=>{x=>1}});                   # existing override
+		NMISNG::Util::writeHashtoFile(file=>"$cus/Graph-cpu.nmis",  json=>0, conf=>$C, data=>{title=>'x'});                                # graph
+
+		my $res = NMISNG::ModelReduce::analyse(custom_dir=>$cus, default_dir=>$def, config=>$C);
+		my %by = map { $_->{basename} => $_ } @$res;
+
+		is($by{"Model-Same"}{category},  "identical",       "identical detected");
+		is($by{"Model-Red"}{category},   "reducible",       "reducible detected");
+		ok($by{"Model-Red"}{verified},                      "reducible verified");
+		is($by{"Model-Drift"}{category}, "drift",           "drift detected");
+		is_deeply($by{"Model-Drift"}{drops}, ["extra"],     "drift lists the dropped top-level section");
+		is($by{"Model-Own"}{category},   "skip-no-default", "genuine custom skipped");
+		is($by{"Graph-cpu"}{category},   "skip-graph",      "graph skipped");
+		is($by{"Override-Model-Same"}{category}, "skip-override", "existing override skipped");
+	}
+}
+
 done_testing();

--- a/test/t_reduce_model.pl
+++ b/test/t_reduce_model.pl
@@ -271,4 +271,36 @@ is(NMISNG::ModelReduce::classify({set=>[],drop=>[],typeconflict=>[{path=>["a"]}]
 	}
 }
 
+# analyse: error category (verify failure with clean diagnostic, and unparseable file)
+{
+	my $C = NMISNG::Util::loadConfTable();
+	SKIP: {
+		skip "no usable config", 4 if (ref($C) ne "HASH" || !%$C);
+		my $base = tempdir("t-reduce-err-XXXXXX", TMPDIR => 1, CLEANUP => 1);
+		my $def = "$base/models-default";
+		my $cus = "$base/models-custom";
+		make_path($def, $cus);
+
+		# a reducible Common that NO model references -> verify has nothing to compile
+		NMISNG::Util::writeHashtoFile(file=>"$def/Common-Lonely.nmis", json=>0, conf=>$C, data=>{
+			systemHealth=>{rrd=>{x=>{threshold=>'base'}}}});
+		NMISNG::Util::writeHashtoFile(file=>"$cus/Common-Lonely.nmis", json=>0, conf=>$C, data=>{
+			systemHealth=>{rrd=>{x=>{threshold=>'tuned'}}}});
+
+		# an unparseable custom file with a valid default counterpart
+		NMISNG::Util::writeHashtoFile(file=>"$def/Model-Bad.nmis", json=>0, conf=>$C, data=>{system=>{nodeVendor=>'V'}});
+		open(my $fh, '>', "$cus/Model-Bad.nmis") or die $!;
+		print $fh "%hash = (this is not valid perl\n";
+		close($fh);
+
+		my $res = NMISNG::ModelReduce::analyse(custom_dir=>$cus, default_dir=>$def, config=>$C);
+		my %by = map { $_->{basename} => $_ } @$res;
+
+		is($by{"Common-Lonely"}{category}, "error", "unreferenced reducible Common -> error");
+		ok(!defined $by{"Common-Lonely"}{override}, "error row carries no override");
+		like($by{"Common-Lonely"}{error}, qr/no models to compile/, "error message is the real reason");
+		is($by{"Model-Bad"}{category}, "error", "unparseable custom file -> error");
+	}
+}
+
 done_testing();

--- a/test/t_reduce_model.pl
+++ b/test/t_reduce_model.pl
@@ -381,4 +381,32 @@ is(NMISNG::ModelReduce::classify({set=>[],drop=>[],typeconflict=>[{path=>["a"]}]
 	}
 }
 
+# verify_reduction: a reduction that breaks compilation is blocked (compile-status-changed)
+{
+	my $C = NMISNG::Util::loadConfTable();
+	SKIP: {
+		skip "no usable config", 2 if (ref($C) ne "HASH" || !%$C);
+		my $base = tempdir("t-reduce-csc-XXXXXX", TMPDIR => 1, CLEANUP => 1);
+		my $def = "$base/models-default";
+		my $cus = "$base/models-custom";
+		make_path($def, $cus);
+
+		# default and custom Model-Foo both load fine (no bogus refs)
+		NMISNG::Util::writeHashtoFile(file=>"$def/Model-Foo.nmis", json=>0, conf=>$C, data=>{
+			system=>{nodeVendor=>'V'}});
+		NMISNG::Util::writeHashtoFile(file=>"$cus/Model-Foo.nmis", json=>0, conf=>$C, data=>{
+			system=>{nodeVendor=>'V'}});
+
+		# An override that, applied on the default base in the AFTER state, references a
+		# Common that does not exist, so the AFTER model fails to load while BEFORE (the
+		# plain custom copy) loads fine.
+		my $v = NMISNG::ModelReduce::verify_reduction(
+			basename=>"Model-Foo", custom_dir=>$cus, default_dir=>$def, config=>$C,
+			override=>{'-common-'=>{class=>{bogus=>{'common-model'=>'NoSuchCommon'}}}});
+		ok(!$v->{ok}, "reduction that breaks compilation is blocked");
+		is($v->{reason}, "compile-status-changed",
+			"reason is compile-status-changed when the after-state fails to load");
+	}
+}
+
 done_testing();

--- a/test/t_reduce_model.pl
+++ b/test/t_reduce_model.pl
@@ -409,4 +409,33 @@ is(NMISNG::ModelReduce::classify({set=>[],drop=>[],typeconflict=>[{path=>["a"]}]
 	}
 }
 
+# apply path end-to-end via the CLI: backup, override write, copy removal, post-apply guard
+{
+	my $C = NMISNG::Util::loadConfTable();
+	SKIP: {
+		skip "no usable config", 5 if (ref($C) ne "HASH" || !%$C);
+		my $base = tempdir("t-reduce-apply-XXXXXX", TMPDIR => 1, CLEANUP => 1);
+		my $def = "$base/models-default";
+		my $cus = "$base/models-custom";
+		make_path($def, $cus);
+
+		# bare models with no commons so they load cleanly in the isolated dirs
+		NMISNG::Util::writeHashtoFile(file=>"$def/Model-ApplyKeep.nmis",   json=>0, conf=>$C, data=>{system=>{nodeVendor=>'V'}});
+		NMISNG::Util::writeHashtoFile(file=>"$def/Model-ApplyChange.nmis", json=>0, conf=>$C, data=>{system=>{nodeVendor=>'V'}});
+		# identical copy (should be removed, no override) and a reducible copy (override + removed)
+		NMISNG::Util::writeHashtoFile(file=>"$cus/Model-ApplyKeep.nmis",   json=>0, conf=>$C, data=>{system=>{nodeVendor=>'V'}});
+		NMISNG::Util::writeHashtoFile(file=>"$cus/Model-ApplyChange.nmis", json=>0, conf=>$C, data=>{system=>{nodeVendor=>'Custom'}});
+
+		my $script = "$FindBin::Bin/../admin/reduce_model.pl";
+		my $out = `echo yes | perl \Q$script\E dir=\Q$cus\E default_dir=\Q$def\E apply=1 2>&1`;
+
+		like($out, qr/All affected models compile identically/, "apply: post-apply guard reports clean");
+		ok(!-e "$cus/Model-ApplyKeep.nmis",   "apply: identical copy removed");
+		ok(!-e "$cus/Model-ApplyChange.nmis", "apply: reducible copy removed");
+		ok(-e "$cus/Override-Model-ApplyChange.nmis", "apply: override written for reducible file");
+		my @bk = glob("$cus/.reduce-backup-*/Model-ApplyChange.nmis");
+		ok(@bk && -e $bk[0], "apply: removed copy backed up before removal");
+	}
+}
+
 done_testing();

--- a/test/t_reduce_model.pl
+++ b/test/t_reduce_model.pl
@@ -5,6 +5,9 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Test::More;
 use NMISNG::ModelReduce;
+use File::Temp qw(tempdir);
+use File::Path qw(make_path);
+use NMISNG::Util;
 
 # deep_equal
 ok(NMISNG::ModelReduce::deep_equal(1, 1), "scalars equal");
@@ -99,6 +102,39 @@ is(NMISNG::ModelReduce::classify({set=>[],drop=>[],typeconflict=>[{path=>["a"]}]
 	my $ov = NMISNG::ModelReduce::build_override({set=>[{path=>['a'],value=>$shared}],drop=>[],typeconflict=>[]});
 	$ov->{a}{x} = 99;
 	is($shared->{x}, 1, "build_override clones values");
+}
+
+# compile_model: base + auto-discovered override merged by the real loader
+{
+	my $C = NMISNG::Util::loadConfTable();
+	SKIP: {
+		skip "no usable config", 3 if (ref($C) ne "HASH" || !%$C);
+
+		my $base = tempdir("t-reduce-XXXXXX", TMPDIR => 1, CLEANUP => 1);
+		my $def = "$base/models-default";
+		my $cus = "$base/models-custom";
+		my $var = "$base/var";
+		make_path($def, $cus, "$var/nmis_system/model_cache");
+
+		NMISNG::Util::writeHashtoFile(file => "$def/Model-Foo.nmis", json => 0, conf => $C, data => {
+			system => { nodeVendor => 'BaseVendor', nodeType => 'router' },
+		});
+
+		my $mdl = NMISNG::ModelReduce::compile_model(
+			model => "Model-Foo", config => $C,
+			default_dir => $def, custom_dir => $cus, var_dir => $var);
+		is(ref($mdl), "HASH", "compile_model returns a hash");
+		is($mdl->{system}{nodeVendor}, 'BaseVendor', "base value present");
+
+		# add an auto-discovered Model override and recompile
+		NMISNG::Util::writeHashtoFile(file => "$cus/Override-Model-Foo.nmis", json => 0, conf => $C, data => {
+			system => { nodeVendor => 'OverriddenVendor' },
+		});
+		my $mdl2 = NMISNG::ModelReduce::compile_model(
+			model => "Model-Foo", config => $C,
+			default_dir => $def, custom_dir => $cus, var_dir => $var);
+		is($mdl2->{system}{nodeVendor}, 'OverriddenVendor', "scoped override applied by real loader");
+	}
 }
 
 done_testing();

--- a/test/t_reduce_model.pl
+++ b/test/t_reduce_model.pl
@@ -303,4 +303,41 @@ is(NMISNG::ModelReduce::classify({set=>[],drop=>[],typeconflict=>[{path=>["a"]}]
 	}
 }
 
+# integration: full outcome mix on synthetic fixtures
+{
+	my $C = NMISNG::Util::loadConfTable();
+	SKIP: {
+		skip "no usable config", 4 if (ref($C) ne "HASH" || !%$C);
+		my $base = tempdir("t-reduce-int-XXXXXX", TMPDIR => 1, CLEANUP => 1);
+		my $def = "$base/models-default";
+		my $cus = "$base/models-custom";
+		make_path($def, $cus);
+
+		# a Common referenced by a model, reducible via override
+		NMISNG::Util::writeHashtoFile(file=>"$def/Common-Feat.nmis", json=>0, conf=>$C, data=>{
+			systemHealth=>{rrd=>{cpu=>{graphtype=>'cpu', threshold=>'base'}}}});
+		NMISNG::Util::writeHashtoFile(file=>"$def/Model-Host.nmis", json=>0, conf=>$C, data=>{
+			system=>{nodeVendor=>'V'}, '-common-'=>{class=>{cpu=>{'common-model'=>'Feat'}}}});
+
+		# custom Common changes a threshold only (reducible)
+		NMISNG::Util::writeHashtoFile(file=>"$cus/Common-Feat.nmis", json=>0, conf=>$C, data=>{
+			systemHealth=>{rrd=>{cpu=>{graphtype=>'cpu', threshold=>'tuned'}}}});
+		# identical model copy
+		NMISNG::Util::writeHashtoFile(file=>"$cus/Model-Host.nmis", json=>0, conf=>$C, data=>{
+			system=>{nodeVendor=>'V'}, '-common-'=>{class=>{cpu=>{'common-model'=>'Feat'}}}});
+
+		my $res = NMISNG::ModelReduce::analyse(custom_dir=>$cus, default_dir=>$def, config=>$C);
+		my %cat;
+		$cat{$_->{category}}++ for @$res;
+
+		is($cat{identical}, 1, "one identical (Model-Host copy)");
+		is($cat{reducible}, 1, "one reducible (Common-Feat)");
+		my ($common) = grep { $_->{basename} eq "Common-Feat" } @$res;
+		ok($common->{verified}, "Common reduction verified via referencing model");
+		is_deeply($common->{override},
+			{systemHealth=>{rrd=>{cpu=>{threshold=>'tuned'}}}},
+			"Common override carries only the changed leaf");
+	}
+}
+
 done_testing();

--- a/test/t_reduce_model.pl
+++ b/test/t_reduce_model.pl
@@ -159,4 +159,42 @@ is(NMISNG::ModelReduce::classify({set=>[],drop=>[],typeconflict=>[{path=>["a"]}]
 	}
 }
 
+# verify_reduction
+{
+	my $C = NMISNG::Util::loadConfTable();
+	SKIP: {
+		skip "no usable config", 3 if (ref($C) ne "HASH" || !%$C);
+		my $base = tempdir("t-reduce-verify-XXXXXX", TMPDIR => 1, CLEANUP => 1);
+		my $def = "$base/models-default";
+		my $cus = "$base/models-custom";
+		make_path($def, $cus);
+
+		# default has vendor Base + nodeType; custom copy changes vendor only.
+		NMISNG::Util::writeHashtoFile(file=>"$def/Model-Bar.nmis", json=>0, conf=>$C, data=>{
+			system=>{nodeVendor=>'Base', nodeType=>'router'}});
+		NMISNG::Util::writeHashtoFile(file=>"$cus/Model-Bar.nmis", json=>0, conf=>$C, data=>{
+			system=>{nodeVendor=>'Custom', nodeType=>'router'}});
+
+		# correct override reproduces the copy: PASS
+		my $good = NMISNG::ModelReduce::verify_reduction(
+			basename=>"Model-Bar", custom_dir=>$cus, default_dir=>$def, config=>$C,
+			override=>{system=>{nodeVendor=>'Custom'}});
+		ok($good->{ok}, "correct override verifies identical");
+
+		# wrong override does NOT reproduce the copy: FAIL
+		my $bad = NMISNG::ModelReduce::verify_reduction(
+			basename=>"Model-Bar", custom_dir=>$cus, default_dir=>$def, config=>$C,
+			override=>{system=>{nodeVendor=>'WRONG'}});
+		ok(!$bad->{ok}, "wrong override fails verification");
+
+		# identical case: copy equals default, removal with no override verifies
+		NMISNG::Util::writeHashtoFile(file=>"$cus/Model-Bar.nmis", json=>0, conf=>$C, data=>{
+			system=>{nodeVendor=>'Base', nodeType=>'router'}});
+		my $same = NMISNG::ModelReduce::verify_reduction(
+			basename=>"Model-Bar", custom_dir=>$cus, default_dir=>$def, config=>$C,
+			override=>undef);
+		ok($same->{ok}, "identical copy removal verifies");
+	}
+}
+
 done_testing();

--- a/test/t_reduce_model.pl
+++ b/test/t_reduce_model.pl
@@ -137,4 +137,26 @@ is(NMISNG::ModelReduce::classify({set=>[],drop=>[],typeconflict=>[{path=>["a"]}]
 	}
 }
 
+# models_referencing_common
+{
+	my $C = NMISNG::Util::loadConfTable();
+	SKIP: {
+		skip "no usable config", 2 if (ref($C) ne "HASH" || !%$C);
+		my $base = tempdir("t-reduce-ref-XXXXXX", TMPDIR => 1, CLEANUP => 1);
+		my $def = "$base/models-default";
+		make_path($def);
+		NMISNG::Util::writeHashtoFile(file=>"$def/Model-Uses.nmis", json=>0, conf=>$C, data=>{
+			'-common-'=>{class=>{cpu=>{'common-model'=>'WidgetCpu'}}}});
+		NMISNG::Util::writeHashtoFile(file=>"$def/Model-AlsoUses.nmis", json=>0, conf=>$C, data=>{
+			'-common-'=>{class=>{cpu=>{'common-model'=>'WidgetCpu'}, ip=>{'common-model'=>'Other'}}}});
+		NMISNG::Util::writeHashtoFile(file=>"$def/Model-Nope.nmis", json=>0, conf=>$C, data=>{
+			'-common-'=>{class=>{ip=>{'common-model'=>'Other'}}}});
+
+		my @refs = NMISNG::ModelReduce::models_referencing_common("WidgetCpu", $def);
+		is_deeply(\@refs, ["Model-AlsoUses","Model-Uses"], "finds all referencing models, sorted");
+		my @none = NMISNG::ModelReduce::models_referencing_common("Missing", $def);
+		is_deeply(\@none, [], "no references -> empty list");
+	}
+}
+
 done_testing();

--- a/test/t_reduce_model.pl
+++ b/test/t_reduce_model.pl
@@ -20,4 +20,51 @@ ok(NMISNG::ModelReduce::deep_equal(undef, undef), "both undef equal");
 ok(!NMISNG::ModelReduce::deep_equal(undef, 1), "undef vs value differ");
 ok(!NMISNG::ModelReduce::deep_equal({a=>1}, [1]), "hash vs array differ");
 
+# semantic_diff
+{
+	my $d = NMISNG::ModelReduce::semantic_diff({a=>1}, {a=>1});
+	is_deeply($d, {set=>[],drop=>[],typeconflict=>[]}, "identical -> empty diff");
+}
+{
+	# added key (custom only)
+	my $d = NMISNG::ModelReduce::semantic_diff({a=>1}, {a=>1, b=>2});
+	is_deeply($d->{set}, [{path=>["b"], value=>2}], "added key -> set");
+	is_deeply($d->{drop}, [], "added key -> no drop");
+}
+{
+	# changed leaf
+	my $d = NMISNG::ModelReduce::semantic_diff({a=>1}, {a=>5});
+	is_deeply($d->{set}, [{path=>["a"], value=>5}], "changed leaf -> set custom value");
+}
+{
+	# dropped key (default only)
+	my $d = NMISNG::ModelReduce::semantic_diff({a=>1, b=>2}, {a=>1});
+	is_deeply($d->{drop}, [{path=>["b"]}], "default-only key -> drop");
+	is_deeply($d->{set}, [], "dropped key -> no set");
+}
+{
+	# array replaced wholesale (any difference -> whole array as set)
+	my $d = NMISNG::ModelReduce::semantic_diff({a=>[1,2,3]}, {a=>[1,2]});
+	is_deeply($d->{set}, [{path=>["a"], value=>[1,2]}], "array diff -> whole custom array");
+}
+{
+	# nested add under a shared hash
+	my $d = NMISNG::ModelReduce::semantic_diff(
+		{'-common-'=>{class=>{a=>{'common-model'=>'a'}}}},
+		{'-common-'=>{class=>{a=>{'common-model'=>'a'}, b=>{'common-model'=>'b'}}}});
+	is_deeply($d->{set}, [{path=>['-common-','class','b'], value=>{'common-model'=>'b'}}],
+		"nested add -> single set at the new key");
+}
+{
+	# type conflict: base hash, custom scalar
+	my $d = NMISNG::ModelReduce::semantic_diff({a=>{x=>1}}, {a=>5});
+	is_deeply($d->{typeconflict}, [{path=>["a"]}], "hash-over-scalar -> typeconflict");
+	is_deeply($d->{set}, [], "type conflict -> no set");
+}
+{
+	# custom hash over base scalar is representable (set)
+	my $d = NMISNG::ModelReduce::semantic_diff({a=>5}, {a=>{x=>1}});
+	is_deeply($d->{set}, [{path=>["a"], value=>{x=>1}}], "custom hash over scalar -> set");
+}
+
 done_testing();

--- a/test/t_reduce_model.pl
+++ b/test/t_reduce_model.pl
@@ -197,4 +197,41 @@ is(NMISNG::ModelReduce::classify({set=>[],drop=>[],typeconflict=>[{path=>["a"]}]
 	}
 }
 
+# verify_reduction: Common target referenced by multiple models
+{
+	my $C = NMISNG::Util::loadConfTable();
+	SKIP: {
+		skip "no usable config", 3 if (ref($C) ne "HASH" || !%$C);
+		my $base = tempdir("t-reduce-common-XXXXXX", TMPDIR => 1, CLEANUP => 1);
+		my $def = "$base/models-default";
+		my $cus = "$base/models-custom";
+		make_path($def, $cus);
+
+		# default: Common-Widget + two models referencing it
+		NMISNG::Util::writeHashtoFile(file=>"$def/Common-Widget.nmis", json=>0, conf=>$C, data=>{
+			systemHealth=>{rrd=>{w=>{graphtype=>'w', threshold=>'base'}}}});
+		NMISNG::Util::writeHashtoFile(file=>"$def/Model-A.nmis", json=>0, conf=>$C, data=>{
+			system=>{nodeVendor=>'V'}, '-common-'=>{class=>{w=>{'common-model'=>'Widget'}}}});
+		NMISNG::Util::writeHashtoFile(file=>"$def/Model-B.nmis", json=>0, conf=>$C, data=>{
+			system=>{nodeVendor=>'V'}, '-common-'=>{class=>{w=>{'common-model'=>'Widget'}}}});
+
+		# custom copy of the Common changes the threshold leaf (reducible)
+		NMISNG::Util::writeHashtoFile(file=>"$cus/Common-Widget.nmis", json=>0, conf=>$C, data=>{
+			systemHealth=>{rrd=>{w=>{graphtype=>'w', threshold=>'tuned'}}}});
+
+		my $good = NMISNG::ModelReduce::verify_reduction(
+			basename=>"Common-Widget", custom_dir=>$cus, default_dir=>$def, config=>$C,
+			override=>{systemHealth=>{rrd=>{w=>{threshold=>'tuned'}}}});
+		ok($good->{ok}, "Common reduction verifies across referencing models");
+		is_deeply([sort @{$good->{models}}], ["Model-A","Model-B"],
+			"both referencing models were compiled");
+
+		# a Common with no referencers -> nothing to compile -> not ok
+		my $orphan = NMISNG::ModelReduce::verify_reduction(
+			basename=>"Common-Orphan", custom_dir=>$cus, default_dir=>$def, config=>$C,
+			override=>{x=>1});
+		ok(!$orphan->{ok}, "Common with no referencers returns not-ok");
+	}
+}
+
 done_testing();

--- a/test/t_reduce_model.pl
+++ b/test/t_reduce_model.pl
@@ -67,4 +67,14 @@ ok(!NMISNG::ModelReduce::deep_equal({a=>1}, [1]), "hash vs array differ");
 	is_deeply($d->{set}, [{path=>["a"], value=>{x=>1}}], "custom hash over scalar -> set");
 }
 
+# classify
+is(NMISNG::ModelReduce::classify({set=>[],drop=>[],typeconflict=>[]}),
+   "identical", "no differences -> identical");
+is(NMISNG::ModelReduce::classify({set=>[{path=>["a"],value=>1}],drop=>[],typeconflict=>[]}),
+   "reducible", "sets only -> reducible");
+is(NMISNG::ModelReduce::classify({set=>[{path=>["a"],value=>1}],drop=>[{path=>["b"]}],typeconflict=>[]}),
+   "drift", "any drop -> drift");
+is(NMISNG::ModelReduce::classify({set=>[],drop=>[],typeconflict=>[{path=>["a"]}]}),
+   "drift", "any type conflict -> drift");
+
 done_testing();

--- a/test/t_reduce_model.pl
+++ b/test/t_reduce_model.pl
@@ -1,0 +1,23 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use Test::More;
+use NMISNG::ModelReduce;
+
+# deep_equal
+ok(NMISNG::ModelReduce::deep_equal(1, 1), "scalars equal");
+ok(!NMISNG::ModelReduce::deep_equal(1, 2), "scalars differ");
+ok(NMISNG::ModelReduce::deep_equal("a", "a"), "strings equal");
+ok(NMISNG::ModelReduce::deep_equal([1,2,3], [1,2,3]), "arrays equal");
+ok(!NMISNG::ModelReduce::deep_equal([1,2], [1,2,3]), "arrays differ by length");
+ok(!NMISNG::ModelReduce::deep_equal([1,2,3], [1,9,3]), "arrays differ by element");
+ok(NMISNG::ModelReduce::deep_equal({a=>1,b=>{c=>2}}, {b=>{c=>2},a=>1}),
+   "nested hashes equal regardless of key order");
+ok(!NMISNG::ModelReduce::deep_equal({a=>1}, {a=>1,b=>2}), "hashes differ by key");
+ok(NMISNG::ModelReduce::deep_equal(undef, undef), "both undef equal");
+ok(!NMISNG::ModelReduce::deep_equal(undef, 1), "undef vs value differ");
+ok(!NMISNG::ModelReduce::deep_equal({a=>1}, [1]), "hash vs array differ");
+
+done_testing();


### PR DESCRIPTION
Adds admin/reduce_model.pl, which turns bulky full-copy models in models-custom/ into small Override-*.nmis files, but only when it can prove the compiled model is unchanged. This automates the manual "diff then hand-write an override" process that docs/model-loading.md currently describes.
For each custom Model-*/Common-* it does a structure-level diff against the shipped default and sorts it into one of three outcomes:
- identical to the default → the copy is redundant, so remove it.
- reducible (only adds/changes) → write an override with just those, remove the copy.
- drift (the copy is missing a key the current default has) → leave it alone and report it, since an override cannot delete a base key.
Every proposed change is checked by compiling the model both ways with the real NMIS loader (NMISNG::Sys) and comparing the merged result, so nothing is applied unless the output is byte-identical. It runs read-only by default. apply=1 backs up each copy before removing it, then runs a post-apply recompile guard. It needs no git, MongoDB, or SNMP, so it is safe to run on a live server.
Also included: models-default/Common-mib2ip.nmis, ported byte-identical from NMIS8. Five default models reference common-model => 'mib2ip' but the file was never carried over in the v8→v9 migration. Three more missing commons (calls, Cisco-system, ifTable, plus entity to investigate) are noted for a separate PR.
Tests: perl test/t_reduce_model.pl, 66 assertions, all passing (pure logic, real-loader verification edge cases, and an end-to-end apply=1 run).