### PR TITLE
Bug fix/omk 12755 : Model File Invalid event not clearing — silent loadModel failures and dangling model references

### DIFF
--- a/conf-default/Config.nmis
+++ b/conf-default/Config.nmis
@@ -134,6 +134,7 @@ my %hash = (
 	'log_node_configuration_events' => 'false',
 	'max_child_runtime' => undef, 		# maximum runtime of per-node operations (ie. collect, update, services). unlimited if set to zero or undef
 	'model_health_sections' => 'cpu_cpm,entityMib,diskIOTable,ds3Errors,SONETErrors',
+	'model_load_strict' => 'false', # true: never cache partially loaded models, missing model dependencies make the cache stale. installer sets true for new installs, upgrades stay false (OMK-12755)
 	'network_health_view' => 'Group',
 	'network_summary_maxgroups' => 30,
 	'network_viewNode_field_list' => 'nodestatus,outage,sysName,host_addr,host_addr_backup,ip_protocol,group,customer,location,businessService,serviceStatus,notes,nodeType,nodeModel,polling_policy,sysUpTime,sysLocation,sysContact,sysDescr,ifNumber,last_ping,last_poll,last_update,nodeVendor,sysObjectName,roleType,netType',

--- a/installer_hooks/05-postcopy-configfiles
+++ b/installer_hooks/05-postcopy-configfiles
@@ -18,6 +18,11 @@ if [ -n "$CLEANSLATE" ]; then
 		execPrint "$TARGETDIR/admin/patch_config.pl -b $TARGETDIR/conf/Config.nmis '/tools/mtr'=mtr"
 		execPrint "$TARGETDIR/admin/patch_config.pl -b $TARGETDIR/conf/Config.nmis '/tools/lft'=lft"
 
+		## new installs get strict model loading: no caching of partially
+		## loaded models, missing model dependencies make the cache stale.
+		## upgrades keep the lenient template default of 'false' (OMK-12755).
+		execPrint "$TARGETDIR/admin/patch_config.pl -b $TARGETDIR/conf/Config.nmis /system/model_load_strict=true"
+
 else
 		# upgrade case
 		printBanner "Updating (missing) configuration files"

--- a/lib/NMISNG/Node.pm
+++ b/lib/NMISNG/Node.pm
@@ -2348,7 +2348,8 @@ sub update_node_info
 					Compat::NMIS::notify(
 						sys     => $S,
 						event   => "Model File Invalid",
-						details => "Model $catchall_data->{nodeModel} could not be loaded",
+						details => "Model $catchall_data->{nodeModel} could not be loaded: "
+									. ($S->status->{error} // "unknown error"),
 						context => {type => "node"},
 						inventory_id => $catchall_inventory->{_id}{hex}
 					);

--- a/lib/NMISNG/Sys.pm
+++ b/lib/NMISNG/Sys.pm
@@ -1740,6 +1740,31 @@ sub loadModel
 	my $catchall_data = $self->{name}? $self->inventory( concept => 'catchall' )->data_live() : {};
 	my $C = $self->{config} // NMISNG::Util::loadConfTable();    # needed to determine the correct dir; generally cached and a/v anyway
 
+	# loadModel reports only its own failures: an error left over from an
+	# earlier operation must not leak into this load's result (or into the
+	# Model File Invalid event raised from it). see OMK-12755.
+	delete $self->{error};
+
+	# strict mode: never cache a partially loaded model, treat a missing
+	# dependency file as stale. default (key absent) is lenient so upgraded
+	# installs keep their existing behaviour; the installer enables strict
+	# for new installs.
+	my $strict = NMISNG::Util::getbool($C->{model_load_strict});
+
+	# ALL load failures are collected and reported in one go: every failure
+	# lands in $self->{error} (and thus in the event details), and exactly
+	# one error line is logged per failed load.
+	my @errors;
+	my $finish = sub {
+		if (@errors)
+		{
+			$exit = 0;
+			$self->{error} = "ERROR (".($self->{name} // '').") model $model: ".join("; ", @errors);
+			$self->nmisng->log->error($self->{error});
+		}
+		return $exit;
+	};
+
 	# load the policy document (if any)
 	my $modelpol = NMISNG::Util::loadTable( dir => 'conf', name => 'Model-Policy', conf => $C );
 	if ( ref($modelpol) ne "HASH" or !keys %$modelpol )
@@ -1763,8 +1788,10 @@ sub loadModel
 		$self->{mdl} = NMISNG::Util::readFiletoHash( file => $thiscf, json => 1, lock => 0, conf => $C );
 		if ( ref( $self->{mdl} ) ne "HASH" or !keys %{$self->{mdl}} )
 		{
-			$self->{error} = "ERROR ($self->{name}) failed to load Model (from cache): $self->{mdl}";
-			$exit = 0;
+			# a broken cache file is not fatal: fall through to a source load,
+			# which rewrites the cache. visible as warning, not as failure.
+			$self->nmisng->log->warn("(".($self->{name} // '').") failed to load cached model for $model, reloading from source: $self->{mdl}");
+			$self->{mdl} = undef;
 		}
 		else
 		{
@@ -1789,9 +1816,19 @@ sub loadModel
 				else
 				{
 					my $meta =  NMISNG::Util::getModelFile(model => $other, only_mtime => 1, conf => $C );
-					$othermtime = $meta->{mtime} if ($meta->{success});
+					if ($meta->{success})
+					{
+						$othermtime = $meta->{mtime};
+					}
+					elsif ($strict)
+					{
+						# strict: a cache whose ingredient is gone cannot be trusted
+						$self->nmisng->log->debug2(sub {"Cached model \"$model\" stale: dependency \"$other\" unavailable: $meta->{error}"});
+						$isstale = 1;
+						last;
+					}
 				}
-				if ($othermtime > $cfage)
+				if (defined($othermtime) && $othermtime > $cfage)
 				{
 					$self->nmisng->log->debug2(sub {"Cached model \"$model\" stale: mtime $cfage, older than \"$other\" ($othermtime)."});
 					$isstale = 1;
@@ -1902,7 +1939,7 @@ sub loadModel
 		my $res = NMISNG::Util::getModelFile(model => $model, conf => $C );
 		if (!$res->{success})
 		{
-			$self->{error} = "ERROR ($self->{name}) failed to load Model file for $model: $res->{error}!";
+			push @errors, "failed to load Model file for $model: $res->{error}";
 			$exit = 0;
 		}
 		else
@@ -1930,21 +1967,21 @@ sub loadModel
 				my $data = NMISNG::Util::loadTable(dir => "models", name => "$name.nmis", conf => $C);
 				if (ref($data) ne "HASH" or !keys %$data)
 				{
-					$self->{error} = "ERROR ($self->{name}) failed to read scoped override $path: $data";
+					push @errors, "failed to read scoped override $path: $data";
 					$exit = 0;
-					return 0;
+					return 1;			# a broken override file is collected, not terminal
 				}
 				if (!$self->_mergeHash($self->{mdl}, $data))
 				{
-					$self->{error} = "ERROR ($self->{name}) scoped override merge failed for $path!";
-					return 0;
+					push @errors, "scoped override merge failed for $path: ".($self->{error} // '');
+					return 0;			# an unmergeable model is terminal
 				}
 				push @applied_overrides, { path => $path, mtime => $mtime };
 				return 1;
 			};
 
 			# apply Override-Model-<shortname> right after the main model is in place
-			return 0 if (!$apply_scoped_override->("Override-Model-$shortname"));
+			return $finish->() if (!$apply_scoped_override->("Override-Model-$shortname"));
 
 			# continue with loading common Models, sorted using characters because we didn't use numbers here...
 			foreach my $class (sort  {$a cmp $b} keys %{$self->{mdl}{'-common-'}{class}} )
@@ -1954,7 +1991,7 @@ sub loadModel
 				my $commonres = NMISNG::Util::getModelFile(model => $name, conf => $C);
 				if (!$commonres->{success})
 				{
-					$self->{error} = "ERROR ($self->{name}) failed to read Model file $name: $commonres->{error}!";
+					push @errors, "failed to read Model file $name: $commonres->{error}";
 					$exit = 0;
 				}
 				else
@@ -1963,11 +2000,11 @@ sub loadModel
 					# however, an unmergeable model is terminal, mustn't be cached, useless.
 					if ( !$self->_mergeHash( $self->{mdl}, $commonres->{data} ) )
 					{
-						$self->{error} = "ERROR ($self->{name}) model merging failed!";
-						return 0;
+						push @errors, "merging of $name failed: ".($self->{error} // '');
+						return $finish->();
 					}
 					# apply Override-Common-<feature> immediately after its base Common file
-					return 0 if (!$apply_scoped_override->("Override-Common-$feature"));
+					return $finish->() if (!$apply_scoped_override->("Override-Common-$feature"));
 				}
 			}
 			# after all models are loaded add in override files
@@ -1977,7 +2014,7 @@ sub loadModel
 				my $commonres = NMISNG::Util::getModelFile(model => $name, conf => $C);
 					if (!$commonres->{success})
 				{
-					$self->{error} = "ERROR ($self->{name}) failed to read Model file $name: $commonres->{error}!";
+					push @errors, "failed to read Model file $name: $commonres->{error}";
 					$exit = 0;
 				}
 				else
@@ -1986,8 +2023,8 @@ sub loadModel
 					# however, an unmergeable model is terminal, mustn't be cached, useless.
 					if ( !$self->_mergeHash( $self->{mdl}, $commonres->{data} ) )
 					{
-						$self->{error} = "ERROR ($self->{name}) model merging failed!";
-						return 0;
+						push @errors, "merging of $name failed: ".($self->{error} // '');
+						return $finish->();
 					}
 				}
 			}
@@ -2024,8 +2061,9 @@ sub loadModel
 				}
 			}
 
-			# save to cache BEFORE the policy application, if caching is on OR if in update operation
-			if ( -d $modelcachedir && ( $self->{cache_models} || $self->{update} ) )
+			# save to cache BEFORE the policy application, if caching is on OR if in update operation.
+			# strict mode never caches a partially loaded model.
+			if ( -d $modelcachedir && ( $self->{cache_models} || $self->{update} ) && ($exit || !$strict) )
 			{
 				NMISNG::Util::writeHashtoFile( file => $thiscf, data => $self->{mdl}, json => 1, pretty => 0, conf => $C );
 				# sidecar with the list of scoped overrides actually merged in. Used by the freshness check
@@ -2183,8 +2221,8 @@ sub loadModel
 			$gt2sc->{$onegt} = $fixedsubconcept;
 		}
 	}
-			
-	return $exit;
+
+	return $finish->();
 }
 
 # small internal helper that merges two hashes
@@ -2205,12 +2243,15 @@ sub _mergeHash
 
 		if ( ref( $dest->{$k} ) eq "HASH" and ref($v) eq "HASH" )
 		{
-			$self->_mergeHash( $dest->{$k}, $source->{$k}, $lvl );
+			# a nested merge failure must propagate, not be swallowed
+			$self->_mergeHash( $dest->{$k}, $source->{$k}, $lvl )
+					or return undef;
 		}
 		elsif ( ref( $dest->{$k} ) eq "HASH" and ref($v) ne "HASH" )
 		{
 			$self->{error} = "cannot merge inconsistent hash: key=$k, value=$v, value is " . ref($v);
-			$self->nmisng->log->error( "($self->{name}) " . $self->{error} );
+			# detail is reported (with the file name) by loadModel's single error line
+			$self->nmisng->log->debug( "(".($self->{name} // '').") " . $self->{error} );
 			return undef;
 		}
 		else

--- a/models-default/Common-ifTable.nmis
+++ b/models-default/Common-ifTable.nmis
@@ -1,0 +1,100 @@
+#
+## $Id: Common-database.nmis,v 8.4 2012/08/14 12:20:36 keiths Exp $
+#
+#  Copyright 1999-2011 Opmantek Limited (www.opmantek.com)
+#  
+#  ALL CODE MODIFICATIONS MUST BE SENT TO CODE@OPMANTEK.COM
+#  
+#  This file is part of Network Management Information System (“NMIS”).
+#  
+#  NMIS is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  
+#  NMIS is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  
+#  You should have received a copy of the GNU General Public License
+#  along with NMIS (most likely in a file named LICENSE).  
+#  If not, see <http://www.gnu.org/licenses/>
+#  
+#  For further information on NMIS or for a license other than GPL please see
+#  www.opmantek.com or email contact@opmantek.com 
+#  
+#  User group details:
+#  http://support.opmantek.com/users/
+#  
+# *****************************************************************************
+
+%hash = (
+  'systemHealth' => {
+    'sys' => {
+      'ifTable' => {
+        'indexed' => 'ifIndex',
+        'headers' => 'ifIndex,ifDescr,ifType,ifAdminStatus,ifOperStatus,ifName,ifLastChange',
+        'snmp' => {
+          'ifIndex' => {
+            'oid' => 'ifIndex',
+            'title' => 'Interface Index'
+          },
+          'ifDescr' => {
+            'oid' => 'ifDescr',
+            'title' => 'Name (ifDescr)'
+          },
+          'ifType' => {
+            'oid' => 'ifType',
+            'title' => 'Type (ifType)',
+            'replace' => {
+              '6' => 'ethernetCsmacd',
+              '37' => 'atm',
+              '135' => 'l2vlan',
+              '194' => 'atmVciEndPt',
+              '209' => 'bridge',
+              '244' => 'wwanPP2',
+              '249' => 'aluELP',
+              '250' => 'gpon',
+            },              
+          },
+          'ifAdminStatus' => {
+            'replace' => {
+              '6' => 'notPresent',
+              '4' => 'unknown',
+              '1' => 'up',
+              '3' => 'testing',
+              '7' => 'lowerLayerDown',
+              '2' => 'down',
+              '5' => 'dormant'
+            },
+            'oid' => 'ifAdminStatus',
+            'title' => 'Admin Status'
+          },
+          'ifOperStatus' => {
+            'replace' => {
+              '6' => 'notPresent',
+              '4' => 'unknown',
+              '1' => 'up',
+              '3' => 'testing',
+              '7' => 'lowerLayerDown',
+              '2' => 'down',
+              '5' => 'dormant'
+            },
+            'oid' => 'ifOperStatus',
+            'title' => 'Oper Status'
+          },
+          'ifName' => {
+            'oid' => 'ifName',
+            'title' => 'Name (ifName)'
+          },
+          'ifLastChange' => {
+            'oid' => 'ifLastChange',
+            'title' => 'Last Change'
+          }
+        }
+      },
+
+    }
+  }
+);

--- a/models-default/Common-mib2ip.nmis
+++ b/models-default/Common-mib2ip.nmis
@@ -1,0 +1,105 @@
+#
+## $Id: Common-mib2ip.nmis,v 1.0 Exp $
+#  Copyright 1999-2011 Opmantek Limited (www.opmantek.com)
+#
+#  ALL CODE MODIFICATIONS MUST BE SENT TO CODE@OPMANTEK.COM
+#
+#  This file is part of Network Management Information System (“NMIS”).
+#
+#  NMIS is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  NMIS is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with NMIS (most likely in a file named LICENSE).
+#  If not, see <http://www.gnu.org/licenses/>
+#
+#  For further information on NMIS or for a license other than GPL please see
+#  www.opmantek.com or email contact@opmantek.com
+#
+#  User group details:
+#  http://support.opmantek.com/users/
+#
+# *****************************************************************************
+
+%hash = (
+  'system' => {
+    'rrd' => {
+      'mib2ip' => {
+        'graphtype' => 'ip,frag',
+        'snmp' => {
+          'ipInAddrErrors' => {
+            'oid' => 'ipInAddrErrors',
+            'option' => 'counter,0:U'
+          },
+          'ipFragCreates' => {
+            'oid' => 'ipFragCreates',
+            'option' => 'counter,0:U'
+          },
+          'ipInDiscards' => {
+            'oid' => 'ipInDiscards',
+            'option' => 'counter,0:U'
+          },
+          'ipInReceives' => {
+            'oid' => 'ipInReceives',
+            'option' => 'counter,0:U'
+          },
+          'ipFragOKs' => {
+            'oid' => 'ipFragOKs',
+            'option' => 'counter,0:U'
+          },
+          'ipInDelivers' => {
+            'oid' => 'ipInDelivers',
+            'option' => 'counter,0:U'
+          },
+          'ipReasmFails' => {
+            'oid' => 'ipReasmFails',
+            'option' => 'counter,0:U'
+          },
+          'ipReasmReqds' => {
+            'oid' => 'ipReasmReqds',
+            'option' => 'counter,0:U'
+          },
+          'ipFragFails' => {
+            'oid' => 'ipFragFails',
+            'option' => 'counter,0:U'
+          },
+          'ipOutRequests' => {
+            'oid' => 'ipOutRequests',
+            'option' => 'counter,0:U'
+          },
+          'ipOutNoRoutes' => {
+            'oid' => 'ipOutNoRoutes',
+            'option' => 'counter,0:U'
+          },
+          'ipInHdrErrors' => {
+            'oid' => 'ipInHdrErrors',
+            'option' => 'counter,0:U'
+          },
+          'ipForwDatagrams' => {
+            'oid' => 'ipForwDatagrams',
+            'option' => 'counter,0:U'
+          },
+          'ipOutDiscards' => {
+            'oid' => 'ipOutDiscards',
+            'option' => 'counter,0:U'
+          },
+          'ipReasmOKs' => {
+            'oid' => 'ipReasmOKs',
+            'option' => 'counter,0:U'
+          },
+          'ipInUnknownProtos' => {
+            'oid' => 'ipInUnknownProtos',
+            'option' => 'counter,0:U'
+          }
+        },
+      }
+    },
+  },
+);

--- a/models-default/Model-CiscoASR1000.nmis
+++ b/models-default/Model-CiscoASR1000.nmis
@@ -53,9 +53,6 @@
       'Cisco-routing' => {
         'common-model' => 'Cisco-routing'
       },
-      'Cisco-system' => {
-        'common-model' => 'Cisco-system'
-      },
       'Cisco-temp' => {
         'common-model' => 'Cisco-temp'
       },

--- a/models-default/Model-CiscoIronPort.nmis
+++ b/models-default/Model-CiscoIronPort.nmis
@@ -83,8 +83,8 @@
       'event' => {
         'common-model' => 'event'
       },
-      'entity' => {
-      'common-model' => 'entity'
+      'entityMib' => {
+      'common-model' => 'entityMib'
       },
       'routing' => {
         'common-model' => 'routing'

--- a/models-default/Model-ExtremeXOS.nmis
+++ b/models-default/Model-ExtremeXOS.nmis
@@ -50,8 +50,8 @@
       'event' => {
         'common-model' => 'event'
       },
-      'entity' => {
-      'common-model' => 'entity'
+      'entityMib' => {
+      'common-model' => 'entityMib'
       },
     }
   },

--- a/models-default/Model-HuaweiRouterAR2240-uses-common.nmis
+++ b/models-default/Model-HuaweiRouterAR2240-uses-common.nmis
@@ -35,9 +35,6 @@
       'database' => {
         'common-model' => 'database'
       },
-      'calls' => {
-        'common-model' => 'calls'
-      },
       'threshold' => {
         'common-model' => 'threshold'
       },

--- a/models-default/Model-MW-HP-GbE2c.nmis
+++ b/models-default/Model-MW-HP-GbE2c.nmis
@@ -35,9 +35,6 @@
       'database' => {
         'common-model' => 'database'
       },
-      'calls' => {
-        'common-model' => 'calls'
-      },
       'threshold' => {
         'common-model' => 'threshold'
       },

--- a/models-default/Model-MW-HP.nmis
+++ b/models-default/Model-MW-HP.nmis
@@ -35,9 +35,6 @@
       'database' => {
         'common-model' => 'database'
       },
-      'calls' => {
-        'common-model' => 'calls'
-      },
       'threshold' => {
         'common-model' => 'threshold'
       },

--- a/models-default/Model-MW-Intel.nmis
+++ b/models-default/Model-MW-Intel.nmis
@@ -35,9 +35,6 @@
       'database' => {
         'common-model' => 'database'
       },
-      'calls' => {
-        'common-model' => 'calls'
-      },
       'threshold' => {
         'common-model' => 'threshold'
       },

--- a/models-default/Model-MW-Juniper.nmis
+++ b/models-default/Model-MW-Juniper.nmis
@@ -35,9 +35,6 @@
       'database' => {
         'common-model' => 'database'
       },
-      'calls' => {
-        'common-model' => 'calls'
-      },
       'threshold' => {
         'common-model' => 'threshold'
       },

--- a/models-default/Model-OmniSwitch.nmis
+++ b/models-default/Model-OmniSwitch.nmis
@@ -35,9 +35,6 @@
       'database' => {
         'common-model' => 'database'
       },
-      'calls' => {
-        'common-model' => 'calls'
-      },
       'threshold' => {
         'common-model' => 'threshold'
       },

--- a/models-default/Model-PulseSecure.nmis
+++ b/models-default/Model-PulseSecure.nmis
@@ -50,9 +50,6 @@
       'stats' => {
         'common-model' => 'stats'
       },
-      'calls' => {
-        'common-model' => 'calls'
-      },
       'heading' => {
         'common-model' => 'heading'
       },

--- a/models-default/Model-Teldat.nmis
+++ b/models-default/Model-Teldat.nmis
@@ -1,9 +1,6 @@
 %hash = (
     '-common-' => {
         'class' => {
-            'calls' => {
-                'common-model' => 'calls'
-            },
             'cbqos' => {
                 'common-model' => 'Teldat-cbqos'
             },

--- a/models-default/Model-TeldatM1-uses-common.nmis
+++ b/models-default/Model-TeldatM1-uses-common.nmis
@@ -1,9 +1,6 @@
 %hash = (
 	  '-common-' => {
 		'class' => {
-		  'calls' => {
-			'common-model' => 'calls'
-		  },
 		  'cbqos' => {
 			'common-model' => 'Teldat-cbqos'
 		  },

--- a/models-default/Model-Teldati60-uses-common.nmis
+++ b/models-default/Model-Teldati60-uses-common.nmis
@@ -1,9 +1,6 @@
 %hash = (
 	  '-common-' => {
 		'class' => {
-		  'calls' => {
-			'common-model' => 'calls'
-		  },
 		  'cbqos' => {
 			'common-model' => 'Teldat-cbqos'
 		  },

--- a/test/t_loadmodel_errors.pl
+++ b/test/t_loadmodel_errors.pl
@@ -1,0 +1,344 @@
+#!/usr/bin/perl
+#
+# t_loadmodel_errors.pl - tests NMISNG::Sys::loadModel() failure handling (OMK-12755).
+#
+# Covers: every failure path returns 0 and reports ALL failures (concatenated)
+# in $sys->{error}; exactly one error line is logged per failed load; a corrupt
+# cache with a good source recovers and returns 1; a successful reload on the
+# same sys object clears a stale error; and the model_load_strict config gate
+# controls whether partially loaded models are cached and whether a missing
+# dependency file makes the cache stale.
+#
+# Runs against isolated temporary directories and a private config copy,
+# needs no MongoDB and does not touch the repository or a live install.
+#
+
+use strict;
+use warnings;
+our $VERSION = "1.0.0";
+
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+
+use Test::More;
+use File::Path qw(make_path);
+use File::Temp qw(tempdir);
+use Clone;
+
+use NMISNG::Sys;
+use NMISNG::Log;
+use NMISNG::Util;
+
+use File::Slurp qw(read_file write_file);
+
+# -----------------------------------------------------------------------------
+# Minimal nmisng-like object: loadModel only needs ->log (and ->config)
+# -----------------------------------------------------------------------------
+{
+	package T::FakeNmisng;
+	sub new { my ($c, %a) = @_; bless { %a }, $c; }
+	sub log { $_[0]->{log} }
+	sub config { $_[0]->{config} }
+}
+
+# -----------------------------------------------------------------------------
+# Isolated environment
+# -----------------------------------------------------------------------------
+my $tmpbase      = tempdir("nmis-loadmodel-test-XXXXXX", TMPDIR => 1, CLEANUP => 1);
+my $defaults_dir = "$tmpbase/models-default";
+my $custom_dir   = "$tmpbase/models-custom";
+my $var_dir      = "$tmpbase/var";
+my $conf_dir     = "$tmpbase/conf";
+my $log_file     = "$tmpbase/test.log";
+make_path($defaults_dir, $custom_dir, $conf_dir, "$var_dir/nmis_system/model_cache");
+
+# private copy of the shipped config: loadConfTable persists things (cluster_id)
+# back into its conf dir, which must never hit the repository copy. The copy is
+# re-owned to the current user so persistence works quietly as non-root.
+my $me = getpwuid($<);
+{
+	my $conf_raw = read_file("$FindBin::Bin/../conf-default/Config.nmis");
+	$conf_raw =~ s/'nmis_user'\s*=>\s*'[^']*'/'nmis_user' => '$me'/;
+	write_file("$conf_dir/Config.nmis", $conf_raw);
+}
+my $real_C = NMISNG::Util::loadConfTable(dir => $conf_dir);
+die "cannot load config\n" if (ref($real_C) ne "HASH" or !keys %$real_C);
+
+my $C = Clone::clone($real_C);
+$C->{'<nmis_default_models>'} = $defaults_dir;
+$C->{'<nmis_models>'}         = $custom_dir;
+$C->{'<nmis_var>'}            = $var_dir;
+$C->{'<nmis_conf>'}           = $conf_dir;
+$C->{'<nmis_conf_default>'}   = $conf_dir;
+delete $C->{global_model_overrides};
+delete $C->{model_load_strict};
+$C->{use_json}        = 'false';
+$C->{use_json_pretty} = 'false';
+
+# file ownership must work as the current, unprivileged user on any box
+$C->{nmis_user}  = $me;
+my ($gid)        = split(' ', $();
+$C->{nmis_group} = getgrgid($gid);
+
+# error-level logger writing to a file so tests can count logged errors
+my $logger      = NMISNG::Log->new(level => 'error', path => $log_file);
+my $fake_nmisng = T::FakeNmisng->new(config => $C, log => $logger);
+
+# -----------------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------------
+sub write_nmis_file {
+	my ($path, $data) = @_;
+	if (my $err = NMISNG::Util::writeHashtoFile(file => $path, data => $data,
+												json => 0, conf => $C))
+	{
+		die "failed to write $path: $err";
+	}
+	my $now = time();
+	utime($now, $now, $path) or die "utime $path: $!";
+	return $path;
+}
+
+sub make_sys {
+	my (%opts) = @_;
+	my $sys = NMISNG::Sys->new();
+	$sys->{config}       = $C;
+	$sys->{_nmisng}      = $fake_nmisng;
+	$sys->{cache_models} = $opts{cache_models} // 1;
+	return $sys;
+}
+
+sub clear_model_cache {
+	my $cache_dir = "$var_dir/nmis_system/model_cache";
+	if (opendir(my $dh, $cache_dir)) {
+		while (my $f = readdir($dh)) {
+			next if $f =~ /^\.\.?$/;
+			unlink "$cache_dir/$f";
+		}
+		closedir($dh);
+	}
+}
+
+sub model_cache_file {
+	my ($model) = @_;
+	return "$var_dir/nmis_system/model_cache/$model.json";
+}
+
+sub reset_log { write_file($log_file, ""); }
+
+sub error_log_count {
+	return 0 if (!-f $log_file);
+	my @lines = grep { /\[error\]/ } read_file($log_file);
+	return scalar(@lines);
+}
+
+# a model referencing a set of commons: class => feature name
+sub install_model {
+	my ($name, %opts) = @_;
+	my $commons = $opts{commons} // {};
+	my $mdl = {
+		system => { nodeVendor => 'TestVendor', nodeType => 'router' },
+		'-common-' => {
+			class => { map { ($_ => { 'common-model' => $commons->{$_} }) } keys %$commons },
+		},
+	};
+	if (my $extra = $opts{extra}) {
+		# shallow top-level merge; extra wins
+		$mdl->{$_} = $extra->{$_} for keys %$extra;
+	}
+	write_nmis_file("$defaults_dir/Model-$name.nmis", $mdl);
+	return $name;
+}
+
+sub install_common {
+	my ($feature, $content) = @_;
+	$content //= { systemHealth => { rrd => { $feature => { graphtype => $feature } } } };
+	write_nmis_file("$defaults_dir/Common-$feature.nmis", $content);
+}
+
+# -----------------------------------------------------------------------------
+# S1: missing main model file
+# -----------------------------------------------------------------------------
+{
+	reset_log(); clear_model_cache();
+
+	my $sys = make_sys();
+	my $ok  = $sys->loadModel(model => "Model-E1NoSuch");
+
+	ok(!$ok, "S1: missing main model file returns 0");
+	like($sys->{error}, qr/Model-E1NoSuch/, "S1: error names the missing model");
+	is(error_log_count(), 1, "S1: exactly one error line logged");
+}
+
+# -----------------------------------------------------------------------------
+# S2: one missing common out of two - partial model, error names the file
+# -----------------------------------------------------------------------------
+{
+	reset_log(); clear_model_cache();
+	install_common("E2Good");
+	install_model("E2Router", commons => { good => 'E2Good', missing => 'E2Missing' });
+
+	my $sys = make_sys();
+	my $ok  = $sys->loadModel(model => "Model-E2Router");
+
+	ok(!$ok, "S2: missing common returns 0");
+	like($sys->{error}, qr/Common-E2Missing/, "S2: error names the missing common");
+	is($sys->{mdl}{systemHealth}{rrd}{E2Good}{graphtype}, 'E2Good',
+	   "S2: content from the good common is still merged");
+	is(error_log_count(), 1, "S2: exactly one error line logged");
+}
+
+# -----------------------------------------------------------------------------
+# S3: two missing commons - error must report BOTH, still one log line
+# -----------------------------------------------------------------------------
+{
+	reset_log(); clear_model_cache();
+	install_model("E3Router", commons => { m1 => 'E3MissA', m2 => 'E3MissB' });
+
+	my $sys = make_sys();
+	ok(!$sys->loadModel(model => "Model-E3Router"), "S3: returns 0");
+	like($sys->{error}, qr/Common-E3MissA/, "S3: error reports first missing common");
+	like($sys->{error}, qr/Common-E3MissB/, "S3: error reports second missing common");
+	is(error_log_count(), 1, "S3: still exactly one error line logged");
+}
+
+# -----------------------------------------------------------------------------
+# S4: missing global override file
+# -----------------------------------------------------------------------------
+{
+	reset_log(); clear_model_cache();
+	install_model("E4Router");
+
+	local $C->{global_model_overrides} = ['e4nosuch'];
+
+	my $sys = make_sys();
+	ok(!$sys->loadModel(model => "Model-E4Router"), "S4: missing global override returns 0");
+	like($sys->{error}, qr/Override-e4nosuch/, "S4: error names the missing override");
+	is(error_log_count(), 1, "S4: exactly one error line logged");
+}
+
+# -----------------------------------------------------------------------------
+# S5: unmergeable common - error must name the file that failed to merge
+# -----------------------------------------------------------------------------
+{
+	reset_log(); clear_model_cache();
+	# model provides a hash at system/clashkey, common provides a scalar there:
+	# _mergeHash refuses (dest is HASH, source is not)
+	install_common("E5Clash", { system => { clashkey => 'scalar-value' } });
+	install_model("E5Router",
+		commons => { clash => 'E5Clash' },
+		extra   => { system => { nodeVendor => 'TestVendor', nodeType => 'router',
+								 clashkey   => { nested => 1 } } });
+
+	my $sys = make_sys();
+	ok(!$sys->loadModel(model => "Model-E5Router"), "S5: unmergeable common returns 0");
+	like($sys->{error}, qr/Common-E5Clash/, "S5: error names the unmergeable common");
+	like($sys->{error}, qr/cannot merge/, "S5: error carries the merge detail");
+	is(error_log_count(), 1, "S5: exactly one error line logged");
+}
+
+# -----------------------------------------------------------------------------
+# S6: corrupt cache file with a good source must recover and return 1
+# -----------------------------------------------------------------------------
+{
+	reset_log(); clear_model_cache();
+	install_common("E6Cpu");
+	install_model("E6Router", commons => { cpu => 'E6Cpu' });
+
+	{
+		my $sys = make_sys();
+		ok($sys->loadModel(model => "Model-E6Router"), "S6: initial load ok");
+	}
+	my $cf = model_cache_file("Model-E6Router");
+	ok(-f $cf, "S6: cache file was written");
+	write_file($cf, "{{{ this is not json");
+
+	my $sys = make_sys();
+	my $ok  = $sys->loadModel(model => "Model-E6Router");
+	ok($ok, "S6: corrupt cache with good source returns 1");
+	ok(!$sys->{error}, "S6: no error left on sys after recovery")
+		or diag("leftover error: $sys->{error}");
+	is($sys->{mdl}{system}{nodeVendor}, 'TestVendor', "S6: model content correct after recovery");
+	is(error_log_count(), 0, "S6: a self-healed cache is not an error");
+}
+
+# -----------------------------------------------------------------------------
+# S7: recovery on the SAME sys object - fix the model, returns 1, error cleared
+# -----------------------------------------------------------------------------
+{
+	reset_log(); clear_model_cache();
+	install_model("E7Router", commons => { cpu => 'E7Cpu' });    # Common-E7Cpu missing
+
+	my $sys = make_sys(cache_models => 0);
+	ok(!$sys->loadModel(model => "Model-E7Router"), "S7: fails while common is missing");
+	like($sys->{error}, qr/Common-E7Cpu/, "S7: error names the missing common");
+
+	install_common("E7Cpu");
+
+	my $ok = $sys->loadModel(model => "Model-E7Router");
+	ok($ok, "S7: same sys returns 1 once the model is fixed");
+	ok(!$sys->{error}, "S7: stale error cleared by successful reload")
+		or diag("leftover error: $sys->{error}");
+	ok(!$sys->status->{error}, "S7: status() no longer reports an error");
+}
+
+# -----------------------------------------------------------------------------
+# S8: lenient default - partially loaded model is still cached (current
+# behaviour, preserved for upgrades)
+# -----------------------------------------------------------------------------
+{
+	reset_log(); clear_model_cache();
+	install_model("E8Router", commons => { miss => 'E8Miss' });
+
+	my $sys = make_sys();
+	ok(!$sys->loadModel(model => "Model-E8Router"), "S8: load fails");
+	ok(-f model_cache_file("Model-E8Router"),
+	   "S8: lenient default still caches the partially loaded model");
+}
+
+# -----------------------------------------------------------------------------
+# S9: strict gate - partially loaded model must NOT be cached
+# -----------------------------------------------------------------------------
+{
+	reset_log(); clear_model_cache();
+	install_model("E9Router", commons => { miss => 'E9Miss' });
+
+	local $C->{model_load_strict} = 'true';
+
+	my $sys = make_sys();
+	ok(!$sys->loadModel(model => "Model-E9Router"), "S9: load fails");
+	ok(!-f model_cache_file("Model-E9Router"),
+	   "S9: strict mode does not cache a partially loaded model");
+}
+
+# -----------------------------------------------------------------------------
+# S10: strict gate - a missing dependency file makes the cache stale
+# -----------------------------------------------------------------------------
+{
+	reset_log(); clear_model_cache();
+	install_common("EACpu");
+	install_model("EARouter", commons => { cpu => 'EACpu' });
+
+	{
+		my $sys = make_sys();
+		ok($sys->loadModel(model => "Model-EARouter"), "S10: initial load ok");
+	}
+
+	unlink("$defaults_dir/Common-EACpu.nmis") or die "unlink: $!";
+
+	# lenient: existing cache keeps being trusted (current behaviour)
+	{
+		my $sys = make_sys();
+		ok($sys->loadModel(model => "Model-EARouter"),
+		   "S10: lenient keeps using the cache when a dependency vanishes");
+	}
+
+	# strict: stale, reload from source, fail loudly naming the file
+	local $C->{model_load_strict} = 'true';
+	my $sys = make_sys();
+	ok(!$sys->loadModel(model => "Model-EARouter"),
+	   "S10: strict treats a missing dependency as stale and fails loudly");
+	like($sys->{error}, qr/Common-EACpu/, "S10: error names the vanished common");
+}
+
+done_testing();

--- a/test/t_model_references.pl
+++ b/test/t_model_references.pl
@@ -1,0 +1,63 @@
+#!/usr/bin/perl
+#
+# t_model_references.pl - shipped-model consistency (OMK-12755).
+#
+# Every Model-*.nmis in models-default must parse, and every common-model
+# reference in its -common- class block must resolve to an existing
+# Common-<feature>.nmis in models-default. A dangling reference makes
+# NMISNG::Sys::loadModel() return 0 for every node using that model, which
+# raises "Model File Invalid" on every update.
+#
+# Static check: no MongoDB, no config, no side effects.
+#
+
+use strict;
+use warnings;
+our $VERSION = "1.0.0";
+
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+
+use Test::More;
+use NMISNG::Util;
+
+my $models_dir = "$FindBin::Bin/../models-default";
+ok(-d $models_dir, "models-default directory exists") or BAIL_OUT("no $models_dir");
+
+opendir(my $dh, $models_dir) or BAIL_OUT("cannot read $models_dir: $!");
+my @model_files = sort grep { /^Model-.+\.nmis$/ } readdir($dh);
+closedir($dh);
+
+cmp_ok(scalar(@model_files), '>', 100, "found a plausible number of model files");
+
+for my $file (@model_files)
+{
+	my $mdl = NMISNG::Util::readFiletoHash(file => "$models_dir/$file");
+	if (ref($mdl) ne "HASH" or !keys %$mdl)
+	{
+		fail("$file: parses as a non-empty hash");
+		diag("$file: $mdl") if (!ref($mdl));    # readFiletoHash returns error string
+		next;
+	}
+	pass("$file: parses as a non-empty hash");
+
+	my @missing;
+	if (ref($mdl->{'-common-'}) eq "HASH" and ref($mdl->{'-common-'}{class}) eq "HASH")
+	{
+		for my $class (sort keys %{$mdl->{'-common-'}{class}})
+		{
+			my $feature = $mdl->{'-common-'}{class}{$class}{'common-model'};
+			if (!defined $feature or $feature eq "")
+			{
+				push @missing, "class $class has no common-model value";
+				next;
+			}
+			push @missing, "Common-$feature.nmis (class $class)"
+				if (!-f "$models_dir/Common-$feature.nmis");
+		}
+	}
+	ok(!@missing, "$file: all common-model references resolve")
+		or diag("$file is missing: " . join(", ", @missing));
+}
+
+done_testing();


### PR DESCRIPTION
Problem

Customer nodes modelled as CiscoASR1000 raised "Model File Invalid" on every update, and clearing the event never stuck. Nothing was logged and the event carried no reason. The nodes polled normally the whole time.

Model-CiscoASR1000 references three Common files that don't exist in the repo, so every source load returned 0 while collect kept working from the cached partial model. Auditing all shipped models found 21 dangling references across 17 models.

Defects fixed in Sys.pm::loadModel

1. No failure path logged anything, and the event details carried no reason.
2. Multiple failures overwrote each other, only the last survived in $sys->{error}.
3. A corrupt cache file set $exit = 0, then fell through to a successful source load but still returned 0. A working model raised the event.
4. A partially loaded model was written to the cache, which collect then used indefinitely.
5. The freshness check treated a missing dependency file as fresh forever (undef > mtime is false).
6. _mergeHash ignored its own recursion result, so a nested merge failure was swallowed and loadModel could return 1 for an unmergeable model.
7. A stale $sys->{error} from earlier operations survived a later successful load.

Changes

fb7e5575 — loadModel rework
- All failures are collected and joined into $sys->{error}, one error log line per failed load.
- Node.pm puts $S->status->{error} into the Model File Invalid event details, so the event itself now names the broken file(s).
- Corrupt cache with a good source recovers, logs a warning, and returns 1.
- Nested merge failures propagate, and the merge error names the file plus the offending key.
- New config flag model_load_strict (see below).

46f18ea4 — cherry-pick of the Common-mib2ip NMIS8 port (5 models reference it)

dee1a1e5 — model fixes, all 17 broken models
- Common-ifTable ported from NMIS8 (sys-only inventory section, no RRD or graph dependencies). CiscoASR1000 and HuaweiGlobal already list ifTable in systemHealth, it just never loaded.
- CiscoIronPort and ExtremeXOS repointed from the never-existing Common-entity to Common-entityMib, which their systemHealth sections already expect.
- CiscoASR1000 drops the redundant Cisco-system reference. The v9 model already carries extra and nodeConfiguration inline and gets temp/power via Common-Cisco-temp/-power.
- Ten dead calls references removed (feature removed in v9).

New config flag: model_load_strict

- true: never cache a partially loaded model, and a missing model dependency makes the cache stale (fails loudly instead of polling from a stale partial model).
- Template ships false. Upgrades get false via updateconfig.pl, so existing installs keep current behaviour. The installer patches it to true for fresh installs ($CLEANSLATE branch of 05-postcopy-configfiles).
- Note the enablement effect: fixing the entity → entityMib reference turns on ENTITY-MIB inventory collection for CiscoIronPort and ExtremeXOS devices, and Common-ifTable adds an ifTable inventory section to CiscoASR1000 and HuaweiGlobal. Both were what the model authors intended.

Tests

- test/t_loadmodel_errors.pl (37 assertions, no MongoDB needed): every failure path, error concatenation, single log line, corrupt-cache recovery, same-sys recovery back to return 1, and both gate modes.
- test/t_model_references.pl (318 assertions): every shipped model must parse and every common-model reference must resolve. Failed on 17 models before the fixes.
- Full sweep: all 158 shipped models load end-to-end through the real loadModel with 0 failures.
- Existing t_model_overrides.pl suite (67 assertions) passes against the rework.
- Not run: the MongoDB-backed test suite. Needs a docker-dev pass before merge.